### PR TITLE
Users/mispeer/serialize nullable references for v2

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -428,7 +428,13 @@ namespace Microsoft.OpenApi.OData.Generator
             Debug.Assert(typeReference != null);
 
             OpenApiSchema schema = new OpenApiSchema();
-            if (typeReference.IsNullable)
+
+            // AnyOf will only be valid openApi for version 3
+            // otherwise the reference should be set directly
+            // as per OASIS documentation for openApi version 2
+            // 
+            if (typeReference.IsNullable && 
+                (context.Settings.OpenApiSpecVersion == OpenApiSpecVersion.OpenApi3_0))
             {
                 schema.Nullable = true;
                 schema.Reference = null;

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -407,17 +407,31 @@ namespace Microsoft.OpenApi.OData.Generator
             OpenApiSchema schema = new OpenApiSchema();
             schema.Nullable = typeReference.IsNullable;
             schema.Reference = null;
-            schema.AnyOf = new List<OpenApiSchema>
+
+            if (context.Settings.OpenApiSpecVersion >= OpenApiSpecVersion.OpenApi3_0)
             {
-                new OpenApiSchema
+                schema.AnyOf = new List<OpenApiSchema>
                 {
-                    Reference = new OpenApiReference
+                    new OpenApiSchema
                     {
-                        Type = ReferenceType.Schema,
-                        Id = typeReference.Definition.FullTypeName()
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = typeReference.Definition.FullTypeName()
+                        }
                     }
-                }
-            };
+                };
+            }
+            else
+            {
+                schema.Type = null;
+                schema.AnyOf = null;
+                schema.Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = typeReference.Definition.FullTypeName()
+                };
+            }
 
             return schema;
         }
@@ -428,15 +442,14 @@ namespace Microsoft.OpenApi.OData.Generator
             Debug.Assert(typeReference != null);
 
             OpenApiSchema schema = new OpenApiSchema();
+            schema.Nullable = typeReference.IsNullable;
 
             // AnyOf will only be valid openApi for version 3
             // otherwise the reference should be set directly
             // as per OASIS documentation for openApi version 2
-            // 
             if (typeReference.IsNullable && 
-                (context.Settings.OpenApiSpecVersion == OpenApiSpecVersion.OpenApi3_0))
+                (context.Settings.OpenApiSpecVersion >= OpenApiSpecVersion.OpenApi3_0))
             {
-                schema.Nullable = true;
                 schema.Reference = null;
                 schema.AnyOf = new List<OpenApiSchema>
                 {
@@ -472,17 +485,32 @@ namespace Microsoft.OpenApi.OData.Generator
             OpenApiSchema schema = new OpenApiSchema();
             schema.Nullable = reference.IsNullable;
             schema.Reference = null;
-            schema.AnyOf = new List<OpenApiSchema>
+
+            if (context.Settings.OpenApiSpecVersion >= OpenApiSpecVersion.OpenApi3_0)
             {
-                new OpenApiSchema
+                schema.AnyOf = new List<OpenApiSchema>
                 {
-                    Reference = new OpenApiReference
+                    new OpenApiSchema
                     {
-                        Type = ReferenceType.Schema,
-                        Id = reference.Definition.FullTypeName()
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = reference.Definition.FullTypeName()
+                        }
                     }
-                }
-            };
+                };
+            }
+            else
+            {
+                schema.Type = null;
+                schema.AnyOf = null;
+                schema.Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = reference.Definition.FullTypeName()
+                };
+            }
+            
 
             return schema;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -58,6 +58,12 @@ namespace Microsoft.OpenApi.OData
         public bool PrefixEntityTypeNameBeforeKey { get; set; } = false;
 
         /// <summary>
+        /// Gets/sets a value indicating whether the version of openApi to serialize to is v2.
+        /// Currently only impacts nullable references for EdmTypeSchemaGenerator
+        /// </summary>
+        public OpenApiSpecVersion OpenApiSpecVersion { get; set; } = OpenApiSpecVersion.OpenApi3_0;
+
+        /// <summary>
         /// Gets/sets a value indicating to set the OperationId on Open API operation.
         /// </summary>
         public bool EnableOperationId { get; set; } = true;
@@ -92,6 +98,7 @@ namespace Microsoft.OpenApi.OData
             newSettings.EnableNavigationPropertyPath = this.EnableNavigationPropertyPath;
             newSettings.TagDepth = this.TagDepth;
             newSettings.PrefixEntityTypeNameBeforeKey = this.PrefixEntityTypeNameBeforeKey;
+            newSettings.OpenApiSpecVersion = this.OpenApiSpecVersion;
             newSettings.EnableOperationId = this.EnableOperationId;
             newSettings.VerifyEdmModel = this.VerifyEdmModel;
             newSettings.IEEE754Compatible = this.IEEE754Compatible;

--- a/src/OoasGui/MainForm.cs
+++ b/src/OoasGui/MainForm.cs
@@ -64,13 +64,13 @@ namespace OoasGui
 
         private void v2RadioBtn_CheckedChanged(object sender, EventArgs e)
         {
-            Version = OpenApiSpecVersion.OpenApi2_0;
+            Settings.OpenApiSpecVersion = Version = OpenApiSpecVersion.OpenApi2_0;
             Convert();
         }
 
         private void v3RadioBtn_CheckedChanged(object sender, EventArgs e)
         {
-            Version = OpenApiSpecVersion.OpenApi3_0;
+            Settings.OpenApiSpecVersion = Version = OpenApiSpecVersion.OpenApi3_0;
             Convert();
         }
 

--- a/src/OoasUtil/ComLineProcesser.cs
+++ b/src/OoasUtil/ComLineProcesser.cs
@@ -46,6 +46,11 @@ namespace OoasUtil
         public OpenApiFormat? Format { get; private set; }
 
         /// <summary>
+        /// Output OpenApi Specification Version.
+        /// </summary>
+        public OpenApiSpecVersion? Version { get; private set; }
+
+        /// <summary>
         /// Output file.
         /// </summary>
         public string Output { get; private set; }
@@ -86,7 +91,7 @@ namespace OoasUtil
 
                         case "--input":
                         case "-i":
-                            if (!ProcessInput(_args[i+1]))
+                            if (!ProcessInput(_args[i + 1]))
                             {
                                 return false;
                             }
@@ -107,6 +112,15 @@ namespace OoasUtil
                             {
                                 return false;
                             }
+                            break;
+
+                        case "--specversion":
+                        case "-s":
+                            if (!int.TryParse(_args[i + 1], out int version) || !ProcessTarget(version))
+                            {
+                                return false;
+                            }
+                            ++i;
                             break;
 
                         case "--output":
@@ -134,6 +148,11 @@ namespace OoasUtil
             if (Format == null)
             {
                 Format = OpenApiFormat.Json;
+            }
+
+            if (Version == null)
+            {
+                Version = OpenApiSpecVersion.OpenApi3_0;
             }
 
             _continue = ValidateArguments();
@@ -179,6 +198,25 @@ namespace OoasUtil
             return true;
         }
 
+        private bool ProcessTarget(int version)
+        {
+            if (Version != null)
+            {
+                Console.WriteLine("[Error:] Multiple [--specversion|-s] are not allowed.\n");
+                PrintUsage();
+                return false;
+            }
+            else if (version > 3 || version < 2)
+            {
+                Console.WriteLine("[Error:] Only OpenApi specification version 2 or 3 are supported.\n");
+                PrintUsage();
+                return false;
+            }
+
+            Version = version == 2 ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            return true;
+        }
+
         private bool ValidateArguments()
         {
             if (String.IsNullOrEmpty(Input))
@@ -216,14 +254,15 @@ namespace OoasUtil
             sb.Append("\nOptions:\n");
             sb.Append("  --help|-h\t\t\tDisplay help.\n");
             sb.Append("  --version|-v\t\t\tDisplay version.\n");
-            sb.Append("  --input|-i CsdlFileOrUrl\t\tSet the CSDL file name or the OData Service Url.\n");
-            sb.Append("  --output|-o OutputFile\t\tSet the output file name.\n");
+            sb.Append("  --input|-i CsdlFileOrUrl\tSet the CSDL file name or the OData Service Url.\n");
+            sb.Append("  --output|-o OutputFile\tSet the output file name.\n");
             sb.Append("  --json|-j\t\t\tSet the output format as JSON.\n");
             sb.Append("  --yaml|-y\t\t\tSet the output format as YAML.\n");
+            sb.Append("  --specversion|-s IntVersion\tSet the OpenApi Specification version of the output. Only 2 or 3 are supported.\n");
 
             sb.Append("\nExamples:\n");
             sb.Append("    OoasUtil.exe -y -i http://services.odata.org/TrippinRESTierService -o trip.yaml\n");
-            sb.Append("    OoasUtil.exe -j -i c:\\csdl.xml -o trip.json\n");
+            sb.Append("    OoasUtil.exe -j -s 2 -i c:\\csdl.xml -o trip.json\n");
 
             Console.WriteLine(sb.ToString());
         } 

--- a/src/OoasUtil/FileOpenApiGenerator.cs
+++ b/src/OoasUtil/FileOpenApiGenerator.cs
@@ -29,8 +29,8 @@ namespace OoasUtil
         /// <param name="input">The input.</param>
         /// <param name="output">The output.</param>
         /// <param name="target">The output target.</param>
-        public FileOpenApiGenerator(string input, string output, OpenApiFormat format)
-            : base(output, format)
+        public FileOpenApiGenerator(string input, string output, OpenApiFormat format, OpenApiSpecVersion version)
+            : base(output, format, version)
         {
             Input = input;
         }

--- a/src/OoasUtil/OpenApiGenerator.cs
+++ b/src/OoasUtil/OpenApiGenerator.cs
@@ -25,6 +25,11 @@ namespace OoasUtil
         public OpenApiFormat Format { get; }
 
         /// <summary>
+        /// Output specification version.
+        /// </summary>
+        public OpenApiSpecVersion Version { get; }
+
+        /// <summary>
         /// Output file.
         /// </summary>
         public string Output { get; }
@@ -35,10 +40,11 @@ namespace OoasUtil
         /// <param name="input">The input.</param>
         /// <param name="output">The output.</param>
         /// <param name="target">The output target.</param>
-        public OpenApiGenerator(string output, OpenApiFormat format)
+        public OpenApiGenerator(string output, OpenApiFormat format, OpenApiSpecVersion version)
         {
             Output = output;
             Format = format;
+            Version = version;
         }
 
         /// <summary>
@@ -51,6 +57,8 @@ namespace OoasUtil
                 IEdmModel edmModel = GetEdmModel();
 
                 OpenApiConvertSettings settings = GetSettings();
+
+                settings.OpenApiSpecVersion = Version;
 
                 using (FileStream fs = File.Create(Output))
                 {

--- a/src/OoasUtil/OpenApiGenerator.cs
+++ b/src/OoasUtil/OpenApiGenerator.cs
@@ -55,7 +55,7 @@ namespace OoasUtil
                 using (FileStream fs = File.Create(Output))
                 {
                     OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
-                    document.Serialize(fs, OpenApiSpecVersion.OpenApi3_0, Format);
+                    document.Serialize(fs, settings.OpenApiSpecVersion, Format);
                     fs.Flush();
                 }
             }

--- a/src/OoasUtil/Program.cs
+++ b/src/OoasUtil/Program.cs
@@ -31,16 +31,16 @@ namespace OoasUtil
             OpenApiGenerator generator;
             if (processer.IsLocalFile)
             {
-                generator = new FileOpenApiGenerator(processer.Input, processer.Output, processer.Format.Value);
+                generator = new FileOpenApiGenerator(processer.Input, processer.Output, processer.Format.Value, processer.Version.Value);
             }
             else
             {
-                generator = new UrlOpenApiGenerator(new Uri(processer.Input), processer.Output, processer.Format.Value);
+                generator = new UrlOpenApiGenerator(new Uri(processer.Input), processer.Output, processer.Format.Value, processer.Version.Value);
             }
 
             if (generator.Generate())
             {
-                Console.WriteLine("Successed!");
+                Console.WriteLine("Succeeded!");
                 return 1;
             }
             else

--- a/src/OoasUtil/README.md
+++ b/src/OoasUtil/README.md
@@ -25,6 +25,14 @@ Output the "JSON" format Open API document;
 
 Output the "YAML" format Open API document;
 
+### [--specversion|-s int]
+
+Indicate which version, either 2 or 3, of the OpenApi specification to output. Only 2 or 3 are supported;
+
+### [--yaml|-y]
+
+Output the "YAML" format Open API document;
+
 ### [--input|-i file]
 
 Indicate to where to get CSDL, from file or from Uri.
@@ -36,7 +44,7 @@ Indicate to output file name.
 
 ## Examples
 
-`OoasUtil.exe -j -i http://services.odata.org/TrippinRESTierService -o trip.json`
+`OoasUtil.exe -j -s 3 -i http://services.odata.org/TrippinRESTierService -o trip.json`
 
 The content of `trip.json` is similar at https://github.com/xuzhg/OData.OpenAPI/blob/master/Microsoft.OData.OpenAPI/Microsoft.OData.OpenAPI.Tests/Resources/TripService.OpenApi.json
 

--- a/src/OoasUtil/UrlOpenApiGenerator.cs
+++ b/src/OoasUtil/UrlOpenApiGenerator.cs
@@ -26,14 +26,14 @@ namespace OoasUtil
         /// </summary>
         public Uri Input { get; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UrlOpenApiGenerator"/> class.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <param name="output">The output.</param>
-        /// <param name="target">The output target.</param>
-        public UrlOpenApiGenerator(Uri input, string output, OpenApiFormat format)
-            : base(output, format)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="UrlOpenApiGenerator"/> class.
+		/// </summary>
+		/// <param name="input">The input.</param>
+		/// <param name="output">The output.</param>
+		/// <param name="target">The output target.</param>
+		public UrlOpenApiGenerator(Uri input, string output, OpenApiFormat format, OpenApiSpecVersion version)
+            : base(output, format, version)
         {
             Input = input;
         }

--- a/src/OoasUtil/UrlOpenApiGenerator.cs
+++ b/src/OoasUtil/UrlOpenApiGenerator.cs
@@ -26,13 +26,13 @@ namespace OoasUtil
         /// </summary>
         public Uri Input { get; }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="UrlOpenApiGenerator"/> class.
-		/// </summary>
-		/// <param name="input">The input.</param>
-		/// <param name="output">The output.</param>
-		/// <param name="target">The output target.</param>
-		public UrlOpenApiGenerator(Uri input, string output, OpenApiFormat format, OpenApiSpecVersion version)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UrlOpenApiGenerator"/> class.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="output">The output.</param>
+        /// <param name="target">The output target.</param>
+        public UrlOpenApiGenerator(Uri input, string output, OpenApiFormat format, OpenApiSpecVersion version)
             : base(output, format, version)
         {
             Input = input;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
@@ -32,21 +32,21 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void EmptyEdmModelToOpenApiJsonWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void EmptyEdmModelToOpenApiJsonWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.EmptyModel;
             var openApiConvertSettings = new OpenApiConvertSettings();
-            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            openApiConvertSettings.OpenApiSpecVersion = specVersion;
 
             // Act
             string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, openApiConvertSettings);
             _output.WriteLine(json);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("Empty.OpenApi.V2.json").ChangeLineBreaks(), json);
             }
@@ -57,21 +57,21 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void EmptyEdmModelToOpenApiYamlWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void EmptyEdmModelToOpenApiYamlWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.EmptyModel;
             var openApiConvertSettings = new OpenApiConvertSettings();
-            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            openApiConvertSettings.OpenApiSpecVersion = specVersion;
 
             // Act
             string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml, openApiConvertSettings);
             _output.WriteLine(yaml);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("Empty.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
             }
@@ -82,21 +82,21 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void BasicEdmModelToOpenApiJsonWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void BasicEdmModelToOpenApiJsonWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
             var openApiConvertSettings = new OpenApiConvertSettings();
-            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            openApiConvertSettings.OpenApiSpecVersion = specVersion;
 
             // Act
             string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, openApiConvertSettings);
             _output.WriteLine(json);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("Basic.OpenApi.V2.json").ChangeLineBreaks(), json);
             }
@@ -107,21 +107,21 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void BasicEdmModelToOpenApiYamlWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void BasicEdmModelToOpenApiYamlWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
             var openApiConvertSettings = new OpenApiConvertSettings();
-            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            openApiConvertSettings.OpenApiSpecVersion = specVersion;
 
             // Act
             string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml, openApiConvertSettings);
             _output.WriteLine(yaml);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("Basic.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
             }
@@ -132,21 +132,21 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void MultipleSchemasEdmModelToOpenApiJsonWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void MultipleSchemasEdmModelToOpenApiJsonWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.MultipleSchemasEdmModel;
             var openApiConvertSettings = new OpenApiConvertSettings();
-            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            openApiConvertSettings.OpenApiSpecVersion = specVersion;
 
             // Act
             string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, openApiConvertSettings);
             _output.WriteLine(json);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.V2.json").ChangeLineBreaks(), json);
             }
@@ -157,21 +157,21 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void MultipleSchemasEdmModelToOpenApiYamlWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void MultipleSchemasEdmModelToOpenApiYamlWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.MultipleSchemasEdmModel;
             var openApiConvertSettings = new OpenApiConvertSettings();
-            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            openApiConvertSettings.OpenApiSpecVersion = specVersion;
 
             // Act
             string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml, openApiConvertSettings);
             _output.WriteLine(yaml);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
             }
@@ -182,9 +182,9 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void TripServiceMetadataToOpenApiJsonWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void TripServiceMetadataToOpenApiJsonWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -194,14 +194,14 @@ namespace Microsoft.OpenApi.OData.Tests
                 Version = new Version(1, 0, 1),
                 ServiceRoot = new Uri("http://services.odata.org/TrippinRESTierService"),
                 IEEE754Compatible = true,
-                OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0
+                OpenApiSpecVersion = specVersion
             };
             // Act
             string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, settings);
             _output.WriteLine(json);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("TripService.OpenApi.V2.json").ChangeLineBreaks(), json);
             }
@@ -212,9 +212,9 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TripServiceMetadataToOpenApiYamlWorks(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void TripServiceMetadataToOpenApiYamlWorks(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -225,7 +225,7 @@ namespace Microsoft.OpenApi.OData.Tests
                 Version = new Version(1, 0, 1),
                 ServiceRoot = new Uri("http://services.odata.org/TrippinRESTierService"),
                 IEEE754Compatible = true,
-                OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0
+                OpenApiSpecVersion = specVersion
             };
 
             // Act
@@ -233,7 +233,7 @@ namespace Microsoft.OpenApi.OData.Tests
             _output.WriteLine(yaml);
 
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(Resources.GetString("TripService.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
@@ -31,92 +31,160 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Throws<ArgumentNullException>("model", () => model.ConvertToOpenApi());
         }
 
-        [Fact]
-        public void EmptyEdmModelToOpenApiJsonWorks()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EmptyEdmModelToOpenApiJsonWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.EmptyModel;
+            var openApiConvertSettings = new OpenApiConvertSettings();
+            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
 
             // Act
-            string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json);
+            string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, openApiConvertSettings);
             _output.WriteLine(json);
 
             // Assert
-            Assert.Equal(Resources.GetString("Empty.OpenApi.json").ChangeLineBreaks(), json);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("Empty.OpenApi.V2.json").ChangeLineBreaks(), json);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("Empty.OpenApi.json").ChangeLineBreaks(), json);
+            }
         }
 
-        [Fact]
-        public void EmptyEdmModelToOpenApiYamlWorks()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EmptyEdmModelToOpenApiYamlWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.EmptyModel;
+            var openApiConvertSettings = new OpenApiConvertSettings();
+            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
 
             // Act
-            string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml);
+            string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml, openApiConvertSettings);
             _output.WriteLine(yaml);
 
             // Assert
-            Assert.Equal(Resources.GetString("Empty.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("Empty.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("Empty.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            }
         }
 
-        [Fact]
-        public void BasicEdmModelToOpenApiJsonWorks()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void BasicEdmModelToOpenApiJsonWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
+            var openApiConvertSettings = new OpenApiConvertSettings();
+            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
 
             // Act
-            string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json);
+            string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, openApiConvertSettings);
             _output.WriteLine(json);
 
             // Assert
-            Assert.Equal(Resources.GetString("Basic.OpenApi.json").ChangeLineBreaks(), json);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("Basic.OpenApi.V2.json").ChangeLineBreaks(), json);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("Basic.OpenApi.json").ChangeLineBreaks(), json);
+            }
         }
 
-        [Fact]
-        public void BasicEdmModelToOpenApiYamlWorks()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void BasicEdmModelToOpenApiYamlWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
+            var openApiConvertSettings = new OpenApiConvertSettings();
+            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
 
             // Act
-            string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml);
+            string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml, openApiConvertSettings);
             _output.WriteLine(yaml);
 
             // Assert
-            Assert.Equal(Resources.GetString("Basic.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("Basic.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("Basic.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            }
         }
 
-        [Fact]
-        public void MultipleSchemasEdmModelToOpenApiJsonWorks()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MultipleSchemasEdmModelToOpenApiJsonWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.MultipleSchemasEdmModel;
+            var openApiConvertSettings = new OpenApiConvertSettings();
+            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
 
             // Act
-            string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json);
+            string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, openApiConvertSettings);
             _output.WriteLine(json);
 
             // Assert
