### PR TITLE
Change encryption for fips compliance

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/CryptographyExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/CryptographyExtensions.cs
@@ -11,14 +11,14 @@ namespace Microsoft.OpenApi.OData.Common
     internal static class CryptographyExtensions
     {
         /// <summary>
-        /// Calculates the MD5 hash for the given string.
+        /// Calculates the SHA256 hash for the given string.
         /// </summary>
-        /// <returns>A 32 char long hash.</returns>
-        public static string GetHashMd5(this string input)
+        /// <returns>A 64 char long hash.</returns>
+        public static string GetHashShah256(this string input)
         {
             Utils.CheckArgumentNull(input, nameof(input));
 
-            var hasher = new MD5CryptoServiceProvider();
+            var hasher = new SHA256CryptoServiceProvider();
             var inputBytes = Encoding.UTF8.GetBytes(input);
             var hashBytes = hasher.ComputeHash(inputBytes);
             var hash = new StringBuilder();

--- a/src/Microsoft.OpenApi.OData.Reader/Common/CryptographyExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/CryptographyExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenApi.OData.Common
         /// Calculates the SHA256 hash for the given string.
         /// </summary>
         /// <returns>A 64 char long hash.</returns>
-        public static string GetHashShah256(this string input)
+        public static string GetHashSHA256(this string input)
         {
             Utils.CheckArgumentNull(input, nameof(input));
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationImportOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationImportOperationHandler.cs
@@ -48,8 +48,8 @@ namespace Microsoft.OpenApi.OData.Operation
                 {
                     ODataOperationImportSegment operationImportSegment = Path.LastSegment as ODataOperationImportSegment;
                     string pathItemName = operationImportSegment.GetPathItemName(Context.Settings);
-                    string md5 = pathItemName.GetHashMd5();
-                    operation.OperationId = "OperationImport." + EdmOperationImport.Name + "." + md5.Substring(8);
+                    string hash = pathItemName.GetHashShah256();
+                    operation.OperationId = "OperationImport." + EdmOperationImport.Name + "." + hash.Substring(8, 24);
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationImportOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationImportOperationHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 {
                     ODataOperationImportSegment operationImportSegment = Path.LastSegment as ODataOperationImportSegment;
                     string pathItemName = operationImportSegment.GetPathItemName(Context.Settings);
-                    string hash = pathItemName.GetHashShah256();
+                    string hash = pathItemName.GetHashSHA256();
                     operation.OperationId = "OperationImport." + EdmOperationImport.Name + "." + hash.Substring(8, 24);
                 }
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 {
                     ODataOperationSegment operationSegment = Path.LastSegment as ODataOperationSegment;
                     string pathItemName = operationSegment.GetPathItemName(Context.Settings);
-                    string hash = pathItemName.GetHashShah256();
+                    string hash = pathItemName.GetHashSHA256();
                     operation.OperationId = operationId + "." + hash.Substring(0, 4);
                 }
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -70,8 +70,8 @@ namespace Microsoft.OpenApi.OData.Operation
                 {
                     ODataOperationSegment operationSegment = Path.LastSegment as ODataOperationSegment;
                     string pathItemName = operationSegment.GetPathItemName(Context.Settings);
-                    string md5 = pathItemName.GetHashMd5();
-                    operation.OperationId = operationId + "." + md5.Substring(0, 4);
+                    string hash = pathItemName.GetHashShah256();
+                    operation.OperationId = operationId + "." + hash.Substring(0, 4);
                 }
             }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("OperationImport.MyFunction.a5ea52712c5e17e3bd081e4f", operation.OperationId);
+                Assert.Equal("OperationImport.MyFunction.790300f48b60d73292a9c056", operation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.MyFunction.1e00", operation.OperationId);
+                Assert.Equal("Customers.MyFunction.373f", operation.OperationId);
             }
             else
             {
@@ -136,7 +136,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.NS.VipCustomer.MyFunction.1e00", operation.OperationId);
+                Assert.Equal("Customers.NS.VipCustomer.MyFunction.373f", operation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -535,7 +535,7 @@
           "Airports"
         ],
         "summary": "Invoke functionImport GetNearestAirport",
-        "operationId": "OperationImport.GetNearestAirport.6896b1324a4eff76ad9867a0",
+        "operationId": "OperationImport.GetNearestAirport.fc9c4516cf76a7e9b89d87b1",
         "produces": [
           "application/json"
         ],
@@ -573,7 +573,7 @@
           "People"
         ],
         "summary": "Invoke functionImport GetPersonWithMostFriends",
-        "operationId": "OperationImport.GetPersonWithMostFriends.de8b4a5ab51ba6c8c254fe80",
+        "operationId": "OperationImport.GetPersonWithMostFriends.14b2097dbee53f4fb8fb308d",
         "produces": [
           "application/json"
         ],
@@ -947,7 +947,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "Me.GetFavoriteAirline.4520",
+        "operationId": "Me.GetFavoriteAirline.56eb",
         "produces": [
           "application/json"
         ],
@@ -971,7 +971,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "Me.GetFriendsTrips.a13d",
+        "operationId": "Me.GetFriendsTrips.679d",
         "produces": [
           "application/json"
         ],
@@ -1101,7 +1101,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "Me.UpdatePersonLastName.a6a4",
+        "operationId": "Me.UpdatePersonLastName.290b",
         "produces": [
           "application/json"
         ],
@@ -1305,7 +1305,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "Me.Trips.GetInvolvedPeople.2707",
+        "operationId": "Me.Trips.GetInvolvedPeople.5b52",
         "produces": [
           "application/json"
         ],
@@ -1926,7 +1926,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "NewComePeople.GetFavoriteAirline.4520",
+        "operationId": "NewComePeople.GetFavoriteAirline.56eb",
         "produces": [
           "application/json"
         ],
@@ -1960,7 +1960,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "NewComePeople.GetFriendsTrips.a13d",
+        "operationId": "NewComePeople.GetFriendsTrips.679d",
         "produces": [
           "application/json"
         ],
@@ -2114,7 +2114,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "NewComePeople.UpdatePersonLastName.a6a4",
+        "operationId": "NewComePeople.UpdatePersonLastName.290b",
         "produces": [
           "application/json"
         ],
@@ -2342,7 +2342,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "NewComePeople.Trips.GetInvolvedPeople.2707",
+        "operationId": "NewComePeople.Trips.GetInvolvedPeople.5b52",
         "produces": [
           "application/json"
         ],
@@ -2971,7 +2971,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "People.GetFavoriteAirline.4520",
+        "operationId": "People.GetFavoriteAirline.56eb",
         "produces": [
           "application/json"
         ],
@@ -3005,7 +3005,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "People.GetFriendsTrips.a13d",
+        "operationId": "People.GetFriendsTrips.679d",
         "produces": [
           "application/json"
         ],
@@ -3159,7 +3159,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "People.UpdatePersonLastName.a6a4",
+        "operationId": "People.UpdatePersonLastName.290b",
         "produces": [
           "application/json"
         ],
@@ -3387,7 +3387,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "People.Trips.GetInvolvedPeople.2707",
+        "operationId": "People.Trips.GetInvolvedPeople.5b52",
         "produces": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -357,7 +357,7 @@ paths:
       tags:
         - Airports
       summary: Invoke functionImport GetNearestAirport
-      operationId: OperationImport.GetNearestAirport.6896b1324a4eff76ad9867a0
+      operationId: OperationImport.GetNearestAirport.fc9c4516cf76a7e9b89d87b1
       produces:
         - application/json
       parameters:
@@ -382,7 +382,7 @@ paths:
       tags:
         - People
       summary: Invoke functionImport GetPersonWithMostFriends
-      operationId: OperationImport.GetPersonWithMostFriends.de8b4a5ab51ba6c8c254fe80
+      operationId: OperationImport.GetPersonWithMostFriends.14b2097dbee53f4fb8fb308d
       produces:
         - application/json
       responses:
@@ -654,7 +654,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: Me.GetFavoriteAirline.4520
+      operationId: Me.GetFavoriteAirline.56eb
       produces:
         - application/json
       responses:
@@ -670,7 +670,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: Me.GetFriendsTrips.a13d
+      operationId: Me.GetFriendsTrips.679d
       produces:
         - application/json
       parameters:
@@ -757,7 +757,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: Me.UpdatePersonLastName.a6a4
+      operationId: Me.UpdatePersonLastName.290b
       produces:
         - application/json
       parameters:
@@ -900,7 +900,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: Me.Trips.GetInvolvedPeople.2707
+      operationId: Me.Trips.GetInvolvedPeople.5b52
       produces:
         - application/json
       parameters:
@@ -1349,7 +1349,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: NewComePeople.GetFavoriteAirline.4520
+      operationId: NewComePeople.GetFavoriteAirline.56eb
       produces:
         - application/json
       parameters:
@@ -1372,7 +1372,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: NewComePeople.GetFriendsTrips.a13d
+      operationId: NewComePeople.GetFriendsTrips.679d
       produces:
         - application/json
       parameters:
@@ -1477,7 +1477,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: NewComePeople.UpdatePersonLastName.a6a4
+      operationId: NewComePeople.UpdatePersonLastName.290b
       produces:
         - application/json
       parameters:
@@ -1638,7 +1638,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: NewComePeople.Trips.GetInvolvedPeople.2707
+      operationId: NewComePeople.Trips.GetInvolvedPeople.5b52
       produces:
         - application/json
       parameters:
@@ -2093,7 +2093,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: People.GetFavoriteAirline.4520
+      operationId: People.GetFavoriteAirline.56eb
       produces:
         - application/json
       parameters:
@@ -2116,7 +2116,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: People.GetFriendsTrips.a13d
+      operationId: People.GetFriendsTrips.679d
       produces:
         - application/json
       parameters:
@@ -2221,7 +2221,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: People.UpdatePersonLastName.a6a4
+      operationId: People.UpdatePersonLastName.290b
       produces:
         - application/json
       parameters:
@@ -2382,7 +2382,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: People.Trips.GetInvolvedPeople.2707
+      operationId: People.Trips.GetInvolvedPeople.5b52
       produces:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -589,7 +589,7 @@
           "Airports"
         ],
         "summary": "Invoke functionImport GetNearestAirport",
-        "operationId": "OperationImport.GetNearestAirport.6896b1324a4eff76ad9867a0",
+        "operationId": "OperationImport.GetNearestAirport.fc9c4516cf76a7e9b89d87b1",
         "parameters": [
           {
             "name": "lat",
@@ -667,7 +667,7 @@
           "People"
         ],
         "summary": "Invoke functionImport GetPersonWithMostFriends",
-        "operationId": "OperationImport.GetPersonWithMostFriends.de8b4a5ab51ba6c8c254fe80",
+        "operationId": "OperationImport.GetPersonWithMostFriends.14b2097dbee53f4fb8fb308d",
         "responses": {
           "200": {
             "description": "Success",
@@ -1086,7 +1086,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "Me.GetFavoriteAirline.4520",
+        "operationId": "Me.GetFavoriteAirline.56eb",
         "responses": {
           "200": {
             "description": "Success",
@@ -1116,7 +1116,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "Me.GetFriendsTrips.a13d",
+        "operationId": "Me.GetFriendsTrips.679d",
         "parameters": [
           {
             "name": "userName",
@@ -1254,7 +1254,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "Me.UpdatePersonLastName.a6a4",
+        "operationId": "Me.UpdatePersonLastName.290b",
         "parameters": [
           {
             "name": "lastName",
@@ -1485,7 +1485,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "Me.Trips.GetInvolvedPeople.2707",
+        "operationId": "Me.Trips.GetInvolvedPeople.5b52",
         "parameters": [
           {
             "name": "TripId",
@@ -2200,7 +2200,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "NewComePeople.GetFavoriteAirline.4520",
+        "operationId": "NewComePeople.GetFavoriteAirline.56eb",
         "parameters": [
           {
             "name": "UserName",
@@ -2242,7 +2242,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "NewComePeople.GetFriendsTrips.a13d",
+        "operationId": "NewComePeople.GetFriendsTrips.679d",
         "parameters": [
           {
             "name": "UserName",
@@ -2414,7 +2414,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "NewComePeople.UpdatePersonLastName.a6a4",
+        "operationId": "NewComePeople.UpdatePersonLastName.290b",
         "parameters": [
           {
             "name": "UserName",
@@ -2675,7 +2675,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "NewComePeople.Trips.GetInvolvedPeople.2707",
+        "operationId": "NewComePeople.Trips.GetInvolvedPeople.5b52",
         "parameters": [
           {
             "name": "UserName",
@@ -3400,7 +3400,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "People.GetFavoriteAirline.4520",
+        "operationId": "People.GetFavoriteAirline.56eb",
         "parameters": [
           {
             "name": "UserName",
@@ -3442,7 +3442,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "People.GetFriendsTrips.a13d",
+        "operationId": "People.GetFriendsTrips.679d",
         "parameters": [
           {
             "name": "UserName",
@@ -3614,7 +3614,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "People.UpdatePersonLastName.a6a4",
+        "operationId": "People.UpdatePersonLastName.290b",
         "parameters": [
           {
             "name": "UserName",
@@ -3875,7 +3875,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "People.Trips.GetInvolvedPeople.2707",
+        "operationId": "People.Trips.GetInvolvedPeople.5b52",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -387,7 +387,7 @@ paths:
       tags:
         - Airports
       summary: Invoke functionImport GetNearestAirport
-      operationId: OperationImport.GetNearestAirport.6896b1324a4eff76ad9867a0
+      operationId: OperationImport.GetNearestAirport.fc9c4516cf76a7e9b89d87b1
       parameters:
         - name: lat
           in: path
@@ -430,7 +430,7 @@ paths:
       tags:
         - People
       summary: Invoke functionImport GetPersonWithMostFriends
-      operationId: OperationImport.GetPersonWithMostFriends.de8b4a5ab51ba6c8c254fe80
+      operationId: OperationImport.GetPersonWithMostFriends.14b2097dbee53f4fb8fb308d
       responses:
         '200':
           description: Success
@@ -730,7 +730,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: Me.GetFavoriteAirline.4520
+      operationId: Me.GetFavoriteAirline.56eb
       responses:
         '200':
           description: Success
@@ -748,7 +748,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: Me.GetFriendsTrips.a13d
+      operationId: Me.GetFriendsTrips.679d
       parameters:
         - name: userName
           in: path
@@ -836,7 +836,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: Me.UpdatePersonLastName.a6a4
+      operationId: Me.UpdatePersonLastName.290b
       parameters:
         - name: lastName
           in: path
@@ -996,7 +996,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: Me.Trips.GetInvolvedPeople.2707
+      operationId: Me.Trips.GetInvolvedPeople.5b52
       parameters:
         - name: TripId
           in: path
@@ -1502,7 +1502,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: NewComePeople.GetFavoriteAirline.4520
+      operationId: NewComePeople.GetFavoriteAirline.56eb
       parameters:
         - name: UserName
           in: path
@@ -1528,7 +1528,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: NewComePeople.GetFriendsTrips.a13d
+      operationId: NewComePeople.GetFriendsTrips.679d
       parameters:
         - name: UserName
           in: path
@@ -1639,7 +1639,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: NewComePeople.UpdatePersonLastName.a6a4
+      operationId: NewComePeople.UpdatePersonLastName.290b
       parameters:
         - name: UserName
           in: path
@@ -1820,7 +1820,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: NewComePeople.Trips.GetInvolvedPeople.2707
+      operationId: NewComePeople.Trips.GetInvolvedPeople.5b52
       parameters:
         - name: UserName
           in: path
@@ -2333,7 +2333,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: People.GetFavoriteAirline.4520
+      operationId: People.GetFavoriteAirline.56eb
       parameters:
         - name: UserName
           in: path
@@ -2359,7 +2359,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: People.GetFriendsTrips.a13d
+      operationId: People.GetFriendsTrips.679d
       parameters:
         - name: UserName
           in: path
@@ -2470,7 +2470,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: People.UpdatePersonLastName.a6a4
+      operationId: People.UpdatePersonLastName.290b
       parameters:
         - name: UserName
           in: path
@@ -2651,7 +2651,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: People.Trips.GetInvolvedPeople.2707
+      operationId: People.Trips.GetInvolvedPeople.5b52
       parameters:
         - name: UserName
           in: path


### PR DESCRIPTION
Currently the OpenAPI.NET.OData implementation is not FIPS compliant, as it uses the non-compliant MD5 has. For any environment that has FIPS compliance enabled, the converter will fail with a FIPS error, as MD5 hash provider's behavior is to throw in that case. 
Changing to SHA256 hash for FIPS compliance.