### PR TITLE
Fixes missing NavigationProperty descriptions in OpenApi

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.Release.nuspec
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.Release.nuspec
@@ -20,6 +20,8 @@
     </metadata>
   <files>
     <file src="$ProductRoot$\net461\Microsoft.OpenApi.OData.Reader.dll" target="lib\net461" />
+    <file src="$ProductRoot$\net461\Microsoft.OpenApi.OData.Reader.pdb" target="lib\net461" />
     <file src="$ProductRoot$\netstandard2.0\Microsoft.OpenApi.OData.Reader.dll" target="lib\netstandard2.0" />
+    <file src="$ProductRoot$\netstandard2.0\Microsoft.OpenApi.OData.Reader.pdb" target="lib\netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
Closes https://github.com/microsoft/OpenAPI.NET.OData/issues/49

Proposes:
- Fixing the missing `NavigationProperty `descriptions in the converted Microsoft Graph OpenApi descriptions from CSDL.