-            Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.json").ChangeLineBreaks(), json);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.V2.json").ChangeLineBreaks(), json);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.json").ChangeLineBreaks(), json);
+            }
         }
 
-        [Fact]
-        public void MultipleSchemasEdmModelToOpenApiYamlWorks()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MultipleSchemasEdmModelToOpenApiYamlWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.MultipleSchemasEdmModel;
+            var openApiConvertSettings = new OpenApiConvertSettings();
+            openApiConvertSettings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
 
             // Act
-            string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml);
+            string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml, openApiConvertSettings);
             _output.WriteLine(yaml);
 
             // Assert
-            Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("Multiple.Schema.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            }
         }
 
-        [Fact]
-        public void TripServiceMetadataToOpenApiJsonWorks()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TripServiceMetadataToOpenApiJsonWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -125,18 +193,28 @@ namespace Microsoft.OpenApi.OData.Tests
                 EnableKeyAsSegment = true,
                 Version = new Version(1, 0, 1),
                 ServiceRoot = new Uri("http://services.odata.org/TrippinRESTierService"),
-                IEEE754Compatible = true
+                IEEE754Compatible = true,
+                OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0
             };
             // Act
             string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, settings);
             _output.WriteLine(json);
 
             // Assert
-            Assert.Equal(Resources.GetString("TripService.OpenApi.json").ChangeLineBreaks(), json);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("TripService.OpenApi.V2.json").ChangeLineBreaks(), json);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("TripService.OpenApi.json").ChangeLineBreaks(), json);
+            }
         }
 
-        [Fact]
-        public void TripServiceMetadataToOpenApiYamlWorks()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TripServiceMetadataToOpenApiYamlWorks(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -146,7 +224,8 @@ namespace Microsoft.OpenApi.OData.Tests
                 EnableKeyAsSegment = true,
                 Version = new Version(1, 0, 1),
                 ServiceRoot = new Uri("http://services.odata.org/TrippinRESTierService"),
-                IEEE754Compatible = true
+                IEEE754Compatible = true,
+                OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0
             };
 
             // Act
@@ -154,7 +233,14 @@ namespace Microsoft.OpenApi.OData.Tests
             _output.WriteLine(yaml);
 
             // Assert
