### PR TITLE
Fix Action Response Serialization

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OpenApi.OData.Generator
 
             OpenApiResponses responses = new OpenApiResponses();
 
-            if (operation.IsAction())
+            if (operation.IsAction() && operation.ReturnType == null)
             {
                 responses.Add(Constants.StatusCode204, Constants.StatusCode204.GetResponse());
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -181,9 +181,10 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
         }
 
         [Theory]
-        [InlineData("ShareTrip", false)]
-        [InlineData("ResetDataSource", true)]
-        public void CreateResponseForEdmActionReturnCorrectResponses(string actionName, bool isActionImport)
+        [InlineData("ShareTrip", false, false)]
+        [InlineData("ResetDataSource", true, false)]
+        [InlineData("GetPeersForTrip", false, true)]
+        public void CreateResponseForEdmActionReturnCorrectResponses(string actionName, bool isActionImport, bool hasResponse)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -208,7 +209,18 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.NotNull(responses);
             Assert.NotEmpty(responses);
             Assert.Equal(2, responses.Count);
-            Assert.Equal(new string[] { "204", "default" }, responses.Select(r => r.Key));
+
+            var responseCode = string.Empty;
+            if (!hasResponse)
+            {
+                responseCode = "204";
+            }
+            else
+            {
+                responseCode = "200";
+            }
+
+            Assert.Equal(new string[] { responseCode, "default" }, responses.Select(r => r.Key));
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -181,10 +181,10 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
         }
 
         [Theory]
-        [InlineData("ShareTrip", false, false)]
-        [InlineData("ResetDataSource", true, false)]
-        [InlineData("GetPeersForTrip", false, true)]
-        public void CreateResponseForEdmActionReturnCorrectResponses(string actionName, bool isActionImport, bool hasResponse)
+        [InlineData("ShareTrip", false, "204")]
+        [InlineData("ResetDataSource", true, "204")]
+        [InlineData("GetPeersForTrip", false, "200")]
+        public void CreateResponseForEdmActionReturnCorrectResponses(string actionName, bool isActionImport, string responseCode)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -209,17 +209,6 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.NotNull(responses);
             Assert.NotEmpty(responses);
             Assert.Equal(2, responses.Count);
-
-            var responseCode = string.Empty;
-            if (!hasResponse)
-            {
-                responseCode = "204";
-            }
-            else
-            {
-                responseCode = "200";
-            }
-
             Assert.Equal(new string[] { responseCode, "default" }, responses.Select(r => r.Key));
         }
     }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -141,6 +141,12 @@
         <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
         <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
       </Action>
+      <Action Name="GetPeersForTrip" IsBound="true">
+        <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
+        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" />
+      </Action>
       <EntityContainer Name="Container">
         <EntitySet Name="People" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
           <NavigationPropertyBinding Path="Friends" Target="People" />

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1153,6 +1153,61 @@
         "x-ms-docs-operation-type": "function"
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip": {
+      "post": {
+        "tags": [
+          "Me.Actions"
+        ],
+        "summary": "Invoke action GetPeersForTrip",
+        "operationId": "Me.GetPeersForTrip",
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userName": {
+                    "type": "string"
+                  },
+                  "tripId": {
+                    "maximum": 2147483647,
+                    "minimum": -2147483648,
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                      }
+                    ],
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
       "post": {
         "tags": [
@@ -2232,6 +2287,73 @@
           }
         },
         "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip": {
+      "post": {
+        "tags": [
+          "NewComePeople.Actions"
+        ],
+        "summary": "Invoke action GetPeersForTrip",
+        "operationId": "NewComePeople.GetPeersForTrip",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userName": {
+                    "type": "string"
+                  },
+                  "tripId": {
+                    "maximum": 2147483647,
+                    "minimum": -2147483648,
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                      }
+                    ],
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
       }
     },
     "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
@@ -3365,6 +3487,73 @@
           }
         },
         "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip": {
+      "post": {
+        "tags": [
+          "People.Actions"
+        ],
+        "summary": "Invoke action GetPeersForTrip",
+        "operationId": "People.GetPeersForTrip",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userName": {
+                    "type": "string"
+                  },
+                  "tripId": {
+                    "maximum": 2147483647,
+                    "minimum": -2147483648,
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                      }
+                    ],
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -769,6 +769,41 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: function
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip:
+    post:
+      tags:
+        - Me.Actions
+      summary: Invoke action GetPeersForTrip
+      operationId: Me.GetPeersForTrip
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userName:
+                  type: string
+                tripId:
+                  maximum: 2147483647
+                  minimum: -2147483648
+                  type: integer
+                  format: int32
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+                  nullable: true
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip:
     post:
       tags:
@@ -1521,6 +1556,49 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: function
+  '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
+    post:
+      tags:
+        - NewComePeople.Actions
+      summary: Invoke action GetPeersForTrip
+      operationId: NewComePeople.GetPeersForTrip
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userName:
+                  type: string
+                tripId:
+                  maximum: 2147483647
+                  minimum: -2147483648
+                  type: integer
+                  format: int32
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+                  nullable: true
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
     post:
       tags:
@@ -2309,6 +2387,49 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: function
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
+    post:
+      tags:
+        - People.Actions
+      summary: Invoke action GetPeersForTrip
+      operationId: People.GetPeersForTrip
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userName:
+                  type: string
+                tripId:
+                  maximum: 2147483647
+                  minimum: -2147483648
+                  type: integer
+                  format: int32
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+                  nullable: true
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
     post:
       tags:


### PR DESCRIPTION
Currently, all action responses are being generated as 204. However, per the OASIS Mapping documentation 4.5.3 :
HTTP response code [of an action should be ] 204 if the response has no body
...200 for other success codes...

For a specific example, the following xml:
<Action Name="GetPeersForTrip" IsBound="true">
        <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
        <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
        <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" />
      </Action>

Should generate a 200 response. 

Modified UnitTest to pass expected responseCode as InlineData