### PR TITLE
Add more types to examples

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiExampleGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiExampleGenerator.cs
@@ -126,11 +126,11 @@ namespace Microsoft.OpenApi.OData.Generator
                     }
                     else if (edmTypeReference.IsDate())
                     {
-                        return new OpenApiDate(DateTime.UtcNow);
+                        return new OpenApiDate(DateTime.MinValue);
                     }
                     else if (edmTypeReference.IsDateTimeOffset())
                     {
-                        return new OpenApiDateTime(DateTimeOffset.UtcNow);
+                        return new OpenApiDateTime(DateTimeOffset.MinValue);
                     }
                     else if (edmTypeReference.IsDecimal() || edmTypeReference.IsDouble())
                     {

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiExampleGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiExampleGenerator.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -24,7 +25,6 @@ namespace Microsoft.OpenApi.OData.Generator
         /// Create the dictionary of <see cref="OpenApiExample"/> object.
         /// </summary>
         /// <param name="context">The OData to Open API context.</param>
-        /// <param name="securitySchemes">The securitySchemes.</param>
         /// <returns>The created <see cref="OpenApiExample"/> dictionary.</returns>
         public static IDictionary<string, OpenApiExample> CreateExamples(this ODataContext context)
         {
@@ -112,9 +112,45 @@ namespace Microsoft.OpenApi.OData.Generator
             switch (edmTypeReference.TypeKind())
             {
                 case EdmTypeKind.Primitive:
-                    if (edmTypeReference.IsBoolean())
+                    if (edmTypeReference.IsBinary())
+                    {
+                        return new OpenApiBinary(new byte[] { 0x00 });
+                    }
+                    else if (edmTypeReference.IsBoolean())
                     {
                         return new OpenApiBoolean(true);
+                    }
+                    else if (edmTypeReference.IsByte())
+                    {
+                        return new OpenApiByte(0x00);
+                    }
+                    else if (edmTypeReference.IsDate())
+                    {
+                        return new OpenApiDate(DateTime.UtcNow);
+                    }
+                    else if (edmTypeReference.IsDateTimeOffset())
+                    {
+                        return new OpenApiDateTime(DateTimeOffset.UtcNow);
+                    }
+                    else if (edmTypeReference.IsDecimal() || edmTypeReference.IsDouble())
+                    {
+                        return new OpenApiDouble(0D);
+                    }
+                    else if (edmTypeReference.IsFloating())
+                    {
+                        return new OpenApiFloat(0F);
+                    }
+                    else if (edmTypeReference.IsGuid())
+                    {
+                        return new OpenApiString(Guid.Empty.ToString());
+                    }
+                    else if (edmTypeReference.IsInt16() || edmTypeReference.IsInt32())
+                    {
+                        return new OpenApiInteger(0);
+                    }
+                    else if (edmTypeReference.IsInt64())
+                    {
+                        return new OpenApiLong(0L);
                     }
                     else
                     {

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.5.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.1.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -1210,7 +1210,7 @@
           "City": {
             "@odata.type": "DefaultNs.City"
           },
-          "Id": "Int32"
+          "Id": 0
         }
       },
       "DefaultNs.WorkAddress": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -4809,7 +4809,7 @@
               "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
             }
           ],
-          "Age": "Int64",
+          "Age": 0,
           "BestFriend": {
             "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
           },
@@ -4889,30 +4889,30 @@
       },
       "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip": {
         "value": {
-          "Budget": "Single",
+          "Budget": 0,
           "Description": "String",
-          "EndsAt": "DateTimeOffset (timestamp)",
+          "EndsAt": "0001-01-01T00:00:00.0000000+00:00",
           "Name": "String",
           "PlanItems": [
             {
               "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem"
             }
           ],
-          "ShareId": "Guid",
-          "StartsAt": "DateTimeOffset (timestamp)",
+          "ShareId": "00000000-0000-0000-0000-000000000000",
+          "StartsAt": "0001-01-01T00:00:00.0000000+00:00",
           "Tags": [
             "String"
           ],
-          "TripId": "Int32 (identifier)"
+          "TripId": 0
         }
       },
       "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem": {
         "value": {
           "ConfirmationCode": "String",
           "Duration": "Duration",
-          "EndsAt": "DateTimeOffset (timestamp)",
-          "PlanItemId": "Int32 (identifier)",
-          "StartsAt": "DateTimeOffset (timestamp)"
+          "EndsAt": "0001-01-01T00:00:00.0000000+00:00",
+          "PlanItemId": 0,
+          "StartsAt": "0001-01-01T00:00:00.0000000+00:00"
         }
       },
       "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Event": {
@@ -4944,7 +4944,7 @@
       },
       "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
         "value": {
-          "Cost": "Int64",
+          "Cost": 0,
           "Peers": [
             {
               "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
@@ -4957,7 +4957,7 @@
           "BossOffice": {
             "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
           },
-          "Budget": "Int64",
+          "Budget": 0,
           "DirectReports": [
             {
               "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"


### PR DESCRIPTION
Currently using Azure API management you receive a ton of errors on the examples section (e.g. [#/components/schemas/type/example/property] Data and type mismatch found.) leading to not being able to import the file.
Added more types as examples to fix this.
Updated Microsoft.OpenApi to the latest version to solve DateTimeOffset serialization. There is an issue with the version currently used where DateTimeOffset is serialized as 0001-01-01T00:00:00.0000000+00:00 instead of "0001-01-01T00:00:00.0000000+00:00".