-            Assert.Equal(Resources.GetString("TripService.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(Resources.GetString("TripService.OpenApi.V2.yaml").ChangeLineBreaks(), yaml);
+            }
+            else
+            {
+                Assert.Equal(Resources.GetString("TripService.OpenApi.yaml").ChangeLineBreaks(), yaml);
+            }
         }
 
         private static string WriteEdmModelAsOpenApi(IEdmModel model, OpenApiFormat target,
@@ -165,7 +251,7 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.NotNull(document); // guard
 
             MemoryStream stream = new MemoryStream();
-            document.Serialize(stream, OpenApiSpecVersion.OpenApi3_0, target);
+            document.Serialize(stream, settings.OpenApiSpecVersion, target);
             stream.Flush();
             stream.Position = 0;
             return new StreamReader(stream).ReadToEnd();

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
@@ -44,16 +44,16 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void CreateEdmTypeSchemaReturnSchemaForNullableCollectionComplexType(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void CreateEdmTypeSchemaReturnSchemaForNullableCollectionComplexType(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
             IEdmComplexType complex = model.SchemaElements.OfType<IEdmComplexType>().First(c => c.Name == "AirportLocation");
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            context.Settings.OpenApiSpecVersion = specVersion;
 
             IEdmCollectionTypeReference collectionType = new EdmCollectionTypeReference(
                 new EdmCollectionType(new EdmComplexTypeReference(complex, true)));
@@ -64,7 +64,7 @@ namespace Microsoft.OpenApi.OData.Tests
             string json = schema.SerializeAsJson(context.Settings.OpenApiSpecVersion);
 
             // & Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(@"{
   ""type"": ""array"",
@@ -164,11 +164,11 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void CreateEdmTypeSchemaReturnSchemaForEnumType(bool isNullable, bool isOpenApiV2Spec)
+        [InlineData(true, OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(true, OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi3_0)]
+        public void CreateEdmTypeSchemaReturnSchemaForEnumType(bool isNullable, OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -177,7 +177,7 @@ namespace Microsoft.OpenApi.OData.Tests
             IEdmEnumTypeReference enumTypeReference = new EdmEnumTypeReference(enumType, isNullable);
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            context.Settings.OpenApiSpecVersion = specVersion;
 
             // Act
             var schema = context.CreateEdmTypeSchema(enumTypeReference);
@@ -189,7 +189,7 @@ namespace Microsoft.OpenApi.OData.Tests
             // for openApiV2 nullable will not be serialized
             Assert.Equal(isNullable, schema.Nullable);
 
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.NotNull(schema.Reference);
                 Assert.Null(schema.AnyOf);
@@ -209,11 +209,11 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void CreateEdmTypeSchemaReturnSchemaForComplexType(bool isNullable, bool isOpenApiV2Spec)
+        [InlineData(true, OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(true, OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi3_0)]
+        public void CreateEdmTypeSchemaReturnSchemaForComplexType(bool isNullable, OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -222,7 +222,7 @@ namespace Microsoft.OpenApi.OData.Tests
             IEdmComplexTypeReference complexTypeReference = new EdmComplexTypeReference(complex, isNullable);
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            context.Settings.OpenApiSpecVersion = specVersion;
 
             // Act
             var schema = context.CreateEdmTypeSchema(complexTypeReference);
@@ -230,7 +230,7 @@ namespace Microsoft.OpenApi.OData.Tests
             // & Assert
             Assert.NotNull(schema);
 
-            if (isOpenApiV2Spec || isNullable == false)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0 || isNullable == false)
             {
                 Assert.Null(schema.AnyOf);
                 Assert.NotNull(schema.Reference);
@@ -250,11 +250,11 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void CreateEdmTypeSchemaReturnSchemaForEntityType(bool isNullable, bool isOpenApiV2Spec)
+        [InlineData(true, OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(true, OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi3_0)]
+        public void CreateEdmTypeSchemaReturnSchemaForEntityType(bool isNullable, OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -263,7 +263,7 @@ namespace Microsoft.OpenApi.OData.Tests
             IEdmEntityTypeReference entityTypeReference = new EdmEntityTypeReference(entity, isNullable);
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            context.Settings.OpenApiSpecVersion = specVersion;
 
             // Act
             var schema = context.CreateEdmTypeSchema(entityTypeReference);
@@ -271,7 +271,7 @@ namespace Microsoft.OpenApi.OData.Tests
             // & Assert
             Assert.NotNull(schema);
 
-            if (isOpenApiV2Spec || isNullable == false)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0 || isNullable == false)
             {
                 Assert.Null(schema.AnyOf);
                 Assert.NotNull(schema.Reference);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
@@ -43,23 +43,39 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Throws<ArgumentNullException>("edmTypeReference", () => context.CreateEdmTypeSchema(edmTypeReference: null));
         }
 
-        [Fact]
-        public void CreateEdmTypeSchemaReturnSchemaForNullableCollectionComplexType()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateEdmTypeSchemaReturnSchemaForNullableCollectionComplexType(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
             IEdmComplexType complex = model.SchemaElements.OfType<IEdmComplexType>().First(c => c.Name == "AirportLocation");
             ODataContext context = new ODataContext(model);
+
+            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+
             IEdmCollectionTypeReference collectionType = new EdmCollectionTypeReference(
                 new EdmCollectionType(new EdmComplexTypeReference(complex, true)));
 
             // Act
             var schema = context.CreateEdmTypeSchema(collectionType);
             Assert.NotNull(schema);
-            string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            string json = schema.SerializeAsJson(context.Settings.OpenApiSpecVersion);
 
             // & Assert
-            Assert.Equal(@"{
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(@"{
+  ""type"": ""array"",
+  ""items"": {
+    ""$ref"": ""#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation""
+  }
+}".ChangeLineBreaks(), json);
+            }
+            else
+            {
+                Assert.Equal(@"{
   ""type"": ""array"",
   ""items"": {
     ""anyOf"": [
@@ -70,6 +86,7 @@ namespace Microsoft.OpenApi.OData.Tests
     ""nullable"": true
   }
 }".ChangeLineBreaks(), json);
+            }           
         }
 
         [Fact]
@@ -147,9 +164,11 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void CreateEdmTypeSchemaReturnSchemaForEnumType(bool isNullable)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void CreateEdmTypeSchemaReturnSchemaForEnumType(bool isNullable, bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -158,25 +177,43 @@ namespace Microsoft.OpenApi.OData.Tests
             IEdmEnumTypeReference enumTypeReference = new EdmEnumTypeReference(enumType, isNullable);
             ODataContext context = new ODataContext(model);
 
+            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+
             // Act
             var schema = context.CreateEdmTypeSchema(enumTypeReference);
 
             // & Assert
             Assert.NotNull(schema);
+
+            // Although the schema will be set
+            // for openApiV2 nullable will not be serialized
             Assert.Equal(isNullable, schema.Nullable);
-            Assert.Null(schema.Reference);
-            Assert.NotNull(schema.AnyOf);
-            Assert.NotEmpty(schema.AnyOf);
-            var anyOf = Assert.Single(schema.AnyOf);
-            Assert.NotNull(anyOf.Reference);
-            Assert.Equal(ReferenceType.Schema, anyOf.Reference.Type);
-            Assert.Equal(enumType.FullTypeName(), anyOf.Reference.Id);
+
+            if (isOpenApiV2Spec)
+            {
+                Assert.NotNull(schema.Reference);
+                Assert.Null(schema.AnyOf);
+                Assert.Equal(ReferenceType.Schema, schema.Reference.Type);
+                Assert.Equal(enumType.FullTypeName(), schema.Reference.Id);
+            }
+            else
+            {
+                Assert.Null(schema.Reference);
+                Assert.NotNull(schema.AnyOf);
+                Assert.NotEmpty(schema.AnyOf);
+                var anyOf = Assert.Single(schema.AnyOf);
+                Assert.NotNull(anyOf.Reference);
+                Assert.Equal(ReferenceType.Schema, anyOf.Reference.Type);
+                Assert.Equal(enumType.FullTypeName(), anyOf.Reference.Id);
+            }
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void CreateEdmTypeSchemaReturnSchemaForComplexType(bool isNullable)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void CreateEdmTypeSchemaReturnSchemaForComplexType(bool isNullable, bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -185,13 +222,22 @@ namespace Microsoft.OpenApi.OData.Tests
             IEdmComplexTypeReference complexTypeReference = new EdmComplexTypeReference(complex, isNullable);
             ODataContext context = new ODataContext(model);
 
+            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+
             // Act
             var schema = context.CreateEdmTypeSchema(complexTypeReference);
 
             // & Assert
             Assert.NotNull(schema);
 
-            if (isNullable)
+            if (isOpenApiV2Spec || isNullable == false)
+            {
+                Assert.Null(schema.AnyOf);
+                Assert.NotNull(schema.Reference);
+                Assert.Equal(ReferenceType.Schema, schema.Reference.Type);
+                Assert.Equal(complex.FullTypeName(), schema.Reference.Id);
+            }
+            else
             {
                 Assert.Null(schema.Reference);
                 Assert.NotNull(schema.AnyOf);
@@ -201,19 +247,14 @@ namespace Microsoft.OpenApi.OData.Tests
                 Assert.Equal(ReferenceType.Schema, anyOf.Reference.Type);
                 Assert.Equal(complex.FullTypeName(), anyOf.Reference.Id);
             }
-            else
-            {
-                Assert.Null(schema.AnyOf);
-                Assert.NotNull(schema.Reference);
-                Assert.Equal(ReferenceType.Schema, schema.Reference.Type);
-                Assert.Equal(complex.FullTypeName(), schema.Reference.Id);
-            }
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void CreateEdmTypeSchemaReturnSchemaForEntityType(bool isNullable)
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void CreateEdmTypeSchemaReturnSchemaForEntityType(bool isNullable, bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
@@ -222,13 +263,22 @@ namespace Microsoft.OpenApi.OData.Tests
             IEdmEntityTypeReference entityTypeReference = new EdmEntityTypeReference(entity, isNullable);
             ODataContext context = new ODataContext(model);
 
+            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+
             // Act
             var schema = context.CreateEdmTypeSchema(entityTypeReference);
 
             // & Assert
             Assert.NotNull(schema);
 
-            if (isNullable)
+            if (isOpenApiV2Spec || isNullable == false)
+            {
+                Assert.Null(schema.AnyOf);
+                Assert.NotNull(schema.Reference);
+                Assert.Equal(ReferenceType.Schema, schema.Reference.Type);
+                Assert.Equal(entity.FullTypeName(), schema.Reference.Id);
+            }
+            else
             {
                 Assert.Null(schema.Reference);
                 Assert.NotNull(schema.AnyOf);
@@ -237,13 +287,6 @@ namespace Microsoft.OpenApi.OData.Tests
                 Assert.NotNull(anyOf.Reference);
                 Assert.Equal(ReferenceType.Schema, anyOf.Reference.Type);
                 Assert.Equal(entity.FullTypeName(), anyOf.Reference.Id);
-            }
-            else
-            {
-                Assert.Null(schema.AnyOf);
-                Assert.NotNull(schema.Reference);
-                Assert.Equal(ReferenceType.Schema, schema.Reference.Type);
-                Assert.Equal(entity.FullTypeName(), schema.Reference.Id);
             }
         }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -138,17 +138,18 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
         }
 
         [Theory]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        [InlineData(true, true)]
-        public void CreateResponseForEdmFunctionReturnCorrectResponses(bool isFunctionImport, bool isOpenApiVersion2)
+        [InlineData(true, OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(true, OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(false, OpenApiSpecVersion.OpenApi2_0)]
+        public void CreateResponseForEdmFunctionReturnCorrectResponses(bool isFunctionImport, OpenApiSpecVersion specVersion)
         {
             // Arrange
             string operationName = "GetPersonWithMostFriends";
             IEdmModel model = EdmModelHelper.TripServiceModel;
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = isOpenApiVersion2 ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            context.Settings.OpenApiSpecVersion = specVersion;
 
             // Act
             OpenApiResponses responses;
@@ -180,7 +181,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.True(mediaType.Schema.Nullable);
 
             // openApi version 2 should have not use nullable
-            if (isOpenApiVersion2)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.NotNull(mediaType.Schema);
                 Assert.Null(mediaType.Schema.AnyOf);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -387,12 +387,17 @@ namespace Microsoft.OpenApi.OData.Tests
         #endregion
 
         #region EdmPropertySchema
-        [Fact]
-        public void CreatePropertySchemaForNonNullableEnumPropertyReturnSchema()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CreatePropertySchemaForNonNullableEnumPropertyReturnSchema(bool isOpenApiSpecV2)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
             ODataContext context = new ODataContext(model);
+
+            context.Settings.OpenApiSpecVersion = isOpenApiSpecV2 ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+
             IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().First(e => e.Name == "Color");
             EdmEntityType entitType = new EdmEntityType("NS", "Entity");
             IEdmProperty property = new EdmStructuralProperty(entitType, "ColorEnumValue", new EdmEnumTypeReference(enumType, false), "yellow");
@@ -403,7 +408,16 @@ namespace Microsoft.OpenApi.OData.Tests
             string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            Assert.Equal(@"{
+
+            if (isOpenApiSpecV2)
+            {
+                Assert.Equal(@"{
+  ""$ref"": ""#/components/schemas/DefaultNs.Color""
+}".ChangeLineBreaks(), json);
+            }
+            else
+            {
+                Assert.Equal(@"{
   ""anyOf"": [
     {
       ""$ref"": ""#/components/schemas/DefaultNs.Color""
@@ -411,14 +425,20 @@ namespace Microsoft.OpenApi.OData.Tests
   ],
   ""default"": ""yellow""
 }".ChangeLineBreaks(), json);
+            }
         }
 
-        [Fact]
-        public void CreatePropertySchemaForNullableEnumPropertyReturnSchema()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CreatePropertySchemaForNullableEnumPropertyReturnSchema(bool isOpenApiV2Spec)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
             ODataContext context = new ODataContext(model);
+
+            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+
             IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().First(e => e.Name == "Color");
             EdmEntityType entitType = new EdmEntityType("NS", "Entity");
             IEdmProperty property = new EdmStructuralProperty(entitType, "ColorEnumValue", new EdmEnumTypeReference(enumType, true), "yellow");
@@ -428,8 +448,17 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.NotNull(schema);
             string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
             _output.WriteLine(json);
+            
             // Assert
-            Assert.Equal(@"{
+            if (isOpenApiV2Spec)
+            {
+                Assert.Equal(@"{
+  ""$ref"": ""#/components/schemas/DefaultNs.Color""
+}".ChangeLineBreaks(), json);
+            }
+            else
+            {
+                Assert.Equal(@"{
   ""anyOf"": [
     {
       ""$ref"": ""#/components/schemas/DefaultNs.Color""
@@ -438,6 +467,7 @@ namespace Microsoft.OpenApi.OData.Tests
   ""default"": ""yellow"",
   ""nullable"": true
 }".ChangeLineBreaks(), json);
+            }
         }
         #endregion
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -388,15 +388,15 @@ namespace Microsoft.OpenApi.OData.Tests
 
         #region EdmPropertySchema
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CreatePropertySchemaForNonNullableEnumPropertyReturnSchema(bool isOpenApiSpecV2)
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        public void CreatePropertySchemaForNonNullableEnumPropertyReturnSchema(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = isOpenApiSpecV2 ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            context.Settings.OpenApiSpecVersion = specVersion;
 
             IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().First(e => e.Name == "Color");
             EdmEntityType entitType = new EdmEntityType("NS", "Entity");
@@ -405,14 +405,14 @@ namespace Microsoft.OpenApi.OData.Tests
             // Act
             var schema = context.CreatePropertySchema(property);
             Assert.NotNull(schema);
-            string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            string json = schema.SerializeAsJson(specVersion);
 
             // Assert
 
-            if (isOpenApiSpecV2)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(@"{
-  ""$ref"": ""#/components/schemas/DefaultNs.Color""
+  ""$ref"": ""#/definitions/DefaultNs.Color""
 }".ChangeLineBreaks(), json);
             }
             else
@@ -429,15 +429,15 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CreatePropertySchemaForNullableEnumPropertyReturnSchema(bool isOpenApiV2Spec)
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        public void CreatePropertySchemaForNullableEnumPropertyReturnSchema(OpenApiSpecVersion specVersion)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.BasicEdmModel;
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = isOpenApiV2Spec ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0;
+            context.Settings.OpenApiSpecVersion = specVersion;
 
             IEdmEnumType enumType = model.SchemaElements.OfType<IEdmEnumType>().First(e => e.Name == "Color");
             EdmEntityType entitType = new EdmEntityType("NS", "Entity");
@@ -446,14 +446,14 @@ namespace Microsoft.OpenApi.OData.Tests
             // Act
             var schema = context.CreatePropertySchema(property);
             Assert.NotNull(schema);
-            string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            string json = schema.SerializeAsJson(specVersion);
             _output.WriteLine(json);
             
             // Assert
-            if (isOpenApiV2Spec)
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.Equal(@"{
-  ""$ref"": ""#/components/schemas/DefaultNs.Color""
+  ""$ref"": ""#/definitions/DefaultNs.Color""
 }".ChangeLineBreaks(), json);
             }
             else

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
@@ -13,15 +13,23 @@
 
   <ItemGroup>
     <None Remove="Resources\Basic.OpenApi.json" />
+    <None Remove="Resources\Basic.OpenApi.V2.json" />
     <None Remove="Resources\Basic.OpenApi.yaml" />
+    <None Remove="Resources\Basic.OpenApi.V2.yaml" />
     <None Remove="Resources\Empty.OpenApi.json" />
+    <None Remove="Resources\Empty.OpenApi.V2.json" />
     <None Remove="Resources\Empty.OpenApi.yaml" />
+    <None Remove="Resources\Empty.OpenApi.V2.yaml" />
     <None Remove="Resources\Graph.Beta.OData.xml" />
     <None Remove="Resources\Multiple.Schema.OData.xml" />
     <None Remove="Resources\Multiple.Schema.OpenApi.json" />
+    <None Remove="Resources\Multiple.Schema.OpenApi.V2.json" />
     <None Remove="Resources\Multiple.Schema.OpenApi.yaml" />
+    <None Remove="Resources\Multiple.Schema.OpenApi.V2.yaml" />
     <None Remove="Resources\TripService.OpenApi.json" />
+    <None Remove="Resources\TripService.OpenApi.V2.json" />
     <None Remove="Resources\TripService.OpenApi.yaml" />
+    <None Remove="Resources\TripService.OpenApi.V2.yaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,15 +38,23 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Basic.OpenApi.json" />
+    <EmbeddedResource Include="Resources\Basic.OpenApi.V2.json" />
     <EmbeddedResource Include="Resources\Basic.OpenApi.yaml" />
+    <EmbeddedResource Include="Resources\Basic.OpenApi.V2.yaml" />
     <EmbeddedResource Include="Resources\Empty.OpenApi.json" />
+    <EmbeddedResource Include="Resources\Empty.OpenApi.V2.json" />
     <EmbeddedResource Include="Resources\Empty.OpenApi.yaml" />
+    <EmbeddedResource Include="Resources\Empty.OpenApi.V2.yaml" />
     <EmbeddedResource Include="Resources\Graph.Beta.OData.xml" />
     <EmbeddedResource Include="Resources\Multiple.Schema.OpenApi.json" />
+    <EmbeddedResource Include="Resources\Multiple.Schema.OpenApi.V2.json" />
     <EmbeddedResource Include="Resources\Multiple.Schema.OpenApi.yaml" />
+    <EmbeddedResource Include="Resources\Multiple.Schema.OpenApi.V2.yaml" />
     <EmbeddedResource Include="Resources\TripService.OData.xml" />
     <EmbeddedResource Include="Resources\TripService.OpenApi.json" />
+    <EmbeddedResource Include="Resources\TripService.OpenApi.V2.json" />
     <EmbeddedResource Include="Resources\TripService.OpenApi.yaml" />
+    <EmbeddedResource Include="Resources\TripService.OpenApi.V2.yaml" />
     <EmbeddedResource Include="Resources\YamlWriterTest.yaml.txt" />
     <EmbeddedResource Include="Resources\JsonWriterTest.json.txt" />
   </ItemGroup>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -1,0 +1,1095 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "OData Service for namespace DefaultNs",
+    "description": "This OData service is located at http://localhost",
+    "version": "1.0.1"
+  },
+  "host": "localhost",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/City": {
+      "get": {
+        "tags": [
+          "City.City"
+        ],
+        "summary": "Get entities from City",
+        "operationId": "City.City.ListCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "Name desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of City",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/DefaultNs.City"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "City.City"
+        ],
+        "summary": "Add new entity to City",
+        "operationId": "City.City.CreateCity",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/City({Name})": {
+      "get": {
+        "tags": [
+          "City.City"
+        ],
+        "summary": "Get entity from City by key",
+        "operationId": "City.City.GetCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Name",
+            "description": "key: Name",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "City"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "City.City"
+        ],
+        "summary": "Update entity in City",
+        "operationId": "City.City.UpdateCity",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Name",
+            "description": "key: Name",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "City"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "City.City"
+        ],
+        "summary": "Delete entity from City",
+        "operationId": "City.City.DeleteCity",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Name",
+            "description": "key: Name",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "City"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/CountryOrRegion": {
+      "get": {
+        "tags": [
+          "CountryOrRegion.CountryOrRegion"
+        ],
+        "summary": "Get entities from CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.ListCountryOrRegion",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "Name desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of CountryOrRegion",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/DefaultNs.CountryOrRegion"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "CountryOrRegion.CountryOrRegion"
+        ],
+        "summary": "Add new entity to CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.CreateCountryOrRegion",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.CountryOrRegion"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.CountryOrRegion"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/CountryOrRegion({Name})": {
+      "get": {
+        "tags": [
+          "CountryOrRegion.CountryOrRegion"
+        ],
+        "summary": "Get entity from CountryOrRegion by key",
+        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegion",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Name",
+            "description": "key: Name",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "CountryOrRegion"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.CountryOrRegion"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "CountryOrRegion.CountryOrRegion"
+        ],
+        "summary": "Update entity in CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Name",
+            "description": "key: Name",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "CountryOrRegion"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.CountryOrRegion"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "CountryOrRegion.CountryOrRegion"
+        ],
+        "summary": "Delete entity from CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Name",
+            "description": "key: Name",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "CountryOrRegion"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Me",
+        "operationId": "Me.Person.GetPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "HomeAddress",
+                "WorkAddress",
+                "Addresses"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Me",
+        "operationId": "Me.Person.UpdatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get entities from People",
+        "operationId": "People.Person.ListPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "WorkAddress",
+                "WorkAddress desc",
+                "Addresses",
+                "Addresses desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "HomeAddress",
+                "WorkAddress",
+                "Addresses"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/DefaultNs.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Add new entity to People",
+        "operationId": "People.Person.CreatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Person"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People({UserName})": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get entity from People by key",
+        "operationId": "People.Person.GetPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "HomeAddress",
+                "WorkAddress",
+                "Addresses"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update entity in People",
+        "operationId": "People.Person.UpdatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete entity from People",
+        "operationId": "People.Person.DeletePerson",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultNs.Color": {
+      "title": "Color",
+      "description": "Enum type 'Color' description.",
+      "enum": [
+        "Blue",
+        "White"
+      ],
+      "type": "string"
+    },
+    "DefaultNs.Person": {
+      "title": "Person",
+      "type": "object",
+      "properties": {
+        "UserName": {
+          "type": "string"
+        },
+        "HomeAddress": {
+          "$ref": "#/definitions/DefaultNs.Address"
+        },
+        "WorkAddress": {
+          "$ref": "#/definitions/DefaultNs.Address"
+        },
+        "Addresses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DefaultNs.Address"
+          }
+        }
+      },
+      "example": {
+        "UserName": "string (identifier)",
+        "HomeAddress": {
+          "@odata.type": "DefaultNs.Address"
+        },
+        "WorkAddress": {
+          "@odata.type": "DefaultNs.Address"
+        },
+        "Addresses": [
+          {
+            "@odata.type": "DefaultNs.Address"
+          }
+        ]
+      }
+    },
+    "DefaultNs.City": {
+      "title": "City",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      },
+      "example": {
+        "Name": "string (identifier)"
+      }
+    },
+    "DefaultNs.CountryOrRegion": {
+      "title": "CountryOrRegion",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      },
+      "example": {
+        "Name": "string (identifier)"
+      }
+    },
+    "DefaultNs.Address": {
+      "title": "Address",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "City": {
+          "$ref": "#/definitions/DefaultNs.City"
+        }
+      },
+      "example": {
+        "Id": "integer",
+        "City": {
+          "@odata.type": "DefaultNs.City"
+        }
+      }
+    },
+    "DefaultNs.WorkAddress": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DefaultNs.Address"
+        },
+        {
+          "title": "WorkAddress",
+          "type": "object",
+          "properties": {
+            "CountryOrRegion": {
+              "$ref": "#/definitions/DefaultNs.CountryOrRegion"
+            }
+          }
+        }
+      ],
+      "example": {
+        "Id": "integer",
+        "City": {
+          "@odata.type": "DefaultNs.City"
+        },
+        "CountryOrRegion": {
+          "@odata.type": "DefaultNs.CountryOrRegion"
+        }
+      }
+    },
+    "odata.error": {
+      "required": [
+        "error"
+      ],
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/odata.error.main"
+        }
+      }
+    },
+    "odata.error.main": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/odata.error.detail"
+          }
+        },
+        "innererror": {
+          "description": "The structure of this object is service-specific",
+          "type": "object"
+        }
+      }
+    },
+    "odata.error.detail": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "top": {
+      "in": "query",
+      "name": "$top",
+      "description": "Show only the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "skip": {
+      "in": "query",
+      "name": "$skip",
+      "description": "Skip the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "count": {
+      "in": "query",
+      "name": "$count",
+      "description": "Include count of items",
+      "type": "boolean"
+    },
+    "filter": {
+      "in": "query",
+      "name": "$filter",
+      "description": "Filter items by property values",
+      "type": "string"
+    },
+    "search": {
+      "in": "query",
+      "name": "$search",
+      "description": "Search items by search phrases",
+      "type": "string"
+    }
+  },
+  "responses": {
+    "error": {
+      "description": "error",
+      "schema": {
+        "$ref": "#/definitions/odata.error"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "City.City",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "CountryOrRegion.CountryOrRegion",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Me.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "People.Person",
+      "x-ms-docs-toc-type": "page"
+    }
+  ]
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -1,0 +1,724 @@
+﻿swagger: '2.0'
+info:
+  title: OData Service for namespace DefaultNs
+  description: This OData service is located at http://localhost
+  version: 1.0.1
+host: localhost
+schemes:
+  - http
+paths:
+  /City:
+    get:
+      tags:
+        - City.City
+      summary: Get entities from City
+      operationId: City.City.ListCity
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Name
+              - Name desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of City
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/DefaultNs.City'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - City.City
+      summary: Add new entity to City
+      operationId: City.City.CreateCity
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/City({Name})':
+    get:
+      tags:
+        - City.City
+      summary: Get entity from City by key
+      operationId: City.City.GetCity
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Name
+          description: 'key: Name'
+          required: true
+          type: string
+          x-ms-docs-key-type: City
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - City.City
+      summary: Update entity in City
+      operationId: City.City.UpdateCity
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Name
+          description: 'key: Name'
+          required: true
+          type: string
+          x-ms-docs-key-type: City
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - City.City
+      summary: Delete entity from City
+      operationId: City.City.DeleteCity
+      parameters:
+        - in: path
+          name: Name
+          description: 'key: Name'
+          required: true
+          type: string
+          x-ms-docs-key-type: City
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /CountryOrRegion:
+    get:
+      tags:
+        - CountryOrRegion.CountryOrRegion
+      summary: Get entities from CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.ListCountryOrRegion
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Name
+              - Name desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of CountryOrRegion
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/DefaultNs.CountryOrRegion'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - CountryOrRegion.CountryOrRegion
+      summary: Add new entity to CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.CreateCountryOrRegion
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.CountryOrRegion'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/DefaultNs.CountryOrRegion'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/CountryOrRegion({Name})':
+    get:
+      tags:
+        - CountryOrRegion.CountryOrRegion
+      summary: Get entity from CountryOrRegion by key
+      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegion
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Name
+          description: 'key: Name'
+          required: true
+          type: string
+          x-ms-docs-key-type: CountryOrRegion
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/DefaultNs.CountryOrRegion'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - CountryOrRegion.CountryOrRegion
+      summary: Update entity in CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Name
+          description: 'key: Name'
+          required: true
+          type: string
+          x-ms-docs-key-type: CountryOrRegion
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.CountryOrRegion'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - CountryOrRegion.CountryOrRegion
+      summary: Delete entity from CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion
+      parameters:
+        - in: path
+          name: Name
+          description: 'key: Name'
+          required: true
+          type: string
+          x-ms-docs-key-type: CountryOrRegion
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Me:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Me
+      operationId: Me.Person.GetPerson
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - HomeAddress
+              - WorkAddress
+              - Addresses
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/DefaultNs.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update Me
+      operationId: Me.Person.UpdatePerson
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /People:
+    get:
+      tags:
+        - People.Person
+      summary: Get entities from People
+      operationId: People.Person.ListPerson
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - HomeAddress
+              - HomeAddress desc
+              - WorkAddress
+              - WorkAddress desc
+              - Addresses
+              - Addresses desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - HomeAddress
+              - WorkAddress
+              - Addresses
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of Person
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/DefaultNs.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Person
+      summary: Add new entity to People
+      operationId: People.Person.CreatePerson
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.Person'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/DefaultNs.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People({UserName})':
+    get:
+      tags:
+        - People.Person
+      summary: Get entity from People by key
+      operationId: People.Person.GetPerson
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - HomeAddress
+              - WorkAddress
+              - Addresses
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/DefaultNs.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update entity in People
+      operationId: People.Person.UpdatePerson
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete entity from People
+      operationId: People.Person.DeletePerson
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+definitions:
+  DefaultNs.Color:
+    title: Color
+    description: Enum type 'Color' description.
+    enum:
+      - Blue
+      - White
+    type: string
+  DefaultNs.Person:
+    title: Person
+    type: object
+    properties:
+      UserName:
+        type: string
+      HomeAddress:
+        $ref: '#/definitions/DefaultNs.Address'
+      WorkAddress:
+        $ref: '#/definitions/DefaultNs.Address'
+      Addresses:
+        type: array
+        items:
+          $ref: '#/definitions/DefaultNs.Address'
+    example:
+      UserName: string (identifier)
+      HomeAddress:
+        '@odata.type': DefaultNs.Address
+      WorkAddress:
+        '@odata.type': DefaultNs.Address
+      Addresses:
+        - '@odata.type': DefaultNs.Address
+  DefaultNs.City:
+    title: City
+    type: object
+    properties:
+      Name:
+        type: string
+    example:
+      Name: string (identifier)
+  DefaultNs.CountryOrRegion:
+    title: CountryOrRegion
+    type: object
+    properties:
+      Name:
+        type: string
+    example:
+      Name: string (identifier)
+  DefaultNs.Address:
+    title: Address
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      City:
+        $ref: '#/definitions/DefaultNs.City'
+    example:
+      Id: integer
+      City:
+        '@odata.type': DefaultNs.City
+  DefaultNs.WorkAddress:
+    allOf:
+      - $ref: '#/definitions/DefaultNs.Address'
+      - title: WorkAddress
+        type: object
+        properties:
+          CountryOrRegion:
+            $ref: '#/definitions/DefaultNs.CountryOrRegion'
+    example:
+      Id: integer
+      City:
+        '@odata.type': DefaultNs.City
+      CountryOrRegion:
+        '@odata.type': DefaultNs.CountryOrRegion
+  odata.error:
+    required:
+      - error
+    type: object
+    properties:
+      error:
+        $ref: '#/definitions/odata.error.main'
+  odata.error.main:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+      details:
+        type: array
+        items:
+          $ref: '#/definitions/odata.error.detail'
+      innererror:
+        description: The structure of this object is service-specific
+        type: object
+  odata.error.detail:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+parameters:
+  top:
+    in: query
+    name: $top
+    description: Show only the first n items
+    type: integer
+    minimum: 0
+  skip:
+    in: query
+    name: $skip
+    description: Skip the first n items
+    type: integer
+    minimum: 0
+  count:
+    in: query
+    name: $count
+    description: Include count of items
+    type: boolean
+  filter:
+    in: query
+    name: $filter
+    description: Filter items by property values
+    type: string
+  search:
+    in: query
+    name: $search
+    description: Search items by search phrases
+    type: string
+responses:
+  error:
+    description: error
+    schema:
+      $ref: '#/definitions/odata.error'
+tags:
+  - name: City.City
+    x-ms-docs-toc-type: page
+  - name: CountryOrRegion.CountryOrRegion
+    x-ms-docs-toc-type: page
+  - name: Me.Person
+    x-ms-docs-toc-type: page
+  - name: People.Person
+    x-ms-docs-toc-type: page

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -1,0 +1,114 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "OData Service for namespace ",
+    "description": "This OData service is located at http://localhost",
+    "version": "1.0.1"
+  },
+  "host": "localhost",
+  "schemes": [
+    "http"
+  ],
+  "paths": { },
+  "definitions": {
+    "odata.error": {
+      "required": [
+        "error"
+      ],
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/odata.error.main"
+        }
+      }
+    },
+    "odata.error.main": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/odata.error.detail"
+          }
+        },
+        "innererror": {
+          "description": "The structure of this object is service-specific",
+          "type": "object"
+        }
+      }
+    },
+    "odata.error.detail": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "top": {
+      "in": "query",
+      "name": "$top",
+      "description": "Show only the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "skip": {
+      "in": "query",
+      "name": "$skip",
+      "description": "Skip the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "count": {
+      "in": "query",
+      "name": "$count",
+      "description": "Include count of items",
+      "type": "boolean"
+    },
+    "filter": {
+      "in": "query",
+      "name": "$filter",
+      "description": "Filter items by property values",
+      "type": "string"
+    },
+    "search": {
+      "in": "query",
+      "name": "$search",
+      "description": "Search items by search phrases",
+      "type": "string"
+    }
+  },
+  "responses": {
+    "error": {
+      "description": "error",
+      "schema": {
+        "$ref": "#/definitions/odata.error"
+      }
+    }
+  }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -1,0 +1,81 @@
+﻿swagger: '2.0'
+info:
+  title: 'OData Service for namespace '
+  description: This OData service is located at http://localhost
+  version: 1.0.1
+host: localhost
+schemes:
+  - http
+paths: { }
+definitions:
+  odata.error:
+    required:
+      - error
+    type: object
+    properties:
+      error:
+        $ref: '#/definitions/odata.error.main'
+  odata.error.main:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+      details:
+        type: array
+        items:
+          $ref: '#/definitions/odata.error.detail'
+      innererror:
+        description: The structure of this object is service-specific
+        type: object
+  odata.error.detail:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+parameters:
+  top:
+    in: query
+    name: $top
+    description: Show only the first n items
+    type: integer
+    minimum: 0
+  skip:
+    in: query
+    name: $skip
+    description: Skip the first n items
+    type: integer
+    minimum: 0
+  count:
+    in: query
+    name: $count
+    description: Include count of items
+    type: boolean
+  filter:
+    in: query
+    name: $filter
+    description: Filter items by property values
+    type: string
+  search:
+    in: query
+    name: $search
+    description: Search items by search phrases
+    type: string
+responses:
+  error:
+    description: error
+    schema:
+      $ref: '#/definitions/odata.error'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -1,0 +1,4239 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "OData Service for namespace Default",
+    "description": "This OData service is located at http://localhost",
+    "version": "1.0.1"
+  },
+  "host": "localhost",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/Categories": {
+      "get": {
+        "tags": [
+          "Categories.CategoryDto"
+        ],
+        "summary": "Get entities from Categories",
+        "operationId": "Categories.CategoryDto.ListCategoryDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Name",
+                "Name desc",
+                "Description",
+                "Description desc",
+                "CreationDate",
+                "CreationDate desc",
+                "ModificationDate",
+                "ModificationDate desc",
+                "DomainId",
+                "DomainId desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "CreationDate",
+                "ModificationDate",
+                "DomainId"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of CategoryDto",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Siterra.Documents.App.DTO.CategoryDto"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Categories.CategoryDto"
+        ],
+        "summary": "Add new entity to Categories",
+        "operationId": "Categories.CategoryDto.CreateCategoryDto",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.CategoryDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.CategoryDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Categories({Id})": {
+      "get": {
+        "tags": [
+          "Categories.CategoryDto"
+        ],
+        "summary": "Get entity from Categories by key",
+        "operationId": "Categories.CategoryDto.GetCategoryDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "CategoryDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "CreationDate",
+                "ModificationDate",
+                "DomainId"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.CategoryDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Categories.CategoryDto"
+        ],
+        "summary": "Update entity in Categories",
+        "operationId": "Categories.CategoryDto.UpdateCategoryDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "CategoryDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.CategoryDto"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Categories.CategoryDto"
+        ],
+        "summary": "Delete entity from Categories",
+        "operationId": "Categories.CategoryDto.DeleteCategoryDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "CategoryDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Documents": {
+      "get": {
+        "tags": [
+          "Documents.DocumentDto"
+        ],
+        "summary": "Get entities from Documents",
+        "operationId": "Documents.DocumentDto.ListDocumentDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Name",
+                "Name desc",
+                "Description",
+                "Description desc",
+                "Filename",
+                "Filename desc",
+                "NumberOfRevisions",
+                "NumberOfRevisions desc",
+                "Suffix",
+                "Suffix desc",
+                "DomainId",
+                "DomainId desc",
+                "ModificationDate",
+                "ModificationDate desc",
+                "ModifiedBy",
+                "ModifiedBy desc",
+                "Tags",
+                "Tags desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "Filename",
+                "NumberOfRevisions",
+                "Suffix",
+                "DomainId",
+                "ModificationDate",
+                "ModifiedBy",
+                "Tags",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of DocumentDto",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Documents.DocumentDto"
+        ],
+        "summary": "Add new entity to Documents",
+        "operationId": "Documents.DocumentDto.CreateDocumentDto",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Documents({Id})": {
+      "get": {
+        "tags": [
+          "Documents.DocumentDto"
+        ],
+        "summary": "Get entity from Documents by key",
+        "operationId": "Documents.DocumentDto.GetDocumentDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "Filename",
+                "NumberOfRevisions",
+                "Suffix",
+                "DomainId",
+                "ModificationDate",
+                "ModifiedBy",
+                "Tags",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Documents.DocumentDto"
+        ],
+        "summary": "Update entity in Documents",
+        "operationId": "Documents.DocumentDto.UpdateDocumentDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Documents.DocumentDto"
+        ],
+        "summary": "Delete entity from Documents",
+        "operationId": "Documents.DocumentDto.DeleteDocumentDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Documents({Id})/Default.Upload": {
+      "post": {
+        "tags": [
+          "Documents.Actions"
+        ],
+        "summary": "Invoke action Upload",
+        "operationId": "Documents.Upload",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/Documents({Id})/Revisions": {
+      "get": {
+        "tags": [
+          "Documents.RevisionDto"
+        ],
+        "summary": "Get Revisions from Documents",
+        "operationId": "Documents.ListRevisions",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Number",
+                "Number desc",
+                "DocumentId",
+                "DocumentId desc",
+                "DocumentName",
+                "DocumentName desc",
+                "DocumentDescription",
+                "DocumentDescription desc",
+                "CreationDate",
+                "CreationDate desc",
+                "CreatedBy",
+                "CreatedBy desc",
+                "IsReviewed",
+                "IsReviewed desc",
+                "ReviewedBy",
+                "ReviewedBy desc",
+                "ReviewedDate",
+                "ReviewedDate desc",
+                "IsApproved",
+                "IsApproved desc",
+                "ApprovedBy",
+                "ApprovedBy desc",
+                "ApprovedDate",
+                "ApprovedDate desc",
+                "IsRejected",
+                "IsRejected desc",
+                "RejectedBy",
+                "RejectedBy desc",
+                "RejectedDate",
+                "RejectedDate desc",
+                "DomainId",
+                "DomainId desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Number",
+                "DocumentId",
+                "DocumentName",
+                "DocumentDescription",
+                "CreationDate",
+                "CreatedBy",
+                "IsReviewed",
+                "ReviewedBy",
+                "ReviewedDate",
+                "IsApproved",
+                "ApprovedBy",
+                "ApprovedDate",
+                "IsRejected",
+                "RejectedBy",
+                "RejectedDate",
+                "DomainId",
+                "Document"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Documents({Id})/Revisions({Id})": {
+      "get": {
+        "tags": [
+          "Documents.RevisionDto"
+        ],
+        "summary": "Get Revisions from Documents",
+        "operationId": "Documents.GetRevisions",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Number",
+                "DocumentId",
+                "DocumentName",
+                "DocumentDescription",
+                "CreationDate",
+                "CreatedBy",
+                "IsReviewed",
+                "ReviewedBy",
+                "ReviewedDate",
+                "IsApproved",
+                "ApprovedBy",
+                "ApprovedDate",
+                "IsRejected",
+                "RejectedBy",
+                "RejectedDate",
+                "DomainId",
+                "Document"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Libraries": {
+      "get": {
+        "tags": [
+          "Libraries.LibraryDto"
+        ],
+        "summary": "Get entities from Libraries",
+        "operationId": "Libraries.LibraryDto.ListLibraryDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Name",
+                "Name desc",
+                "Number",
+                "Number desc",
+                "Description",
+                "Description desc",
+                "LibraryTemplateId",
+                "LibraryTemplateId desc",
+                "ParentTypeId",
+                "ParentTypeId desc",
+                "ParentId",
+                "ParentId desc",
+                "AllowMultiple",
+                "AllowMultiple desc",
+                "AutoCreate",
+                "AutoCreate desc",
+                "TypeId",
+                "TypeId desc",
+                "DomainId",
+                "DomainId desc",
+                "CreatedBy",
+                "CreatedBy desc",
+                "CreationDate",
+                "CreationDate desc",
+                "ModifiedBy",
+                "ModifiedBy desc",
+                "ModificationDate",
+                "ModificationDate desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Number",
+                "Description",
+                "LibraryTemplateId",
+                "ParentTypeId",
+                "ParentId",
+                "AllowMultiple",
+                "AutoCreate",
+                "TypeId",
+                "DomainId",
+                "CreatedBy",
+                "CreationDate",
+                "ModifiedBy",
+                "ModificationDate",
+                "Documents"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Documents"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of LibraryDto",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Siterra.Documents.App.DTO.LibraryDto"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Libraries.LibraryDto"
+        ],
+        "summary": "Add new entity to Libraries",
+        "operationId": "Libraries.LibraryDto.CreateLibraryDto",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.LibraryDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.LibraryDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Libraries({Id})": {
+      "get": {
+        "tags": [
+          "Libraries.LibraryDto"
+        ],
+        "summary": "Get entity from Libraries by key",
+        "operationId": "Libraries.LibraryDto.GetLibraryDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Number",
+                "Description",
+                "LibraryTemplateId",
+                "ParentTypeId",
+                "ParentId",
+                "AllowMultiple",
+                "AutoCreate",
+                "TypeId",
+                "DomainId",
+                "CreatedBy",
+                "CreationDate",
+                "ModifiedBy",
+                "ModificationDate",
+                "Documents"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Documents"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.LibraryDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Libraries.LibraryDto"
+        ],
+        "summary": "Update entity in Libraries",
+        "operationId": "Libraries.LibraryDto.UpdateLibraryDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.LibraryDto"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Libraries.LibraryDto"
+        ],
+        "summary": "Delete entity from Libraries",
+        "operationId": "Libraries.LibraryDto.DeleteLibraryDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Libraries({Id})/Documents": {
+      "get": {
+        "tags": [
+          "Libraries.DocumentDto"
+        ],
+        "summary": "Get Documents from Libraries",
+        "operationId": "Libraries.ListDocuments",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Name",
+                "Name desc",
+                "Description",
+                "Description desc",
+                "Filename",
+                "Filename desc",
+                "NumberOfRevisions",
+                "NumberOfRevisions desc",
+                "Suffix",
+                "Suffix desc",
+                "DomainId",
+                "DomainId desc",
+                "ModificationDate",
+                "ModificationDate desc",
+                "ModifiedBy",
+                "ModifiedBy desc",
+                "Tags",
+                "Tags desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "Filename",
+                "NumberOfRevisions",
+                "Suffix",
+                "DomainId",
+                "ModificationDate",
+                "ModifiedBy",
+                "Tags",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Libraries({Id})/Documents({Id})": {
+      "get": {
+        "tags": [
+          "Libraries.DocumentDto"
+        ],
+        "summary": "Get Documents from Libraries",
+        "operationId": "Libraries.GetDocuments",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "Filename",
+                "NumberOfRevisions",
+                "Suffix",
+                "DomainId",
+                "ModificationDate",
+                "ModifiedBy",
+                "Tags",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Revisions": {
+      "get": {
+        "tags": [
+          "Revisions.RevisionDto"
+        ],
+        "summary": "Get entities from Revisions",
+        "operationId": "Revisions.RevisionDto.ListRevisionDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Number",
+                "Number desc",
+                "DocumentId",
+                "DocumentId desc",
+                "DocumentName",
+                "DocumentName desc",
+                "DocumentDescription",
+                "DocumentDescription desc",
+                "CreationDate",
+                "CreationDate desc",
+                "CreatedBy",
+                "CreatedBy desc",
+                "IsReviewed",
+                "IsReviewed desc",
+                "ReviewedBy",
+                "ReviewedBy desc",
+                "ReviewedDate",
+                "ReviewedDate desc",
+                "IsApproved",
+                "IsApproved desc",
+                "ApprovedBy",
+                "ApprovedBy desc",
+                "ApprovedDate",
+                "ApprovedDate desc",
+                "IsRejected",
+                "IsRejected desc",
+                "RejectedBy",
+                "RejectedBy desc",
+                "RejectedDate",
+                "RejectedDate desc",
+                "DomainId",
+                "DomainId desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Number",
+                "DocumentId",
+                "DocumentName",
+                "DocumentDescription",
+                "CreationDate",
+                "CreatedBy",
+                "IsReviewed",
+                "ReviewedBy",
+                "ReviewedDate",
+                "IsApproved",
+                "ApprovedBy",
+                "ApprovedDate",
+                "IsRejected",
+                "RejectedBy",
+                "RejectedDate",
+                "DomainId",
+                "Document"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of RevisionDto",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Revisions.RevisionDto"
+        ],
+        "summary": "Add new entity to Revisions",
+        "operationId": "Revisions.RevisionDto.CreateRevisionDto",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Revisions({Id})": {
+      "get": {
+        "tags": [
+          "Revisions.RevisionDto"
+        ],
+        "summary": "Get entity from Revisions by key",
+        "operationId": "Revisions.RevisionDto.GetRevisionDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Number",
+                "DocumentId",
+                "DocumentName",
+                "DocumentDescription",
+                "CreationDate",
+                "CreatedBy",
+                "IsReviewed",
+                "ReviewedBy",
+                "ReviewedDate",
+                "IsApproved",
+                "ApprovedBy",
+                "ApprovedDate",
+                "IsRejected",
+                "RejectedBy",
+                "RejectedDate",
+                "DomainId",
+                "Document"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Revisions.RevisionDto"
+        ],
+        "summary": "Update entity in Revisions",
+        "operationId": "Revisions.RevisionDto.UpdateRevisionDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Revisions.RevisionDto"
+        ],
+        "summary": "Delete entity from Revisions",
+        "operationId": "Revisions.RevisionDto.DeleteRevisionDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Revisions({Id})/Document": {
+      "get": {
+        "tags": [
+          "Revisions.Document"
+        ],
+        "summary": "Get Document from Revisions",
+        "operationId": "Revisions.GetDocument",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "StatusId",
+                "TypeId",
+                "Keywords",
+                "CreationDate",
+                "CreatedBy",
+                "ModificationDate",
+                "ModifiedBy",
+                "DomainId",
+                "LibraryId",
+                "OwnerUserId",
+                "StatusDate",
+                "LastRevisionId",
+                "CheckoutDate",
+                "CheckoutPath",
+                "CheckoutUserId",
+                "Number",
+                "OriginalDate",
+                "FileSized",
+                "FileClientPath",
+                "LastRevisionFileId",
+                "IsDeleted",
+                "IsNa",
+                "IsRejected",
+                "IsReviewed",
+                "NaDescription",
+                "NaReason",
+                "RejectedDescription",
+                "RejectedReason",
+                "ReviewDescription",
+                "SourceDocumentId",
+                "ScraperMapId",
+                "LastDownloadedDate",
+                "SmsId",
+                "IsApprovedOld",
+                "Suffix",
+                "ScrapeResultId",
+                "IsApproved",
+                "CategoryId",
+                "SectionId",
+                "VersionCount",
+                "LastFileName",
+                "DocumentClasses",
+                "Tags",
+                "Library",
+                "LastRevisionFile",
+                "SourceDocument",
+                "SourceDocumentChildren",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Library",
+                "LastRevisionFile",
+                "SourceDocument",
+                "SourceDocumentChildren",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Tasks": {
+      "get": {
+        "tags": [
+          "Tasks.DocumentDto"
+        ],
+        "summary": "Get entities from Tasks",
+        "operationId": "Tasks.DocumentDto.ListDocumentDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Name",
+                "Name desc",
+                "Description",
+                "Description desc",
+                "Filename",
+                "Filename desc",
+                "NumberOfRevisions",
+                "NumberOfRevisions desc",
+                "Suffix",
+                "Suffix desc",
+                "DomainId",
+                "DomainId desc",
+                "ModificationDate",
+                "ModificationDate desc",
+                "ModifiedBy",
+                "ModifiedBy desc",
+                "Tags",
+                "Tags desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "Filename",
+                "NumberOfRevisions",
+                "Suffix",
+                "DomainId",
+                "ModificationDate",
+                "ModifiedBy",
+                "Tags",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of DocumentDto",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Tasks.DocumentDto"
+        ],
+        "summary": "Add new entity to Tasks",
+        "operationId": "Tasks.DocumentDto.CreateDocumentDto",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Tasks({Id})": {
+      "get": {
+        "tags": [
+          "Tasks.DocumentDto"
+        ],
+        "summary": "Get entity from Tasks by key",
+        "operationId": "Tasks.DocumentDto.GetDocumentDto",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Name",
+                "Description",
+                "Filename",
+                "NumberOfRevisions",
+                "Suffix",
+                "DomainId",
+                "ModificationDate",
+                "ModifiedBy",
+                "Tags",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Revisions"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Tasks.DocumentDto"
+        ],
+        "summary": "Update entity in Tasks",
+        "operationId": "Tasks.DocumentDto.UpdateDocumentDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Tasks.DocumentDto"
+        ],
+        "summary": "Delete entity from Tasks",
+        "operationId": "Tasks.DocumentDto.DeleteDocumentDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Tasks({Id})/Default.Upload": {
+      "post": {
+        "tags": [
+          "Tasks.Actions"
+        ],
+        "summary": "Invoke action Upload",
+        "operationId": "Tasks.Upload",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/Tasks({Id})/Revisions": {
+      "get": {
+        "tags": [
+          "Tasks.RevisionDto"
+        ],
+        "summary": "Get Revisions from Tasks",
+        "operationId": "Tasks.ListRevisions",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc",
+                "Number",
+                "Number desc",
+                "DocumentId",
+                "DocumentId desc",
+                "DocumentName",
+                "DocumentName desc",
+                "DocumentDescription",
+                "DocumentDescription desc",
+                "CreationDate",
+                "CreationDate desc",
+                "CreatedBy",
+                "CreatedBy desc",
+                "IsReviewed",
+                "IsReviewed desc",
+                "ReviewedBy",
+                "ReviewedBy desc",
+                "ReviewedDate",
+                "ReviewedDate desc",
+                "IsApproved",
+                "IsApproved desc",
+                "ApprovedBy",
+                "ApprovedBy desc",
+                "ApprovedDate",
+                "ApprovedDate desc",
+                "IsRejected",
+                "IsRejected desc",
+                "RejectedBy",
+                "RejectedBy desc",
+                "RejectedDate",
+                "RejectedDate desc",
+                "DomainId",
+                "DomainId desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Number",
+                "DocumentId",
+                "DocumentName",
+                "DocumentDescription",
+                "CreationDate",
+                "CreatedBy",
+                "IsReviewed",
+                "ReviewedBy",
+                "ReviewedDate",
+                "IsApproved",
+                "ApprovedBy",
+                "ApprovedDate",
+                "IsRejected",
+                "RejectedBy",
+                "RejectedDate",
+                "DomainId",
+                "Document"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Tasks({Id})/Revisions({Id})": {
+      "get": {
+        "tags": [
+          "Tasks.RevisionDto"
+        ],
+        "summary": "Get Revisions from Tasks",
+        "operationId": "Tasks.GetRevisions",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Number",
+                "DocumentId",
+                "DocumentName",
+                "DocumentDescription",
+                "CreationDate",
+                "CreatedBy",
+                "IsReviewed",
+                "ReviewedBy",
+                "ReviewedDate",
+                "IsApproved",
+                "ApprovedBy",
+                "ApprovedDate",
+                "IsRejected",
+                "RejectedBy",
+                "RejectedDate",
+                "DomainId",
+                "Document"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    }
+  },
+  "definitions": {
+    "Siterra.Documents.App.DTO.DocumentDto": {
+      "title": "DocumentDto",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Filename": {
+          "type": "string"
+        },
+        "NumberOfRevisions": {
+          "type": "string"
+        },
+        "Suffix": {
+          "type": "string"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+          }
+        },
+        "Revisions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.App.DTO.RevisionDto"
+          }
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Name": "string",
+        "Description": "string",
+        "Filename": "string",
+        "NumberOfRevisions": "string",
+        "Suffix": "string",
+        "DomainId": "integer",
+        "ModificationDate": "string (timestamp)",
+        "ModifiedBy": "integer",
+        "Tags": [
+          {
+            "@odata.type": "Siterra.Documents.App.DTO.DocumentTagRelDto"
+          }
+        ],
+        "Revisions": [
+          {
+            "@odata.type": "Siterra.Documents.App.DTO.RevisionDto"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.App.DTO.LibraryDto": {
+      "title": "LibraryDto",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Number": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "LibraryTemplateId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ParentTypeId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ParentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "AllowMultiple": {
+          "type": "boolean"
+        },
+        "AutoCreate": {
+          "type": "boolean"
+        },
+        "TypeId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "Documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentDto"
+          }
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Name": "string",
+        "Number": "string",
+        "Description": "string",
+        "LibraryTemplateId": "integer",
+        "ParentTypeId": "integer",
+        "ParentId": "integer",
+        "AllowMultiple": true,
+        "AutoCreate": true,
+        "TypeId": "integer",
+        "DomainId": "integer",
+        "CreatedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModifiedBy": "integer",
+        "ModificationDate": "string (timestamp)",
+        "Documents": [
+          {
+            "@odata.type": "Siterra.Documents.App.DTO.DocumentDto"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.App.DTO.RevisionDto": {
+      "title": "RevisionDto",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Number": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DocumentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DocumentName": {
+          "type": "string"
+        },
+        "DocumentDescription": {
+          "type": "string"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsReviewed": {
+          "type": "boolean"
+        },
+        "ReviewedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ReviewedDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "IsApproved": {
+          "type": "boolean"
+        },
+        "ApprovedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ApprovedDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "IsRejected": {
+          "type": "boolean"
+        },
+        "RejectedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "RejectedDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Document": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Number": "integer",
+        "DocumentId": "integer",
+        "DocumentName": "string",
+        "DocumentDescription": "string",
+        "CreationDate": "string (timestamp)",
+        "CreatedBy": "integer",
+        "IsReviewed": true,
+        "ReviewedBy": "integer",
+        "ReviewedDate": "string (timestamp)",
+        "IsApproved": true,
+        "ApprovedBy": "integer",
+        "ApprovedDate": "string (timestamp)",
+        "IsRejected": true,
+        "RejectedBy": "integer",
+        "RejectedDate": "string (timestamp)",
+        "DomainId": "integer",
+        "Document": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        }
+      }
+    },
+    "Siterra.Documents.App.DTO.CategoryDto": {
+      "title": "CategoryDto",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Name": "string",
+        "Description": "string",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)",
+        "DomainId": "integer"
+      }
+    },
+    "Siterra.Documents.App.DTO.DocumentTagRelDto": {
+      "title": "DocumentTagRelDto",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      },
+      "example": {
+        "Name": "string"
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Document.Document": {
+      "title": "Document",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "StatusId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "TypeId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Keywords": {
+          "type": "string"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "LibraryId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "OwnerUserId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "StatusDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "LastRevisionId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CheckoutDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "CheckoutPath": {
+          "type": "string"
+        },
+        "CheckoutUserId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Number": {
+          "type": "string"
+        },
+        "OriginalDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "FileSized": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "FileClientPath": {
+          "type": "string"
+        },
+        "LastRevisionFileId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsDeleted": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsNa": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "IsRejected": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "IsReviewed": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "NaDescription": {
+          "type": "string"
+        },
+        "NaReason": {
+          "type": "string"
+        },
+        "RejectedDescription": {
+          "type": "string"
+        },
+        "RejectedReason": {
+          "type": "string"
+        },
+        "ReviewDescription": {
+          "type": "string"
+        },
+        "SourceDocumentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ScraperMapId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "LastDownloadedDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "SmsId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsApprovedOld": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Suffix": {
+          "type": "string"
+        },
+        "ScrapeResultId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsApproved": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "CategoryId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "SectionId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "VersionCount": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "LastFileName": {
+          "type": "string"
+        },
+        "DocumentClasses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+          }
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+          }
+        },
+        "Library": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library"
+        },
+        "LastRevisionFile": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.DocumentFile.DocumentFile"
+        },
+        "SourceDocument": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        },
+        "SourceDocumentChildren": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        },
+        "Revisions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Revision.Revision"
+          }
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Name": "string",
+        "Description": "string",
+        "StatusId": "integer",
+        "TypeId": "integer",
+        "Keywords": "string",
+        "CreationDate": "string (timestamp)",
+        "CreatedBy": "integer",
+        "ModificationDate": "string (timestamp)",
+        "ModifiedBy": "integer",
+        "DomainId": "integer",
+        "LibraryId": "integer",
+        "OwnerUserId": "integer",
+        "StatusDate": "string (timestamp)",
+        "LastRevisionId": "integer",
+        "CheckoutDate": "string (timestamp)",
+        "CheckoutPath": "string",
+        "CheckoutUserId": "integer",
+        "Number": "string",
+        "OriginalDate": "string (timestamp)",
+        "FileSized": "number",
+        "FileClientPath": "string",
+        "LastRevisionFileId": "integer",
+        "IsDeleted": "integer",
+        "IsNa": "number",
+        "IsRejected": "number",
+        "IsReviewed": "number",
+        "NaDescription": "string",
+        "NaReason": "string",
+        "RejectedDescription": "string",
+        "RejectedReason": "string",
+        "ReviewDescription": "string",
+        "SourceDocumentId": "integer",
+        "ScraperMapId": "integer",
+        "LastDownloadedDate": "string (timestamp)",
+        "SmsId": "integer",
+        "IsApprovedOld": "integer",
+        "Suffix": "string",
+        "ScrapeResultId": "integer",
+        "IsApproved": "number",
+        "CategoryId": "integer",
+        "SectionId": "integer",
+        "VersionCount": "integer",
+        "LastFileName": "string",
+        "DocumentClasses": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+          }
+        ],
+        "Tags": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+          }
+        ],
+        "Library": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.Library"
+        },
+        "LastRevisionFile": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.DocumentFile.DocumentFile"
+        },
+        "SourceDocument": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        },
+        "SourceDocumentChildren": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        ],
+        "Revisions": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Revision.Revision"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass": {
+      "title": "DocumentClass",
+      "type": "object",
+      "properties": {
+        "ClassInstance": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ClassId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DocumentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "IsPrimary": {
+          "type": "boolean"
+        },
+        "Document": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        }
+      },
+      "example": {
+        "ClassInstance": "integer",
+        "ClassId": "integer",
+        "DocumentId": "integer",
+        "CreatedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModifiedBy": "integer",
+        "ModificationDate": "string (timestamp)",
+        "IsPrimary": true,
+        "Document": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        }
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel": {
+      "title": "DocumentTagRel",
+      "type": "object",
+      "properties": {
+        "DocumentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "TagId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "Document": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        },
+        "Tag": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag"
+        }
+      },
+      "example": {
+        "DocumentId": "integer",
+        "TagId": "integer",
+        "DomainId": "integer",
+        "CreatedBy": "integer",
+        "ModifiedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)",
+        "Document": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        },
+        "Tag": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Tags.Tag"
+        }
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Library.Library": {
+      "title": "Library",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "ParentFolderId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Number": {
+          "type": "string"
+        },
+        "TypeId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "OwnerUserId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "TotalSize": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "FilesCounter": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "FoldersCounter": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ProjectId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "SearchRingId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "SiteId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "AssetId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "AllowMultiple": {
+          "type": "boolean"
+        },
+        "AutoCreate": {
+          "type": "boolean"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "IsTemplate": {
+          "type": "boolean"
+        },
+        "ProgramId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "SourceFolderId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "TemplateClassId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "TemplateSubType": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsHidden": {
+          "type": "boolean"
+        },
+        "IsDeleted": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "StatusId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "SmsId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ContractId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "VendorId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IncidentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "EventId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ClassInstance": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ClassId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "LibraryParent": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library"
+        },
+        "Type": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+        },
+        "SourceFolder": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library"
+        },
+        "Documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        },
+        "LibraryChildren": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library"
+          }
+        },
+        "SourceLibraryChildren": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library"
+          }
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "DomainId": "integer",
+        "Name": "string",
+        "ParentFolderId": "integer",
+        "Number": "string",
+        "TypeId": "integer",
+        "OwnerUserId": "integer",
+        "TotalSize": "number",
+        "FilesCounter": "integer",
+        "FoldersCounter": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)",
+        "ModifiedBy": "integer",
+        "CreatedBy": "integer",
+        "ProjectId": "integer",
+        "SearchRingId": "integer",
+        "SiteId": "integer",
+        "AssetId": "integer",
+        "AllowMultiple": true,
+        "AutoCreate": true,
+        "Description": "string",
+        "IsTemplate": true,
+        "ProgramId": "integer",
+        "SourceFolderId": "integer",
+        "TemplateClassId": "integer",
+        "TemplateSubType": "integer",
+        "IsHidden": true,
+        "IsDeleted": "integer",
+        "StatusId": "integer",
+        "SmsId": "integer",
+        "ContractId": "integer",
+        "VendorId": "integer",
+        "OrganizationUnitId": "integer",
+        "IncidentId": "integer",
+        "EventId": "integer",
+        "ClassInstance": "integer",
+        "ClassId": "integer",
+        "LibraryParent": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.Library"
+        },
+        "Type": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+        },
+        "SourceFolder": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.Library"
+        },
+        "Documents": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        ],
+        "LibraryChildren": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.Library"
+          }
+        ],
+        "SourceLibraryChildren": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.Library"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Library.LibraryType": {
+      "title": "LibraryType",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "XmlName": {
+          "type": "string"
+        },
+        "MasterId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Number": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ClassId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ParentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "HasChanged": {
+          "type": "boolean"
+        },
+        "MasterLibraryType": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+        },
+        "ParentLibraryTypes": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+        },
+        "MasterLibraryTypeChildren": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+          }
+        },
+        "ChildrenLibraryTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+          }
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Name": "string",
+        "ModifiedBy": "integer",
+        "CreatedBy": "integer",
+        "ModificationDate": "string (timestamp)",
+        "CreationDate": "string (timestamp)",
+        "DomainId": "integer",
+        "Description": "string",
+        "XmlName": "string",
+        "MasterId": "integer",
+        "Number": "integer",
+        "ClassId": "integer",
+        "ParentId": "integer",
+        "HasChanged": true,
+        "MasterLibraryType": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+        },
+        "ParentLibraryTypes": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+        },
+        "MasterLibraryTypeChildren": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+          }
+        ],
+        "ChildrenLibraryTypes": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Library.LibraryType"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.DocumentFile.DocumentFile": {
+      "title": "DocumentFile",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Path": {
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "Sized": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "ActualName": {
+          "type": "string"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "SourceClassId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ContentTypeId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ClientPath": {
+          "type": "string"
+        },
+        "IsSelfHosted": {
+          "format": "int16",
+          "maximum": 32767,
+          "minimum": -32768,
+          "type": "integer"
+        },
+        "SmsId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Latitude": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "Longitude": {
+          "format": "decimal",
+          "multipleOf": 1,
+          "type": "number"
+        },
+        "Documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Name": "string",
+        "Path": "string",
+        "ModifiedBy": "integer",
+        "CreatedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)",
+        "Sized": "number",
+        "ActualName": "string",
+        "DomainId": "integer",
+        "SourceClassId": "integer",
+        "ContentTypeId": "integer",
+        "ClientPath": "string",
+        "IsSelfHosted": "integer",
+        "SmsId": "integer",
+        "Latitude": "number",
+        "Longitude": "number",
+        "Documents": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Tags.Tag": {
+      "title": "Tag",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "DomainId": "integer",
+        "Name": "string",
+        "Description": "string",
+        "CreatedBy": "integer",
+        "ModifiedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)"
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Tags.UserDefinedTag": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag"
+        },
+        {
+          "title": "UserDefinedTag",
+          "type": "object",
+          "properties": {
+            "Documents": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+              }
+            }
+          }
+        }
+      ],
+      "example": {
+        "Id": "integer (identifier)",
+        "DomainId": "integer",
+        "Name": "string",
+        "Description": "string",
+        "CreatedBy": "integer",
+        "ModifiedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)",
+        "Documents": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Tags.Section": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag"
+        },
+        {
+          "title": "Section",
+          "type": "object",
+          "properties": {
+            "Documents": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+              }
+            }
+          }
+        }
+      ],
+      "example": {
+        "Id": "integer (identifier)",
+        "DomainId": "integer",
+        "Name": "string",
+        "Description": "string",
+        "CreatedBy": "integer",
+        "ModifiedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)",
+        "Documents": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Tags.Category": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag"
+        },
+        {
+          "title": "Category",
+          "type": "object",
+          "properties": {
+            "Documents": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+              }
+            }
+          }
+        }
+      ],
+      "example": {
+        "Id": "integer (identifier)",
+        "DomainId": "integer",
+        "Name": "string",
+        "Description": "string",
+        "CreatedBy": "integer",
+        "ModifiedBy": "integer",
+        "CreationDate": "string (timestamp)",
+        "ModificationDate": "string (timestamp)",
+        "Documents": [
+          {
+            "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+          }
+        ]
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Revision.Revision": {
+      "title": "Revision",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Number": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DocumentId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ModificationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "CreationDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ModifiedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "CreatedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "Remarks": {
+          "type": "string"
+        },
+        "FileId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DocumentOwnerContact": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "DocumentDescription": {
+          "type": "string"
+        },
+        "DocumentStatusDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "DocumentFolder": {
+          "type": "string"
+        },
+        "DocumentKeywords": {
+          "type": "string"
+        },
+        "DocumentStatus": {
+          "type": "string"
+        },
+        "DocumentType": {
+          "type": "string"
+        },
+        "DocumentName": {
+          "type": "string"
+        },
+        "DocumentNumber": {
+          "type": "string"
+        },
+        "DomainId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsDeleted": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsReviewed": {
+          "type": "boolean"
+        },
+        "ReviewDescription": {
+          "type": "string"
+        },
+        "ReviewedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsRejected": {
+          "type": "boolean"
+        },
+        "RejectedReason": {
+          "type": "string"
+        },
+        "RejectedDescription": {
+          "type": "string"
+        },
+        "RejectedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "IsApproved": {
+          "type": "boolean"
+        },
+        "ApprovedBy": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ReviewedDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "RejectedDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "ApprovedDate": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "Document": {
+          "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        }
+      },
+      "example": {
+        "Id": "integer (identifier)",
+        "Number": "integer",
+        "DocumentId": "integer",
+        "ModificationDate": "string (timestamp)",
+        "CreationDate": "string (timestamp)",
+        "ModifiedBy": "integer",
+        "CreatedBy": "integer",
+        "Remarks": "string",
+        "FileId": "integer",
+        "DocumentOwnerContact": "integer",
+        "DocumentDescription": "string",
+        "DocumentStatusDate": "string (timestamp)",
+        "DocumentFolder": "string",
+        "DocumentKeywords": "string",
+        "DocumentStatus": "string",
+        "DocumentType": "string",
+        "DocumentName": "string",
+        "DocumentNumber": "string",
+        "DomainId": "integer",
+        "IsDeleted": "integer",
+        "IsReviewed": true,
+        "ReviewDescription": "string",
+        "ReviewedBy": "integer",
+        "IsRejected": true,
+        "RejectedReason": "string",
+        "RejectedDescription": "string",
+        "RejectedBy": "integer",
+        "IsApproved": true,
+        "ApprovedBy": "integer",
+        "ReviewedDate": "string (timestamp)",
+        "RejectedDate": "string (timestamp)",
+        "ApprovedDate": "string (timestamp)",
+        "Document": {
+          "@odata.type": "Siterra.Documents.BusinessLogic.Entities.Document.Document"
+        }
+      }
+    },
+    "odata.error": {
+      "required": [
+        "error"
+      ],
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/odata.error.main"
+        }
+      }
+    },
+    "odata.error.main": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/odata.error.detail"
+          }
+        },
+        "innererror": {
+          "description": "The structure of this object is service-specific",
+          "type": "object"
+        }
+      }
+    },
+    "odata.error.detail": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "top": {
+      "in": "query",
+      "name": "$top",
+      "description": "Show only the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "skip": {
+      "in": "query",
+      "name": "$skip",
+      "description": "Skip the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "count": {
+      "in": "query",
+      "name": "$count",
+      "description": "Include count of items",
+      "type": "boolean"
+    },
+    "filter": {
+      "in": "query",
+      "name": "$filter",
+      "description": "Filter items by property values",
+      "type": "string"
+    },
+    "search": {
+      "in": "query",
+      "name": "$search",
+      "description": "Search items by search phrases",
+      "type": "string"
+    }
+  },
+  "responses": {
+    "error": {
+      "description": "error",
+      "schema": {
+        "$ref": "#/definitions/odata.error"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Categories.CategoryDto",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Documents.DocumentDto",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Documents.Actions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "Documents.RevisionDto",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Libraries.LibraryDto",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Libraries.DocumentDto",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Revisions.RevisionDto",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Revisions.Document",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Tasks.DocumentDto",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Tasks.Actions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "Tasks.RevisionDto",
+      "x-ms-docs-toc-type": "page"
+    }
+  ]
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -1,0 +1,3160 @@
+﻿swagger: '2.0'
+info:
+  title: OData Service for namespace Default
+  description: This OData service is located at http://localhost
+  version: 1.0.1
+host: localhost
+schemes:
+  - http
+paths:
+  /Categories:
+    get:
+      tags:
+        - Categories.CategoryDto
+      summary: Get entities from Categories
+      operationId: Categories.CategoryDto.ListCategoryDto
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Name
+              - Name desc
+              - Description
+              - Description desc
+              - CreationDate
+              - CreationDate desc
+              - ModificationDate
+              - ModificationDate desc
+              - DomainId
+              - DomainId desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - CreationDate
+              - ModificationDate
+              - DomainId
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of CategoryDto
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Siterra.Documents.App.DTO.CategoryDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Categories.CategoryDto
+      summary: Add new entity to Categories
+      operationId: Categories.CategoryDto.CreateCategoryDto
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.CategoryDto'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.CategoryDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Categories({Id})':
+    get:
+      tags:
+        - Categories.CategoryDto
+      summary: Get entity from Categories by key
+      operationId: Categories.CategoryDto.GetCategoryDto
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: CategoryDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - CreationDate
+              - ModificationDate
+              - DomainId
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.CategoryDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Categories.CategoryDto
+      summary: Update entity in Categories
+      operationId: Categories.CategoryDto.UpdateCategoryDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: CategoryDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.CategoryDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Categories.CategoryDto
+      summary: Delete entity from Categories
+      operationId: Categories.CategoryDto.DeleteCategoryDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: CategoryDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Documents:
+    get:
+      tags:
+        - Documents.DocumentDto
+      summary: Get entities from Documents
+      operationId: Documents.DocumentDto.ListDocumentDto
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Name
+              - Name desc
+              - Description
+              - Description desc
+              - Filename
+              - Filename desc
+              - NumberOfRevisions
+              - NumberOfRevisions desc
+              - Suffix
+              - Suffix desc
+              - DomainId
+              - DomainId desc
+              - ModificationDate
+              - ModificationDate desc
+              - ModifiedBy
+              - ModifiedBy desc
+              - Tags
+              - Tags desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - Filename
+              - NumberOfRevisions
+              - Suffix
+              - DomainId
+              - ModificationDate
+              - ModifiedBy
+              - Tags
+              - Revisions
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Revisions
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of DocumentDto
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Documents.DocumentDto
+      summary: Add new entity to Documents
+      operationId: Documents.DocumentDto.CreateDocumentDto
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Documents({Id})':
+    get:
+      tags:
+        - Documents.DocumentDto
+      summary: Get entity from Documents by key
+      operationId: Documents.DocumentDto.GetDocumentDto
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - Filename
+              - NumberOfRevisions
+              - Suffix
+              - DomainId
+              - ModificationDate
+              - ModifiedBy
+              - Tags
+              - Revisions
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Revisions
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Documents.DocumentDto
+      summary: Update entity in Documents
+      operationId: Documents.DocumentDto.UpdateDocumentDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Documents.DocumentDto
+      summary: Delete entity from Documents
+      operationId: Documents.DocumentDto.DeleteDocumentDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Documents({Id})/Default.Upload':
+    post:
+      tags:
+        - Documents.Actions
+      summary: Invoke action Upload
+      operationId: Documents.Upload
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  '/Documents({Id})/Revisions':
+    get:
+      tags:
+        - Documents.RevisionDto
+      summary: Get Revisions from Documents
+      operationId: Documents.ListRevisions
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Number
+              - Number desc
+              - DocumentId
+              - DocumentId desc
+              - DocumentName
+              - DocumentName desc
+              - DocumentDescription
+              - DocumentDescription desc
+              - CreationDate
+              - CreationDate desc
+              - CreatedBy
+              - CreatedBy desc
+              - IsReviewed
+              - IsReviewed desc
+              - ReviewedBy
+              - ReviewedBy desc
+              - ReviewedDate
+              - ReviewedDate desc
+              - IsApproved
+              - IsApproved desc
+              - ApprovedBy
+              - ApprovedBy desc
+              - ApprovedDate
+              - ApprovedDate desc
+              - IsRejected
+              - IsRejected desc
+              - RejectedBy
+              - RejectedBy desc
+              - RejectedDate
+              - RejectedDate desc
+              - DomainId
+              - DomainId desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Number
+              - DocumentId
+              - DocumentName
+              - DocumentDescription
+              - CreationDate
+              - CreatedBy
+              - IsReviewed
+              - ReviewedBy
+              - ReviewedDate
+              - IsApproved
+              - ApprovedBy
+              - ApprovedDate
+              - IsRejected
+              - RejectedBy
+              - RejectedDate
+              - DomainId
+              - Document
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Documents({Id})/Revisions({Id})':
+    get:
+      tags:
+        - Documents.RevisionDto
+      summary: Get Revisions from Documents
+      operationId: Documents.GetRevisions
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Number
+              - DocumentId
+              - DocumentName
+              - DocumentDescription
+              - CreationDate
+              - CreatedBy
+              - IsReviewed
+              - ReviewedBy
+              - ReviewedDate
+              - IsApproved
+              - ApprovedBy
+              - ApprovedDate
+              - IsRejected
+              - RejectedBy
+              - RejectedDate
+              - DomainId
+              - Document
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Libraries:
+    get:
+      tags:
+        - Libraries.LibraryDto
+      summary: Get entities from Libraries
+      operationId: Libraries.LibraryDto.ListLibraryDto
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Name
+              - Name desc
+              - Number
+              - Number desc
+              - Description
+              - Description desc
+              - LibraryTemplateId
+              - LibraryTemplateId desc
+              - ParentTypeId
+              - ParentTypeId desc
+              - ParentId
+              - ParentId desc
+              - AllowMultiple
+              - AllowMultiple desc
+              - AutoCreate
+              - AutoCreate desc
+              - TypeId
+              - TypeId desc
+              - DomainId
+              - DomainId desc
+              - CreatedBy
+              - CreatedBy desc
+              - CreationDate
+              - CreationDate desc
+              - ModifiedBy
+              - ModifiedBy desc
+              - ModificationDate
+              - ModificationDate desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Number
+              - Description
+              - LibraryTemplateId
+              - ParentTypeId
+              - ParentId
+              - AllowMultiple
+              - AutoCreate
+              - TypeId
+              - DomainId
+              - CreatedBy
+              - CreationDate
+              - ModifiedBy
+              - ModificationDate
+              - Documents
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Documents
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of LibraryDto
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Siterra.Documents.App.DTO.LibraryDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Libraries.LibraryDto
+      summary: Add new entity to Libraries
+      operationId: Libraries.LibraryDto.CreateLibraryDto
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.LibraryDto'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.LibraryDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Libraries({Id})':
+    get:
+      tags:
+        - Libraries.LibraryDto
+      summary: Get entity from Libraries by key
+      operationId: Libraries.LibraryDto.GetLibraryDto
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Number
+              - Description
+              - LibraryTemplateId
+              - ParentTypeId
+              - ParentId
+              - AllowMultiple
+              - AutoCreate
+              - TypeId
+              - DomainId
+              - CreatedBy
+              - CreationDate
+              - ModifiedBy
+              - ModificationDate
+              - Documents
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Documents
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.LibraryDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Libraries.LibraryDto
+      summary: Update entity in Libraries
+      operationId: Libraries.LibraryDto.UpdateLibraryDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.LibraryDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Libraries.LibraryDto
+      summary: Delete entity from Libraries
+      operationId: Libraries.LibraryDto.DeleteLibraryDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Libraries({Id})/Documents':
+    get:
+      tags:
+        - Libraries.DocumentDto
+      summary: Get Documents from Libraries
+      operationId: Libraries.ListDocuments
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Name
+              - Name desc
+              - Description
+              - Description desc
+              - Filename
+              - Filename desc
+              - NumberOfRevisions
+              - NumberOfRevisions desc
+              - Suffix
+              - Suffix desc
+              - DomainId
+              - DomainId desc
+              - ModificationDate
+              - ModificationDate desc
+              - ModifiedBy
+              - ModifiedBy desc
+              - Tags
+              - Tags desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - Filename
+              - NumberOfRevisions
+              - Suffix
+              - DomainId
+              - ModificationDate
+              - ModifiedBy
+              - Tags
+              - Revisions
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Revisions
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Libraries({Id})/Documents({Id})':
+    get:
+      tags:
+        - Libraries.DocumentDto
+      summary: Get Documents from Libraries
+      operationId: Libraries.GetDocuments
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - Filename
+              - NumberOfRevisions
+              - Suffix
+              - DomainId
+              - ModificationDate
+              - ModifiedBy
+              - Tags
+              - Revisions
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Revisions
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Revisions:
+    get:
+      tags:
+        - Revisions.RevisionDto
+      summary: Get entities from Revisions
+      operationId: Revisions.RevisionDto.ListRevisionDto
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Number
+              - Number desc
+              - DocumentId
+              - DocumentId desc
+              - DocumentName
+              - DocumentName desc
+              - DocumentDescription
+              - DocumentDescription desc
+              - CreationDate
+              - CreationDate desc
+              - CreatedBy
+              - CreatedBy desc
+              - IsReviewed
+              - IsReviewed desc
+              - ReviewedBy
+              - ReviewedBy desc
+              - ReviewedDate
+              - ReviewedDate desc
+              - IsApproved
+              - IsApproved desc
+              - ApprovedBy
+              - ApprovedBy desc
+              - ApprovedDate
+              - ApprovedDate desc
+              - IsRejected
+              - IsRejected desc
+              - RejectedBy
+              - RejectedBy desc
+              - RejectedDate
+              - RejectedDate desc
+              - DomainId
+              - DomainId desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Number
+              - DocumentId
+              - DocumentName
+              - DocumentDescription
+              - CreationDate
+              - CreatedBy
+              - IsReviewed
+              - ReviewedBy
+              - ReviewedDate
+              - IsApproved
+              - ApprovedBy
+              - ApprovedDate
+              - IsRejected
+              - RejectedBy
+              - RejectedDate
+              - DomainId
+              - Document
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of RevisionDto
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Revisions.RevisionDto
+      summary: Add new entity to Revisions
+      operationId: Revisions.RevisionDto.CreateRevisionDto
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Revisions({Id})':
+    get:
+      tags:
+        - Revisions.RevisionDto
+      summary: Get entity from Revisions by key
+      operationId: Revisions.RevisionDto.GetRevisionDto
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Number
+              - DocumentId
+              - DocumentName
+              - DocumentDescription
+              - CreationDate
+              - CreatedBy
+              - IsReviewed
+              - ReviewedBy
+              - ReviewedDate
+              - IsApproved
+              - ApprovedBy
+              - ApprovedDate
+              - IsRejected
+              - RejectedBy
+              - RejectedDate
+              - DomainId
+              - Document
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Revisions.RevisionDto
+      summary: Update entity in Revisions
+      operationId: Revisions.RevisionDto.UpdateRevisionDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Revisions.RevisionDto
+      summary: Delete entity from Revisions
+      operationId: Revisions.RevisionDto.DeleteRevisionDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Revisions({Id})/Document':
+    get:
+      tags:
+        - Revisions.Document
+      summary: Get Document from Revisions
+      operationId: Revisions.GetDocument
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - StatusId
+              - TypeId
+              - Keywords
+              - CreationDate
+              - CreatedBy
+              - ModificationDate
+              - ModifiedBy
+              - DomainId
+              - LibraryId
+              - OwnerUserId
+              - StatusDate
+              - LastRevisionId
+              - CheckoutDate
+              - CheckoutPath
+              - CheckoutUserId
+              - Number
+              - OriginalDate
+              - FileSized
+              - FileClientPath
+              - LastRevisionFileId
+              - IsDeleted
+              - IsNa
+              - IsRejected
+              - IsReviewed
+              - NaDescription
+              - NaReason
+              - RejectedDescription
+              - RejectedReason
+              - ReviewDescription
+              - SourceDocumentId
+              - ScraperMapId
+              - LastDownloadedDate
+              - SmsId
+              - IsApprovedOld
+              - Suffix
+              - ScrapeResultId
+              - IsApproved
+              - CategoryId
+              - SectionId
+              - VersionCount
+              - LastFileName
+              - DocumentClasses
+              - Tags
+              - Library
+              - LastRevisionFile
+              - SourceDocument
+              - SourceDocumentChildren
+              - Revisions
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Library
+              - LastRevisionFile
+              - SourceDocument
+              - SourceDocumentChildren
+              - Revisions
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Tasks:
+    get:
+      tags:
+        - Tasks.DocumentDto
+      summary: Get entities from Tasks
+      operationId: Tasks.DocumentDto.ListDocumentDto
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Name
+              - Name desc
+              - Description
+              - Description desc
+              - Filename
+              - Filename desc
+              - NumberOfRevisions
+              - NumberOfRevisions desc
+              - Suffix
+              - Suffix desc
+              - DomainId
+              - DomainId desc
+              - ModificationDate
+              - ModificationDate desc
+              - ModifiedBy
+              - ModifiedBy desc
+              - Tags
+              - Tags desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - Filename
+              - NumberOfRevisions
+              - Suffix
+              - DomainId
+              - ModificationDate
+              - ModifiedBy
+              - Tags
+              - Revisions
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Revisions
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of DocumentDto
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Tasks.DocumentDto
+      summary: Add new entity to Tasks
+      operationId: Tasks.DocumentDto.CreateDocumentDto
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Tasks({Id})':
+    get:
+      tags:
+        - Tasks.DocumentDto
+      summary: Get entity from Tasks by key
+      operationId: Tasks.DocumentDto.GetDocumentDto
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Name
+              - Description
+              - Filename
+              - NumberOfRevisions
+              - Suffix
+              - DomainId
+              - ModificationDate
+              - ModifiedBy
+              - Tags
+              - Revisions
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Revisions
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Tasks.DocumentDto
+      summary: Update entity in Tasks
+      operationId: Tasks.DocumentDto.UpdateDocumentDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Tasks.DocumentDto
+      summary: Delete entity from Tasks
+      operationId: Tasks.DocumentDto.DeleteDocumentDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Tasks({Id})/Default.Upload':
+    post:
+      tags:
+        - Tasks.Actions
+      summary: Invoke action Upload
+      operationId: Tasks.Upload
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  '/Tasks({Id})/Revisions':
+    get:
+      tags:
+        - Tasks.RevisionDto
+      summary: Get Revisions from Tasks
+      operationId: Tasks.ListRevisions
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+              - Number
+              - Number desc
+              - DocumentId
+              - DocumentId desc
+              - DocumentName
+              - DocumentName desc
+              - DocumentDescription
+              - DocumentDescription desc
+              - CreationDate
+              - CreationDate desc
+              - CreatedBy
+              - CreatedBy desc
+              - IsReviewed
+              - IsReviewed desc
+              - ReviewedBy
+              - ReviewedBy desc
+              - ReviewedDate
+              - ReviewedDate desc
+              - IsApproved
+              - IsApproved desc
+              - ApprovedBy
+              - ApprovedBy desc
+              - ApprovedDate
+              - ApprovedDate desc
+              - IsRejected
+              - IsRejected desc
+              - RejectedBy
+              - RejectedBy desc
+              - RejectedDate
+              - RejectedDate desc
+              - DomainId
+              - DomainId desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Number
+              - DocumentId
+              - DocumentName
+              - DocumentDescription
+              - CreationDate
+              - CreatedBy
+              - IsReviewed
+              - ReviewedBy
+              - ReviewedDate
+              - IsApproved
+              - ApprovedBy
+              - ApprovedDate
+              - IsRejected
+              - RejectedBy
+              - RejectedDate
+              - DomainId
+              - Document
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Tasks({Id})/Revisions({Id})':
+    get:
+      tags:
+        - Tasks.RevisionDto
+      summary: Get Revisions from Tasks
+      operationId: Tasks.GetRevisions
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: path
+          name: Id
+          description: 'key: Id'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - Number
+              - DocumentId
+              - DocumentName
+              - DocumentDescription
+              - CreationDate
+              - CreatedBy
+              - IsReviewed
+              - ReviewedBy
+              - ReviewedDate
+              - IsApproved
+              - ApprovedBy
+              - ApprovedDate
+              - IsRejected
+              - RejectedBy
+              - RejectedDate
+              - DomainId
+              - Document
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+definitions:
+  Siterra.Documents.App.DTO.DocumentDto:
+    title: DocumentDto
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      Description:
+        type: string
+      Filename:
+        type: string
+      NumberOfRevisions:
+        type: string
+      Suffix:
+        type: string
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Tags:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+      Revisions:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.App.DTO.RevisionDto'
+    example:
+      Id: integer (identifier)
+      Name: string
+      Description: string
+      Filename: string
+      NumberOfRevisions: string
+      Suffix: string
+      DomainId: integer
+      ModificationDate: string (timestamp)
+      ModifiedBy: integer
+      Tags:
+        - '@odata.type': Siterra.Documents.App.DTO.DocumentTagRelDto
+      Revisions:
+        - '@odata.type': Siterra.Documents.App.DTO.RevisionDto
+  Siterra.Documents.App.DTO.LibraryDto:
+    title: LibraryDto
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      Number:
+        type: string
+      Description:
+        type: string
+      LibraryTemplateId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ParentTypeId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ParentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      AllowMultiple:
+        type: boolean
+      AutoCreate:
+        type: boolean
+      TypeId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      Documents:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentDto'
+    example:
+      Id: integer (identifier)
+      Name: string
+      Number: string
+      Description: string
+      LibraryTemplateId: integer
+      ParentTypeId: integer
+      ParentId: integer
+      AllowMultiple: true
+      AutoCreate: true
+      TypeId: integer
+      DomainId: integer
+      CreatedBy: integer
+      CreationDate: string (timestamp)
+      ModifiedBy: integer
+      ModificationDate: string (timestamp)
+      Documents:
+        - '@odata.type': Siterra.Documents.App.DTO.DocumentDto
+  Siterra.Documents.App.DTO.RevisionDto:
+    title: RevisionDto
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Number:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DocumentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DocumentName:
+        type: string
+      DocumentDescription:
+        type: string
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsReviewed:
+        type: boolean
+      ReviewedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ReviewedDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      IsApproved:
+        type: boolean
+      ApprovedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ApprovedDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      IsRejected:
+        type: boolean
+      RejectedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      RejectedDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Document:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+    example:
+      Id: integer (identifier)
+      Number: integer
+      DocumentId: integer
+      DocumentName: string
+      DocumentDescription: string
+      CreationDate: string (timestamp)
+      CreatedBy: integer
+      IsReviewed: true
+      ReviewedBy: integer
+      ReviewedDate: string (timestamp)
+      IsApproved: true
+      ApprovedBy: integer
+      ApprovedDate: string (timestamp)
+      IsRejected: true
+      RejectedBy: integer
+      RejectedDate: string (timestamp)
+      DomainId: integer
+      Document:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+  Siterra.Documents.App.DTO.CategoryDto:
+    title: CategoryDto
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      Description:
+        type: string
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+    example:
+      Id: integer (identifier)
+      Name: string
+      Description: string
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+      DomainId: integer
+  Siterra.Documents.App.DTO.DocumentTagRelDto:
+    title: DocumentTagRelDto
+    type: object
+    properties:
+      Name:
+        type: string
+    example:
+      Name: string
+  Siterra.Documents.BusinessLogic.Entities.Document.Document:
+    title: Document
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      Description:
+        type: string
+      StatusId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      TypeId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Keywords:
+        type: string
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      LibraryId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      OwnerUserId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      StatusDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      LastRevisionId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CheckoutDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      CheckoutPath:
+        type: string
+      CheckoutUserId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Number:
+        type: string
+      OriginalDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      FileSized:
+        format: decimal
+        multipleOf: 1
+        type: number
+      FileClientPath:
+        type: string
+      LastRevisionFileId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsDeleted:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsNa:
+        format: decimal
+        multipleOf: 1
+        type: number
+      IsRejected:
+        format: decimal
+        multipleOf: 1
+        type: number
+      IsReviewed:
+        format: decimal
+        multipleOf: 1
+        type: number
+      NaDescription:
+        type: string
+      NaReason:
+        type: string
+      RejectedDescription:
+        type: string
+      RejectedReason:
+        type: string
+      ReviewDescription:
+        type: string
+      SourceDocumentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ScraperMapId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      LastDownloadedDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      SmsId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsApprovedOld:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Suffix:
+        type: string
+      ScrapeResultId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsApproved:
+        format: decimal
+        multipleOf: 1
+        type: number
+      CategoryId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      SectionId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      VersionCount:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      LastFileName:
+        type: string
+      DocumentClasses:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
+      Tags:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
+      Library:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library'
+      LastRevisionFile:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.DocumentFile.DocumentFile'
+      SourceDocument:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+      SourceDocumentChildren:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+      Revisions:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Revision.Revision'
+    example:
+      Id: integer (identifier)
+      Name: string
+      Description: string
+      StatusId: integer
+      TypeId: integer
+      Keywords: string
+      CreationDate: string (timestamp)
+      CreatedBy: integer
+      ModificationDate: string (timestamp)
+      ModifiedBy: integer
+      DomainId: integer
+      LibraryId: integer
+      OwnerUserId: integer
+      StatusDate: string (timestamp)
+      LastRevisionId: integer
+      CheckoutDate: string (timestamp)
+      CheckoutPath: string
+      CheckoutUserId: integer
+      Number: string
+      OriginalDate: string (timestamp)
+      FileSized: number
+      FileClientPath: string
+      LastRevisionFileId: integer
+      IsDeleted: integer
+      IsNa: number
+      IsRejected: number
+      IsReviewed: number
+      NaDescription: string
+      NaReason: string
+      RejectedDescription: string
+      RejectedReason: string
+      ReviewDescription: string
+      SourceDocumentId: integer
+      ScraperMapId: integer
+      LastDownloadedDate: string (timestamp)
+      SmsId: integer
+      IsApprovedOld: integer
+      Suffix: string
+      ScrapeResultId: integer
+      IsApproved: number
+      CategoryId: integer
+      SectionId: integer
+      VersionCount: integer
+      LastFileName: string
+      DocumentClasses:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass
+      Tags:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel
+      Library:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.Library
+      LastRevisionFile:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.DocumentFile.DocumentFile
+      SourceDocument:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+      SourceDocumentChildren:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+      Revisions:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Revision.Revision
+  Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass:
+    title: DocumentClass
+    type: object
+    properties:
+      ClassInstance:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ClassId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DocumentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      IsPrimary:
+        type: boolean
+      Document:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+    example:
+      ClassInstance: integer
+      ClassId: integer
+      DocumentId: integer
+      CreatedBy: integer
+      CreationDate: string (timestamp)
+      ModifiedBy: integer
+      ModificationDate: string (timestamp)
+      IsPrimary: true
+      Document:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+  Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel:
+    title: DocumentTagRel
+    type: object
+    properties:
+      DocumentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      TagId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      Document:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+      Tag:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag'
+    example:
+      DocumentId: integer
+      TagId: integer
+      DomainId: integer
+      CreatedBy: integer
+      ModifiedBy: integer
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+      Document:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+      Tag:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Tags.Tag
+  Siterra.Documents.BusinessLogic.Entities.Library.Library:
+    title: Library
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      ParentFolderId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Number:
+        type: string
+      TypeId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      OwnerUserId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      TotalSize:
+        format: decimal
+        multipleOf: 1
+        type: number
+      FilesCounter:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      FoldersCounter:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ProjectId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      SearchRingId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      SiteId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      AssetId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      AllowMultiple:
+        type: boolean
+      AutoCreate:
+        type: boolean
+      Description:
+        type: string
+      IsTemplate:
+        type: boolean
+      ProgramId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      SourceFolderId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      TemplateClassId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      TemplateSubType:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsHidden:
+        type: boolean
+      IsDeleted:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      StatusId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      SmsId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ContractId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      VendorId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      OrganizationUnitId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IncidentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      EventId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ClassInstance:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ClassId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      LibraryParent:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library'
+      Type:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType'
+      SourceFolder:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library'
+      Documents:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+      LibraryChildren:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library'
+      SourceLibraryChildren:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.Library'
+    example:
+      Id: integer (identifier)
+      DomainId: integer
+      Name: string
+      ParentFolderId: integer
+      Number: string
+      TypeId: integer
+      OwnerUserId: integer
+      TotalSize: number
+      FilesCounter: integer
+      FoldersCounter: integer
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+      ModifiedBy: integer
+      CreatedBy: integer
+      ProjectId: integer
+      SearchRingId: integer
+      SiteId: integer
+      AssetId: integer
+      AllowMultiple: true
+      AutoCreate: true
+      Description: string
+      IsTemplate: true
+      ProgramId: integer
+      SourceFolderId: integer
+      TemplateClassId: integer
+      TemplateSubType: integer
+      IsHidden: true
+      IsDeleted: integer
+      StatusId: integer
+      SmsId: integer
+      ContractId: integer
+      VendorId: integer
+      OrganizationUnitId: integer
+      IncidentId: integer
+      EventId: integer
+      ClassInstance: integer
+      ClassId: integer
+      LibraryParent:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.Library
+      Type:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.LibraryType
+      SourceFolder:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.Library
+      Documents:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+      LibraryChildren:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.Library
+      SourceLibraryChildren:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.Library
+  Siterra.Documents.BusinessLogic.Entities.Library.LibraryType:
+    title: LibraryType
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Description:
+        type: string
+      XmlName:
+        type: string
+      MasterId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Number:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ClassId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ParentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      HasChanged:
+        type: boolean
+      MasterLibraryType:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType'
+      ParentLibraryTypes:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType'
+      MasterLibraryTypeChildren:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType'
+      ChildrenLibraryTypes:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType'
+    example:
+      Id: integer (identifier)
+      Name: string
+      ModifiedBy: integer
+      CreatedBy: integer
+      ModificationDate: string (timestamp)
+      CreationDate: string (timestamp)
+      DomainId: integer
+      Description: string
+      XmlName: string
+      MasterId: integer
+      Number: integer
+      ClassId: integer
+      ParentId: integer
+      HasChanged: true
+      MasterLibraryType:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.LibraryType
+      ParentLibraryTypes:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.LibraryType
+      MasterLibraryTypeChildren:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.LibraryType
+      ChildrenLibraryTypes:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Library.LibraryType
+  Siterra.Documents.BusinessLogic.Entities.DocumentFile.DocumentFile:
+    title: DocumentFile
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      Path:
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      Sized:
+        format: decimal
+        multipleOf: 1
+        type: number
+      ActualName:
+        type: string
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      SourceClassId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ContentTypeId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ClientPath:
+        type: string
+      IsSelfHosted:
+        format: int16
+        maximum: 32767
+        minimum: -32768
+        type: integer
+      SmsId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Latitude:
+        format: decimal
+        multipleOf: 1
+        type: number
+      Longitude:
+        format: decimal
+        multipleOf: 1
+        type: number
+      Documents:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+    example:
+      Id: integer (identifier)
+      Name: string
+      Path: string
+      ModifiedBy: integer
+      CreatedBy: integer
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+      Sized: number
+      ActualName: string
+      DomainId: integer
+      SourceClassId: integer
+      ContentTypeId: integer
+      ClientPath: string
+      IsSelfHosted: integer
+      SmsId: integer
+      Latitude: number
+      Longitude: number
+      Documents:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+  Siterra.Documents.BusinessLogic.Entities.Tags.Tag:
+    title: Tag
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Name:
+        type: string
+      Description:
+        type: string
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+    example:
+      Id: integer (identifier)
+      DomainId: integer
+      Name: string
+      Description: string
+      CreatedBy: integer
+      ModifiedBy: integer
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+  Siterra.Documents.BusinessLogic.Entities.Tags.UserDefinedTag:
+    allOf:
+      - $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag'
+      - title: UserDefinedTag
+        type: object
+        properties:
+          Documents:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
+    example:
+      Id: integer (identifier)
+      DomainId: integer
+      Name: string
+      Description: string
+      CreatedBy: integer
+      ModifiedBy: integer
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+      Documents:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel
+  Siterra.Documents.BusinessLogic.Entities.Tags.Section:
+    allOf:
+      - $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag'
+      - title: Section
+        type: object
+        properties:
+          Documents:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+    example:
+      Id: integer (identifier)
+      DomainId: integer
+      Name: string
+      Description: string
+      CreatedBy: integer
+      ModifiedBy: integer
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+      Documents:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+  Siterra.Documents.BusinessLogic.Entities.Tags.Category:
+    allOf:
+      - $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Tags.Tag'
+      - title: Category
+        type: object
+        properties:
+          Documents:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+    example:
+      Id: integer (identifier)
+      DomainId: integer
+      Name: string
+      Description: string
+      CreatedBy: integer
+      ModifiedBy: integer
+      CreationDate: string (timestamp)
+      ModificationDate: string (timestamp)
+      Documents:
+        - '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+  Siterra.Documents.BusinessLogic.Entities.Revision.Revision:
+    title: Revision
+    type: object
+    properties:
+      Id:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Number:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DocumentId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ModificationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      CreationDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ModifiedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      CreatedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      Remarks:
+        type: string
+      FileId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DocumentOwnerContact:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      DocumentDescription:
+        type: string
+      DocumentStatusDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      DocumentFolder:
+        type: string
+      DocumentKeywords:
+        type: string
+      DocumentStatus:
+        type: string
+      DocumentType:
+        type: string
+      DocumentName:
+        type: string
+      DocumentNumber:
+        type: string
+      DomainId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsDeleted:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsReviewed:
+        type: boolean
+      ReviewDescription:
+        type: string
+      ReviewedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsRejected:
+        type: boolean
+      RejectedReason:
+        type: string
+      RejectedDescription:
+        type: string
+      RejectedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      IsApproved:
+        type: boolean
+      ApprovedBy:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ReviewedDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      RejectedDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      ApprovedDate:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      Document:
+        $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.Document'
+    example:
+      Id: integer (identifier)
+      Number: integer
+      DocumentId: integer
+      ModificationDate: string (timestamp)
+      CreationDate: string (timestamp)
+      ModifiedBy: integer
+      CreatedBy: integer
+      Remarks: string
+      FileId: integer
+      DocumentOwnerContact: integer
+      DocumentDescription: string
+      DocumentStatusDate: string (timestamp)
+      DocumentFolder: string
+      DocumentKeywords: string
+      DocumentStatus: string
+      DocumentType: string
+      DocumentName: string
+      DocumentNumber: string
+      DomainId: integer
+      IsDeleted: integer
+      IsReviewed: true
+      ReviewDescription: string
+      ReviewedBy: integer
+      IsRejected: true
+      RejectedReason: string
+      RejectedDescription: string
+      RejectedBy: integer
+      IsApproved: true
+      ApprovedBy: integer
+      ReviewedDate: string (timestamp)
+      RejectedDate: string (timestamp)
+      ApprovedDate: string (timestamp)
+      Document:
+        '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
+  odata.error:
+    required:
+      - error
+    type: object
+    properties:
+      error:
+        $ref: '#/definitions/odata.error.main'
+  odata.error.main:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+      details:
+        type: array
+        items:
+          $ref: '#/definitions/odata.error.detail'
+      innererror:
+        description: The structure of this object is service-specific
+        type: object
+  odata.error.detail:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+parameters:
+  top:
+    in: query
+    name: $top
+    description: Show only the first n items
+    type: integer
+    minimum: 0
+  skip:
+    in: query
+    name: $skip
+    description: Skip the first n items
+    type: integer
+    minimum: 0
+  count:
+    in: query
+    name: $count
+    description: Include count of items
+    type: boolean
+  filter:
+    in: query
+    name: $filter
+    description: Filter items by property values
+    type: string
+  search:
+    in: query
+    name: $search
+    description: Search items by search phrases
+    type: string
+responses:
+  error:
+    description: error
+    schema:
+      $ref: '#/definitions/odata.error'
+tags:
+  - name: Categories.CategoryDto
+    x-ms-docs-toc-type: page
+  - name: Documents.DocumentDto
+    x-ms-docs-toc-type: page
+  - name: Documents.Actions
+    x-ms-docs-toc-type: container
+  - name: Documents.RevisionDto
+    x-ms-docs-toc-type: page
+  - name: Libraries.LibraryDto
+    x-ms-docs-toc-type: page
+  - name: Libraries.DocumentDto
+    x-ms-docs-toc-type: page
+  - name: Revisions.RevisionDto
+    x-ms-docs-toc-type: page
+  - name: Revisions.Document
+    x-ms-docs-toc-type: page
+  - name: Tasks.DocumentDto
+    x-ms-docs-toc-type: page
+  - name: Tasks.Actions
+    x-ms-docs-toc-type: container
+  - name: Tasks.RevisionDto
+    x-ms-docs-toc-type: page

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1,0 +1,4406 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models",
+    "description": "This OData service is located at http://services.odata.org/TrippinRESTierService",
+    "version": "1.0.1"
+  },
+  "host": "services.odata.org",
+  "basePath": "/TrippinRESTierService",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/Airlines": {
+      "get": {
+        "tags": [
+          "Airlines.Airline"
+        ],
+        "summary": "Get entities from Airlines",
+        "operationId": "Airlines.Airline.ListAirline",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "AirlineCode",
+                "AirlineCode desc",
+                "Name",
+                "Name desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "AirlineCode",
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Airline",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Airlines.Airline"
+        ],
+        "summary": "Add new entity to Airlines",
+        "operationId": "Airlines.Airline.CreateAirline",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Airlines/{AirlineCode}": {
+      "get": {
+        "tags": [
+          "Airlines.Airline"
+        ],
+        "summary": "Get entity from Airlines by key",
+        "operationId": "Airlines.Airline.GetAirline",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AirlineCode",
+            "description": "key: AirlineCode",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airline"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "AirlineCode",
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Airlines.Airline"
+        ],
+        "summary": "Update entity in Airlines",
+        "operationId": "Airlines.Airline.UpdateAirline",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AirlineCode",
+            "description": "key: AirlineCode",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airline"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Airlines.Airline"
+        ],
+        "summary": "Delete entity from Airlines",
+        "operationId": "Airlines.Airline.DeleteAirline",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AirlineCode",
+            "description": "key: AirlineCode",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airline"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Airports": {
+      "get": {
+        "tags": [
+          "Airports.Airport"
+        ],
+        "summary": "Get entities from Airports",
+        "operationId": "Airports.Airport.ListAirport",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "Name desc",
+                "IcaoCode",
+                "IcaoCode desc",
+                "IataCode",
+                "IataCode desc",
+                "Location",
+                "Location desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "IcaoCode",
+                "IataCode",
+                "Location"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Airport",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Airports.Airport"
+        ],
+        "summary": "Add new entity to Airports",
+        "operationId": "Airports.Airport.CreateAirport",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Airports/{IcaoCode}": {
+      "get": {
+        "tags": [
+          "Airports.Airport"
+        ],
+        "summary": "Get entity from Airports by key",
+        "operationId": "Airports.Airport.GetAirport",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "IcaoCode",
+                "IataCode",
+                "Location"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Airports.Airport"
+        ],
+        "summary": "Update entity in Airports",
+        "operationId": "Airports.Airport.UpdateAirport",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Airports.Airport"
+        ],
+        "summary": "Delete entity from Airports",
+        "operationId": "Airports.Airport.DeleteAirport",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/GetNearestAirport(lat={lat},lon={lon})": {
+      "get": {
+        "tags": [
+          "Airports"
+        ],
+        "summary": "Invoke functionImport GetNearestAirport",
+        "operationId": "OperationImport.GetNearestAirport.6896b1324a4eff76ad9867a0",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "lat",
+            "required": true,
+            "format": "double"
+          },
+          {
+            "in": "path",
+            "name": "lon",
+            "required": true,
+            "format": "double"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "functionImport"
+      }
+    },
+    "/GetPersonWithMostFriends()": {
+      "get": {
+        "tags": [
+          "People"
+        ],
+        "summary": "Invoke functionImport GetPersonWithMostFriends",
+        "operationId": "OperationImport.GetPersonWithMostFriends.de8b4a5ab51ba6c8c254fe80",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "functionImport"
+      }
+    },
+    "/Me": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Me",
+        "operationId": "Me.Person.GetPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Me",
+        "operationId": "Me.Person.UpdatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/BestFriend": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get BestFriend from Me",
+        "operationId": "Me.GetBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Friends": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Friends from Me",
+        "operationId": "Me.ListFriends",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Friends/{UserName}": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Friends from Me",
+        "operationId": "Me.GetFriends",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function GetFavoriteAirline",
+        "operationId": "Me.GetFavoriteAirline.4520",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName={userName})": {
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function GetFriendsTrips",
+        "operationId": "Me.GetFriendsTrips.a13d",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip": {
+      "post": {
+        "tags": [
+          "Me.Actions"
+        ],
+        "summary": "Invoke action GetPeersForTrip",
+        "operationId": "Me.GetPeersForTrip",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Action parameters",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": -2147483648,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
+      "post": {
+        "tags": [
+          "Me.Actions"
+        ],
+        "summary": "Invoke action ShareTrip",
+        "operationId": "Me.ShareTrip",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Action parameters",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": -2147483648,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName={lastName})": {
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function UpdatePersonLastName",
+        "operationId": "Me.UpdatePersonLastName.a6a4",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "lastName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/Me/Trips": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get Trips from Me",
+        "operationId": "Me.ListTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Trips/{TripId}": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get Trips from Me",
+        "operationId": "Me.GetTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "Me.Trips.GetInvolvedPeople.2707",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/NewComePeople": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get entities from NewComePeople",
+        "operationId": "NewComePeople.Person.ListPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Add new entity to NewComePeople",
+        "operationId": "NewComePeople.Person.CreatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get entity from NewComePeople by key",
+        "operationId": "NewComePeople.Person.GetPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update entity in NewComePeople",
+        "operationId": "NewComePeople.Person.UpdatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete entity from NewComePeople",
+        "operationId": "NewComePeople.Person.DeletePerson",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get BestFriend from NewComePeople",
+        "operationId": "NewComePeople.GetBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Friends": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Friends from NewComePeople",
+        "operationId": "NewComePeople.ListFriends",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName}": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Friends from NewComePeople",
+        "operationId": "NewComePeople.GetFriends",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
+      "get": {
+        "tags": [
+          "NewComePeople.Functions"
+        ],
+        "summary": "Invoke function GetFavoriteAirline",
+        "operationId": "NewComePeople.GetFavoriteAirline.4520",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName={userName})": {
+      "get": {
+        "tags": [
+          "NewComePeople.Functions"
+        ],
+        "summary": "Invoke function GetFriendsTrips",
+        "operationId": "NewComePeople.GetFriendsTrips.a13d",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "userName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip": {
+      "post": {
+        "tags": [
+          "NewComePeople.Actions"
+        ],
+        "summary": "Invoke action GetPeersForTrip",
+        "operationId": "NewComePeople.GetPeersForTrip",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Action parameters",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": -2147483648,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
+      "post": {
+        "tags": [
+          "NewComePeople.Actions"
+        ],
+        "summary": "Invoke action ShareTrip",
+        "operationId": "NewComePeople.ShareTrip",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Action parameters",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": -2147483648,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName={lastName})": {
+      "get": {
+        "tags": [
+          "NewComePeople.Functions"
+        ],
+        "summary": "Invoke function UpdatePersonLastName",
+        "operationId": "NewComePeople.UpdatePersonLastName.a6a4",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "lastName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/NewComePeople/{UserName}/Trips": {
+      "get": {
+        "tags": [
+          "NewComePeople.Trip"
+        ],
+        "summary": "Get Trips from NewComePeople",
+        "operationId": "NewComePeople.ListTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Trips/{TripId}": {
+      "get": {
+        "tags": [
+          "NewComePeople.Trip"
+        ],
+        "summary": "Get Trips from NewComePeople",
+        "operationId": "NewComePeople.GetTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "get": {
+        "tags": [
+          "NewComePeople.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "NewComePeople.Trips.GetInvolvedPeople.2707",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/People": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get entities from People",
+        "operationId": "People.Person.ListPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Add new entity to People",
+        "operationId": "People.Person.CreatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New entity",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get entity from People by key",
+        "operationId": "People.Person.GetPerson",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update entity in People",
+        "operationId": "People.Person.UpdatePerson",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete entity from People",
+        "operationId": "People.Person.DeletePerson",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/BestFriend": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get BestFriend from People",
+        "operationId": "People.GetBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Friends": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Friends from People",
+        "operationId": "People.ListFriends",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Friends/{UserName}": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Friends from People",
+        "operationId": "People.GetFriends",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function GetFavoriteAirline",
+        "operationId": "People.GetFavoriteAirline.4520",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName={userName})": {
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function GetFriendsTrips",
+        "operationId": "People.GetFriendsTrips.a13d",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "userName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip": {
+      "post": {
+        "tags": [
+          "People.Actions"
+        ],
+        "summary": "Invoke action GetPeersForTrip",
+        "operationId": "People.GetPeersForTrip",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Action parameters",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": -2147483648,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
+      "post": {
+        "tags": [
+          "People.Actions"
+        ],
+        "summary": "Invoke action ShareTrip",
+        "operationId": "People.ShareTrip",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Action parameters",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": -2147483648,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName={lastName})": {
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function UpdatePersonLastName",
+        "operationId": "People.UpdatePersonLastName.a6a4",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "lastName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/People/{UserName}/Trips": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get Trips from People",
+        "operationId": "People.ListTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Trips/{TripId}": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get Trips from People",
+        "operationId": "People.GetTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "People.Trips.GetInvolvedPeople.2707",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "function"
+      }
+    },
+    "/ResetDataSource": {
+      "post": {
+        "tags": [
+          "ResetDataSource"
+        ],
+        "summary": "Invoke actionImport ResetDataSource",
+        "operationId": "OperationImport.ResetDataSource",
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "actionImport"
+      }
+    }
+  },
+  "definitions": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person": {
+      "title": "Person",
+      "type": "object",
+      "properties": {
+        "UserName": {
+          "type": "string"
+        },
+        "FirstName": {
+          "type": "string"
+        },
+        "LastName": {
+          "type": "string"
+        },
+        "MiddleName": {
+          "type": "string"
+        },
+        "Gender": {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
+        },
+        "Age": {
+          "format": "int64"
+        },
+        "Emails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressInfo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+          }
+        },
+        "HomeAddress": {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+        },
+        "FavoriteFeature": {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+        },
+        "Features": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+          }
+        },
+        "Friends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+          }
+        },
+        "BestFriend": {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+        },
+        "Trips": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+          }
+        }
+      },
+      "example": {
+        "UserName": "string (identifier)",
+        "FirstName": "string",
+        "LastName": "string",
+        "MiddleName": "string",
+        "Gender": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
+        },
+        "Age": "int64",
+        "Emails": [
+          "string"
+        ],
+        "AddressInfo": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+          }
+        ],
+        "HomeAddress": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+        },
+        "FavoriteFeature": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+        },
+        "Features": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+          }
+        ],
+        "Friends": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+          }
+        ],
+        "BestFriend": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+        },
+        "Trips": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+          }
+        ]
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline": {
+      "title": "Airline",
+      "type": "object",
+      "properties": {
+        "AirlineCode": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "example": {
+        "AirlineCode": "string (identifier)",
+        "Name": "string"
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport": {
+      "title": "Airport",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IcaoCode": {
+          "type": "string"
+        },
+        "IataCode": {
+          "type": "string"
+        },
+        "Location": {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation"
+        }
+      },
+      "example": {
+        "Name": "string",
+        "IcaoCode": "string (identifier)",
+        "IataCode": "string",
+        "Location": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation"
+        }
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location": {
+      "title": "Location",
+      "type": "object",
+      "properties": {
+        "Address": {
+          "type": "string"
+        },
+        "City": {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.City"
+        }
+      },
+      "example": {
+        "Address": "string",
+        "City": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.City"
+        }
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.City": {
+      "title": "City",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "CountryRegion": {
+          "type": "string"
+        },
+        "Region": {
+          "type": "string"
+        }
+      },
+      "example": {
+        "Name": "string",
+        "CountryRegion": "string",
+        "Region": "string"
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+        },
+        {
+          "title": "AirportLocation",
+          "type": "object",
+          "properties": {
+            "Loc": {
+              "$ref": "#/definitions/Edm.GeographyPoint"
+            }
+          }
+        }
+      ],
+      "example": {
+        "Address": "string",
+        "City": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.City"
+        },
+        "Loc": "Edm.GeographyPoint"
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+        },
+        {
+          "title": "EventLocation",
+          "type": "object",
+          "properties": {
+            "BuildingInfo": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "example": {
+        "Address": "string",
+        "City": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.City"
+        },
+        "BuildingInfo": "string"
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip": {
+      "title": "Trip",
+      "type": "object",
+      "properties": {
+        "TripId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ShareId": {
+          "format": "uuid",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Budget": {
+          "format": "float"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StartsAt": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "EndsAt": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "PlanItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem"
+          }
+        }
+      },
+      "example": {
+        "TripId": "integer (identifier)",
+        "ShareId": "string",
+        "Name": "string",
+        "Budget": "float",
+        "Description": "string",
+        "Tags": [
+          "string"
+        ],
+        "StartsAt": "string (timestamp)",
+        "EndsAt": "string (timestamp)",
+        "PlanItems": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem"
+          }
+        ]
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem": {
+      "title": "PlanItem",
+      "type": "object",
+      "properties": {
+        "PlanItemId": {
+          "format": "int32",
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        },
+        "ConfirmationCode": {
+          "type": "string"
+        },
+        "StartsAt": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "EndsAt": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "Duration": {
+          "format": "duration",
+          "pattern": "^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$",
+          "type": "string"
+        }
+      },
+      "example": {
+        "PlanItemId": "integer (identifier)",
+        "ConfirmationCode": "string",
+        "StartsAt": "string (timestamp)",
+        "EndsAt": "string (timestamp)",
+        "Duration": "string"
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem"
+        },
+        {
+          "title": "Event",
+          "type": "object",
+          "properties": {
+            "OccursAt": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation"
+            },
+            "Description": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "example": {
+        "PlanItemId": "integer (identifier)",
+        "ConfirmationCode": "string",
+        "StartsAt": "string (timestamp)",
+        "EndsAt": "string (timestamp)",
+        "Duration": "string",
+        "OccursAt": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation"
+        },
+        "Description": "string"
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PublicTransportation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem"
+        },
+        {
+          "title": "PublicTransportation",
+          "type": "object",
+          "properties": {
+            "SeatNumber": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "example": {
+        "PlanItemId": "integer (identifier)",
+        "ConfirmationCode": "string",
+        "StartsAt": "string (timestamp)",
+        "EndsAt": "string (timestamp)",
+        "Duration": "string",
+        "SeatNumber": "string"
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PublicTransportation"
+        },
+        {
+          "title": "Flight",
+          "type": "object",
+          "properties": {
+            "FlightNumber": {
+              "type": "string"
+            },
+            "Airline": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+            },
+            "From": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+            },
+            "To": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+            }
+          }
+        }
+      ],
+      "example": {
+        "PlanItemId": "integer (identifier)",
+        "ConfirmationCode": "string",
+        "StartsAt": "string (timestamp)",
+        "EndsAt": "string (timestamp)",
+        "Duration": "string",
+        "SeatNumber": "string",
+        "FlightNumber": "string",
+        "Airline": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"
+        },
+        "From": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+        },
+        "To": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"
+        }
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+        },
+        {
+          "title": "Employee",
+          "type": "object",
+          "properties": {
+            "Cost": {
+              "format": "int64"
+            },
+            "Peers": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          }
+        }
+      ],
+      "example": {
+        "UserName": "string (identifier)",
+        "FirstName": "string",
+        "LastName": "string",
+        "MiddleName": "string",
+        "Gender": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
+        },
+        "Age": "int64",
+        "Emails": [
+          "string"
+        ],
+        "AddressInfo": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+          }
+        ],
+        "HomeAddress": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+        },
+        "FavoriteFeature": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+        },
+        "Features": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+          }
+        ],
+        "Friends": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+          }
+        ],
+        "BestFriend": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+        },
+        "Trips": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+          }
+        ],
+        "Cost": "int64",
+        "Peers": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+          }
+        ]
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+        },
+        {
+          "title": "Manager",
+          "type": "object",
+          "properties": {
+            "Budget": {
+              "format": "int64"
+            },
+            "BossOffice": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            },
+            "DirectReports": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          }
+        }
+      ],
+      "example": {
+        "UserName": "string (identifier)",
+        "FirstName": "string",
+        "LastName": "string",
+        "MiddleName": "string",
+        "Gender": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
+        },
+        "Age": "int64",
+        "Emails": [
+          "string"
+        ],
+        "AddressInfo": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+          }
+        ],
+        "HomeAddress": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+        },
+        "FavoriteFeature": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+        },
+        "Features": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
+          }
+        ],
+        "Friends": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+          }
+        ],
+        "BestFriend": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+        },
+        "Trips": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+          }
+        ],
+        "Budget": "int64",
+        "BossOffice": {
+          "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+        },
+        "DirectReports": [
+          {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+          }
+        ]
+      }
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender": {
+      "title": "PersonGender",
+      "enum": [
+        "Male",
+        "Female",
+        "Unknow"
+      ],
+      "type": "string"
+    },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature": {
+      "title": "Feature",
+      "enum": [
+        "Feature1",
+        "Feature2",
+        "Feature3",
+        "Feature4"
+      ],
+      "type": "string"
+    },
+    "Edm.Geography": {
+      "$ref": "#/definitions/Edm.Geometry"
+    },
+    "Edm.GeographyPoint": {
+      "$ref": "#/definitions/Edm.GeometryPoint"
+    },
+    "Edm.GeographyLineString": {
+      "$ref": "#/definitions/Edm.GeometryLineString"
+    },
+    "Edm.GeographyPolygon": {
+      "$ref": "#/definitions/Edm.GeometryPolygon"
+    },
+    "Edm.GeographyMultiPoint": {
+      "$ref": "#/definitions/Edm.GeometryMultiPoint"
+    },
+    "Edm.GeographyMultiLineString": {
+      "$ref": "#/definitions/Edm.GeometryMultiLineString"
+    },
+    "Edm.GeographyMultiPolygon": {
+      "$ref": "#/definitions/Edm.GeometryMultiPolygon"
+    },
+    "Edm.GeographyCollection": {
+      "$ref": "#/definitions/Edm.GeometryCollection"
+    },
+    "Edm.Geometry": {
+      "type": "object"
+    },
+    "Edm.GeometryPoint": {
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "default": "Point",
+          "enum": [
+            "Point"
+          ],
+          "type": "string"
+        },
+        "coordinates": {
+          "$ref": "#/definitions/GeoJSON.position"
+        }
+      }
+    },
+    "Edm.GeometryLineString": {
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "LineString"
+          ]
+        },
+        "coordinates": {
+          "minItems": 2,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GeoJSON.position"
+          }
+        }
+      }
+    },
+    "Edm.GeometryPolygon": {
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "Polygon"
+          ]
+        },
+        "coordinates": {
+          "minItems": 4,
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/GeoJSON.position"
+            }
+          }
+        }
+      }
+    },
+    "Edm.GeometryMultiPoint": {
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "MultiPoint"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GeoJSON.position"
+          }
+        }
+      }
+    },
+    "Edm.GeometryMultiLineString": {
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "MultiLineString"
+          ]
+        },
+        "coordinates": {
+          "minItems": 2,
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/GeoJSON.position"
+            }
+          }
+        }
+      }
+    },
+    "Edm.GeometryMultiPolygon": {
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "MultiPolygon"
+          ]
+        },
+        "coordinates": {
+          "minItems": 4,
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GeoJSON.position"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Edm.GeometryCollection": {
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "GeometryCollection"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Edm.Geometry"
+          }
+        }
+      }
+    },
+    "GeoJSON.position": {
+      "minItems": 2,
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "odata.error": {
+      "required": [
+        "error"
+      ],
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/odata.error.main"
+        }
+      }
+    },
+    "odata.error.main": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/odata.error.detail"
+          }
+        },
+        "innererror": {
+          "description": "The structure of this object is service-specific",
+          "type": "object"
+        }
+      }
+    },
+    "odata.error.detail": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "top": {
+      "in": "query",
+      "name": "$top",
+      "description": "Show only the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "skip": {
+      "in": "query",
+      "name": "$skip",
+      "description": "Skip the first n items",
+      "type": "integer",
+      "minimum": 0
+    },
+    "count": {
+      "in": "query",
+      "name": "$count",
+      "description": "Include count of items",
+      "type": "boolean"
+    },
+    "filter": {
+      "in": "query",
+      "name": "$filter",
+      "description": "Filter items by property values",
+      "type": "string"
+    },
+    "search": {
+      "in": "query",
+      "name": "$search",
+      "description": "Search items by search phrases",
+      "type": "string"
+    }
+  },
+  "responses": {
+    "error": {
+      "description": "error",
+      "schema": {
+        "$ref": "#/definitions/odata.error"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Airlines.Airline",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Airports.Airport",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Airports",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "People",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "Me.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Me.Functions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "Me.Actions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "Me.Trip",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "NewComePeople.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "NewComePeople.Functions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "NewComePeople.Actions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "NewComePeople.Trip",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "People.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "People.Functions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "People.Actions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
+      "name": "People.Trip",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "ResetDataSource",
+      "x-ms-docs-toc-type": "container"
+    }
+  ]
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1,0 +1,3040 @@
+﻿swagger: '2.0'
+info:
+  title: OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
+  description: This OData service is located at http://services.odata.org/TrippinRESTierService
+  version: 1.0.1
+host: services.odata.org
+basePath: /TrippinRESTierService
+schemes:
+  - http
+paths:
+  /Airlines:
+    get:
+      tags:
+        - Airlines.Airline
+      summary: Get entities from Airlines
+      operationId: Airlines.Airline.ListAirline
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - AirlineCode
+              - AirlineCode desc
+              - Name
+              - Name desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - AirlineCode
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of Airline
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Airlines.Airline
+      summary: Add new entity to Airlines
+      operationId: Airlines.Airline.CreateAirline
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Airlines/{AirlineCode}':
+    get:
+      tags:
+        - Airlines.Airline
+      summary: Get entity from Airlines by key
+      operationId: Airlines.Airline.GetAirline
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: AirlineCode
+          description: 'key: AirlineCode'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airline
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - AirlineCode
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Airlines.Airline
+      summary: Update entity in Airlines
+      operationId: Airlines.Airline.UpdateAirline
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: AirlineCode
+          description: 'key: AirlineCode'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airline
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Airlines.Airline
+      summary: Delete entity from Airlines
+      operationId: Airlines.Airline.DeleteAirline
+      parameters:
+        - in: path
+          name: AirlineCode
+          description: 'key: AirlineCode'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airline
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Airports:
+    get:
+      tags:
+        - Airports.Airport
+      summary: Get entities from Airports
+      operationId: Airports.Airport.ListAirport
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Name
+              - Name desc
+              - IcaoCode
+              - IcaoCode desc
+              - IataCode
+              - IataCode desc
+              - Location
+              - Location desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+              - IcaoCode
+              - IataCode
+              - Location
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of Airport
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Airports.Airport
+      summary: Add new entity to Airports
+      operationId: Airports.Airport.CreateAirport
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Airports/{IcaoCode}':
+    get:
+      tags:
+        - Airports.Airport
+      summary: Get entity from Airports by key
+      operationId: Airports.Airport.GetAirport
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+              - IcaoCode
+              - IataCode
+              - Location
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Airports.Airport
+      summary: Update entity in Airports
+      operationId: Airports.Airport.UpdateAirport
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Airports.Airport
+      summary: Delete entity from Airports
+      operationId: Airports.Airport.DeleteAirport
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/GetNearestAirport(lat={lat},lon={lon})':
+    get:
+      tags:
+        - Airports
+      summary: Invoke functionImport GetNearestAirport
+      operationId: OperationImport.GetNearestAirport.6896b1324a4eff76ad9867a0
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: lat
+          required: true
+          format: double
+        - in: path
+          name: lon
+          required: true
+          format: double
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: functionImport
+  /GetPersonWithMostFriends():
+    get:
+      tags:
+        - People
+      summary: Invoke functionImport GetPersonWithMostFriends
+      operationId: OperationImport.GetPersonWithMostFriends.de8b4a5ab51ba6c8c254fe80
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: functionImport
+  /Me:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Me
+      operationId: Me.Person.GetPerson
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update Me
+      operationId: Me.Person.UpdatePerson
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Me/BestFriend:
+    get:
+      tags:
+        - Me.Person
+      summary: Get BestFriend from Me
+      operationId: Me.GetBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Me/Friends:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Friends from Me
+      operationId: Me.ListFriends
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Me/Friends/{UserName}':
+    get:
+      tags:
+        - Me.Person
+      summary: Get Friends from Me
+      operationId: Me.GetFriends
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline():
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function GetFavoriteAirline
+      operationId: Me.GetFavoriteAirline.4520
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName={userName})':
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function GetFriendsTrips
+      operationId: Me.GetFriendsTrips.a13d
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: userName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip:
+    post:
+      tags:
+        - Me.Actions
+      summary: Invoke action GetPeersForTrip
+      operationId: Me.GetPeersForTrip
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Action parameters
+          required: true
+          schema:
+            type: object
+            properties:
+              userName:
+                type: string
+              tripId:
+                format: int32
+                maximum: 2147483647
+                minimum: -2147483648
+                type: integer
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip:
+    post:
+      tags:
+        - Me.Actions
+      summary: Invoke action ShareTrip
+      operationId: Me.ShareTrip
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Action parameters
+          required: true
+          schema:
+            type: object
+            properties:
+              userName:
+                type: string
+              tripId:
+                format: int32
+                maximum: 2147483647
+                minimum: -2147483648
+                type: integer
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName={lastName})':
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function UpdatePersonLastName
+      operationId: Me.UpdatePersonLastName.a6a4
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: lastName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            default: false
+            type: boolean
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  /Me/Trips:
+    get:
+      tags:
+        - Me.Trip
+      summary: Get Trips from Me
+      operationId: Me.ListTrips
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Me/Trips/{TripId}':
+    get:
+      tags:
+        - Me.Trip
+      summary: Get Trips from Me
+      operationId: Me.GetTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: 'key: TripId'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: Me.Trips.GetInvolvedPeople.2707
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: 'key: TripId'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  /NewComePeople:
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get entities from NewComePeople
+      operationId: NewComePeople.Person.ListPerson
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of Person
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - NewComePeople.Person
+      summary: Add new entity to NewComePeople
+      operationId: NewComePeople.Person.CreatePerson
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}':
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get entity from NewComePeople by key
+      operationId: NewComePeople.Person.GetPerson
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - NewComePeople.Person
+      summary: Update entity in NewComePeople
+      operationId: NewComePeople.Person.UpdatePerson
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete entity from NewComePeople
+      operationId: NewComePeople.Person.DeletePerson
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/BestFriend':
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get BestFriend from NewComePeople
+      operationId: NewComePeople.GetBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Friends':
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Friends from NewComePeople
+      operationId: NewComePeople.ListFriends
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Friends/{UserName}':
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Friends from NewComePeople
+      operationId: NewComePeople.GetFriends
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
+    get:
+      tags:
+        - NewComePeople.Functions
+      summary: Invoke function GetFavoriteAirline
+      operationId: NewComePeople.GetFavoriteAirline.4520
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName={userName})':
+    get:
+      tags:
+        - NewComePeople.Functions
+      summary: Invoke function GetFriendsTrips
+      operationId: NewComePeople.GetFriendsTrips.a13d
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: userName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
+    post:
+      tags:
+        - NewComePeople.Actions
+      summary: Invoke action GetPeersForTrip
+      operationId: NewComePeople.GetPeersForTrip
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: Action parameters
+          required: true
+          schema:
+            type: object
+            properties:
+              userName:
+                type: string
+              tripId:
+                format: int32
+                maximum: 2147483647
+                minimum: -2147483648
+                type: integer
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
+    post:
+      tags:
+        - NewComePeople.Actions
+      summary: Invoke action ShareTrip
+      operationId: NewComePeople.ShareTrip
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: Action parameters
+          required: true
+          schema:
+            type: object
+            properties:
+              userName:
+                type: string
+              tripId:
+                format: int32
+                maximum: 2147483647
+                minimum: -2147483648
+                type: integer
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName={lastName})':
+    get:
+      tags:
+        - NewComePeople.Functions
+      summary: Invoke function UpdatePersonLastName
+      operationId: NewComePeople.UpdatePersonLastName.a6a4
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: lastName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            default: false
+            type: boolean
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  '/NewComePeople/{UserName}/Trips':
+    get:
+      tags:
+        - NewComePeople.Trip
+      summary: Get Trips from NewComePeople
+      operationId: NewComePeople.ListTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Trips/{TripId}':
+    get:
+      tags:
+        - NewComePeople.Trip
+      summary: Get Trips from NewComePeople
+      operationId: NewComePeople.GetTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: 'key: TripId'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    get:
+      tags:
+        - NewComePeople.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: NewComePeople.Trips.GetInvolvedPeople.2707
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: 'key: TripId'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  /People:
+    get:
+      tags:
+        - People.Person
+      summary: Get entities from People
+      operationId: People.Person.ListPerson
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved entities
+          schema:
+            title: Collection of Person
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Person
+      summary: Add new entity to People
+      operationId: People.Person.CreatePerson
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New entity
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '201':
+          description: Created entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}':
+    get:
+      tags:
+        - People.Person
+      summary: Get entity from People by key
+      operationId: People.Person.GetPerson
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved entity
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update entity in People
+      operationId: People.Person.UpdatePerson
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete entity from People
+      operationId: People.Person.DeletePerson
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/BestFriend':
+    get:
+      tags:
+        - People.Person
+      summary: Get BestFriend from People
+      operationId: People.GetBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Friends':
+    get:
+      tags:
+        - People.Person
+      summary: Get Friends from People
+      operationId: People.ListFriends
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Friends/{UserName}':
+    get:
+      tags:
+        - People.Person
+      summary: Get Friends from People
+      operationId: People.GetFriends
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function GetFavoriteAirline
+      operationId: People.GetFavoriteAirline.4520
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName={userName})':
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function GetFriendsTrips
+      operationId: People.GetFriendsTrips.a13d
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: userName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
+    post:
+      tags:
+        - People.Actions
+      summary: Invoke action GetPeersForTrip
+      operationId: People.GetPeersForTrip
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: Action parameters
+          required: true
+          schema:
+            type: object
+            properties:
+              userName:
+                type: string
+              tripId:
+                format: int32
+                maximum: 2147483647
+                minimum: -2147483648
+                type: integer
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
+    post:
+      tags:
+        - People.Actions
+      summary: Invoke action ShareTrip
+      operationId: People.ShareTrip
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: Action parameters
+          required: true
+          schema:
+            type: object
+            properties:
+              userName:
+                type: string
+              tripId:
+                format: int32
+                maximum: 2147483647
+                minimum: -2147483648
+                type: integer
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: action
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName={lastName})':
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function UpdatePersonLastName
+      operationId: People.UpdatePersonLastName.a6a4
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: lastName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            default: false
+            type: boolean
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  '/People/{UserName}/Trips':
+    get:
+      tags:
+        - People.Trip
+      summary: Get Trips from People
+      operationId: People.ListTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Trips/{TripId}':
+    get:
+      tags:
+        - People.Trip
+      summary: Get Trips from People
+      operationId: People.GetTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: 'key: TripId'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: People.Trips.GetInvolvedPeople.2707
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: 'key: TripId'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: function
+  /ResetDataSource:
+    post:
+      tags:
+        - ResetDataSource
+      summary: Invoke actionImport ResetDataSource
+      operationId: OperationImport.ResetDataSource
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: actionImport
+definitions:
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person:
+    title: Person
+    type: object
+    properties:
+      UserName:
+        type: string
+      FirstName:
+        type: string
+      LastName:
+        type: string
+      MiddleName:
+        type: string
+      Gender:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'
+      Age:
+        format: int64
+      Emails:
+        type: array
+        items:
+          type: string
+      AddressInfo:
+        type: array
+        items:
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      HomeAddress:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      FavoriteFeature:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'
+      Features:
+        type: array
+        items:
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'
+      Friends:
+        type: array
+        items:
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      BestFriend:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      Trips:
+        type: array
+        items:
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+    example:
+      UserName: string (identifier)
+      FirstName: string
+      LastName: string
+      MiddleName: string
+      Gender:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender
+      Age: int64
+      Emails:
+        - string
+      AddressInfo:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      HomeAddress:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      FavoriteFeature:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature
+      Features:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature
+      Friends:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+      BestFriend:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+      Trips:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline:
+    title: Airline
+    type: object
+    properties:
+      AirlineCode:
+        type: string
+      Name:
+        type: string
+    example:
+      AirlineCode: string (identifier)
+      Name: string
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport:
+    title: Airport
+    type: object
+    properties:
+      Name:
+        type: string
+      IcaoCode:
+        type: string
+      IataCode:
+        type: string
+      Location:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation'
+    example:
+      Name: string
+      IcaoCode: string (identifier)
+      IataCode: string
+      Location:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location:
+    title: Location
+    type: object
+    properties:
+      Address:
+        type: string
+      City:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.City'
+    example:
+      Address: string
+      City:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.City
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.City:
+    title: City
+    type: object
+    properties:
+      Name:
+        type: string
+      CountryRegion:
+        type: string
+      Region:
+        type: string
+    example:
+      Name: string
+      CountryRegion: string
+      Region: string
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation:
+    allOf:
+      - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      - title: AirportLocation
+        type: object
+        properties:
+          Loc:
+            $ref: '#/definitions/Edm.GeographyPoint'
+    example:
+      Address: string
+      City:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.City
+      Loc: Edm.GeographyPoint
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    allOf:
+      - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      - title: EventLocation
+        type: object
+        properties:
+          BuildingInfo:
+            type: string
+    example:
+      Address: string
+      City:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.City
+      BuildingInfo: string
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip:
+    title: Trip
+    type: object
+    properties:
+      TripId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ShareId:
+        format: uuid
+        pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        type: string
+      Name:
+        type: string
+      Budget:
+        format: float
+      Description:
+        type: string
+      Tags:
+        type: array
+        items:
+          type: string
+      StartsAt:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      EndsAt:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      PlanItems:
+        type: array
+        items:
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem'
+    example:
+      TripId: integer (identifier)
+      ShareId: string
+      Name: string
+      Budget: float
+      Description: string
+      Tags:
+        - string
+      StartsAt: string (timestamp)
+      EndsAt: string (timestamp)
+      PlanItems:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem:
+    title: PlanItem
+    type: object
+    properties:
+      PlanItemId:
+        format: int32
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      ConfirmationCode:
+        type: string
+      StartsAt:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      EndsAt:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      Duration:
+        format: duration
+        pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
+        type: string
+    example:
+      PlanItemId: integer (identifier)
+      ConfirmationCode: string
+      StartsAt: string (timestamp)
+      EndsAt: string (timestamp)
+      Duration: string
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Event:
+    allOf:
+      - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem'
+      - title: Event
+        type: object
+        properties:
+          OccursAt:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation'
+          Description:
+            type: string
+    example:
+      PlanItemId: integer (identifier)
+      ConfirmationCode: string
+      StartsAt: string (timestamp)
+      EndsAt: string (timestamp)
+      Duration: string
+      OccursAt:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation
+      Description: string
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.PublicTransportation:
+    allOf:
+      - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem'
+      - title: PublicTransportation
+        type: object
+        properties:
+          SeatNumber:
+            type: string
+    example:
+      PlanItemId: integer (identifier)
+      ConfirmationCode: string
+      StartsAt: string (timestamp)
+      EndsAt: string (timestamp)
+      Duration: string
+      SeatNumber: string
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight:
+    allOf:
+      - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PublicTransportation'
+      - title: Flight
+        type: object
+        properties:
+          FlightNumber:
+            type: string
+          Airline:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
+          From:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+          To:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
+    example:
+      PlanItemId: integer (identifier)
+      ConfirmationCode: string
+      StartsAt: string (timestamp)
+      EndsAt: string (timestamp)
+      Duration: string
+      SeatNumber: string
+      FlightNumber: string
+      Airline:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline
+      From:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport
+      To:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    allOf:
+      - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      - title: Employee
+        type: object
+        properties:
+          Cost:
+            format: int64
+          Peers:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+    example:
+      UserName: string (identifier)
+      FirstName: string
+      LastName: string
+      MiddleName: string
+      Gender:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender
+      Age: int64
+      Emails:
+        - string
+      AddressInfo:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      HomeAddress:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      FavoriteFeature:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature
+      Features:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature
+      Friends:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+      BestFriend:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+      Trips:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip
+      Cost: int64
+      Peers:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    allOf:
+      - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      - title: Manager
+        type: object
+        properties:
+          Budget:
+            format: int64
+          BossOffice:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+          DirectReports:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+    example:
+      UserName: string (identifier)
+      FirstName: string
+      LastName: string
+      MiddleName: string
+      Gender:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender
+      Age: int64
+      Emails:
+        - string
+      AddressInfo:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      HomeAddress:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      FavoriteFeature:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature
+      Features:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature
+      Friends:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+      BestFriend:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+      Trips:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip
+      Budget: int64
+      BossOffice:
+        '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      DirectReports:
+        - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender:
+    title: PersonGender
+    enum:
+      - Male
+      - Female
+      - Unknow
+    type: string
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature:
+    title: Feature
+    enum:
+      - Feature1
+      - Feature2
+      - Feature3
+      - Feature4
+    type: string
+  Edm.Geography:
+    $ref: '#/definitions/Edm.Geometry'
+  Edm.GeographyPoint:
+    $ref: '#/definitions/Edm.GeometryPoint'
+  Edm.GeographyLineString:
+    $ref: '#/definitions/Edm.GeometryLineString'
+  Edm.GeographyPolygon:
+    $ref: '#/definitions/Edm.GeometryPolygon'
+  Edm.GeographyMultiPoint:
+    $ref: '#/definitions/Edm.GeometryMultiPoint'
+  Edm.GeographyMultiLineString:
+    $ref: '#/definitions/Edm.GeometryMultiLineString'
+  Edm.GeographyMultiPolygon:
+    $ref: '#/definitions/Edm.GeometryMultiPolygon'
+  Edm.GeographyCollection:
+    $ref: '#/definitions/Edm.GeometryCollection'
+  Edm.Geometry:
+    type: object
+  Edm.GeometryPoint:
+    required:
+      - type
+      - coordinates
+    type: object
+    properties:
+      type:
+        default: Point
+        enum:
+          - Point
+        type: string
+      coordinates:
+        $ref: '#/definitions/GeoJSON.position'
+  Edm.GeometryLineString:
+    required:
+      - type
+      - coordinates
+    type: object
+    properties:
+      type:
+        enum:
+          - LineString
+      coordinates:
+        minItems: 2
+        type: array
+        items:
+          $ref: '#/definitions/GeoJSON.position'
+  Edm.GeometryPolygon:
+    required:
+      - type
+      - coordinates
+    type: object
+    properties:
+      type:
+        enum:
+          - Polygon
+      coordinates:
+        minItems: 4
+        type: array
+        items:
+          type: array
+          items:
+            $ref: '#/definitions/GeoJSON.position'
+  Edm.GeometryMultiPoint:
+    required:
+      - type
+      - coordinates
+    type: object
+    properties:
+      type:
+        enum:
+          - MultiPoint
+      coordinates:
+        type: array
+        items:
+          $ref: '#/definitions/GeoJSON.position'
+  Edm.GeometryMultiLineString:
+    required:
+      - type
+      - coordinates
+    type: object
+    properties:
+      type:
+        enum:
+          - MultiLineString
+      coordinates:
+        minItems: 2
+        type: array
+        items:
+          type: array
+          items:
+            $ref: '#/definitions/GeoJSON.position'
+  Edm.GeometryMultiPolygon:
+    required:
+      - type
+      - coordinates
+    type: object
+    properties:
+      type:
+        enum:
+          - MultiPolygon
+      coordinates:
+        minItems: 4
+        type: array
+        items:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: '#/definitions/GeoJSON.position'
+  Edm.GeometryCollection:
+    required:
+      - type
+      - coordinates
+    type: object
+    properties:
+      type:
+        enum:
+          - GeometryCollection
+      coordinates:
+        type: array
+        items:
+          $ref: '#/definitions/Edm.Geometry'
+  GeoJSON.position:
+    minItems: 2
+    type: array
+    items:
+      type: number
+  odata.error:
+    required:
+      - error
+    type: object
+    properties:
+      error:
+        $ref: '#/definitions/odata.error.main'
+  odata.error.main:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+      details:
+        type: array
+        items:
+          $ref: '#/definitions/odata.error.detail'
+      innererror:
+        description: The structure of this object is service-specific
+        type: object
+  odata.error.detail:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      target:
+        type: string
+parameters:
+  top:
+    in: query
+    name: $top
+    description: Show only the first n items
+    type: integer
+    minimum: 0
+  skip:
+    in: query
+    name: $skip
+    description: Skip the first n items
+    type: integer
+    minimum: 0
+  count:
+    in: query
+    name: $count
+    description: Include count of items
+    type: boolean
+  filter:
+    in: query
+    name: $filter
+    description: Filter items by property values
+    type: string
+  search:
+    in: query
+    name: $search
+    description: Search items by search phrases
+    type: string
+responses:
+  error:
+    description: error
+    schema:
+      $ref: '#/definitions/odata.error'
+tags:
+  - name: Airlines.Airline
+    x-ms-docs-toc-type: page
+  - name: Airports.Airport
+    x-ms-docs-toc-type: page
+  - name: Airports
+    x-ms-docs-toc-type: container
+  - name: People
+    x-ms-docs-toc-type: container
+  - name: Me.Person
+    x-ms-docs-toc-type: page
+  - name: Me.Functions
+    x-ms-docs-toc-type: container
+  - name: Me.Actions
+    x-ms-docs-toc-type: container
+  - name: Me.Trip
+    x-ms-docs-toc-type: page
+  - name: NewComePeople.Person
+    x-ms-docs-toc-type: page
+  - name: NewComePeople.Functions
+    x-ms-docs-toc-type: container
+  - name: NewComePeople.Actions
+    x-ms-docs-toc-type: container
+  - name: NewComePeople.Trip
+    x-ms-docs-toc-type: page
+  - name: People.Person
+    x-ms-docs-toc-type: page
+  - name: People.Functions
+    x-ms-docs-toc-type: container
+  - name: People.Actions
+    x-ms-docs-toc-type: container
+  - name: People.Trip
+    x-ms-docs-toc-type: page
+  - name: ResetDataSource
+    x-ms-docs-toc-type: container


### PR DESCRIPTION
This pull request partially addresses the incorrect serialization of OpenApi Specification version 2. When generating the model to be serialized, the AnyOf schema property was used in certain cases, specifically Entity, Enum, and Structured types. This meets the OASIS mapping documentation for OpenApi version 3.x, however version 2.x does not support AnyOf, nor Nullable json.schema properties (https://www.oasis-open.org/committees/document.php?document_id=61852&wg_abbrev=odata , specifically draft 5, the latest draft for OpenApi 2.0). 
In the case when the (new) configuration is set for 2.0, AnyOf will not be set in these cases, as the OpenApi serializer will simply ignore that node. 