### PR TITLE
Adds discriminator support to OpenApi

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -64,5 +64,10 @@ namespace Microsoft.OpenApi.OData.Common
         /// extension for paging
         /// </summary>
         public static string xMsPageable = "x-ms-pageable";
+
+        /// <summary>
+        /// extension for discriminator value support
+        /// </summary>
+        public static string xMsDiscriminatorValue = "x-ms-discriminator-value";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -100,6 +100,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public string PageableOperationName { get; set; } = "listMore";
 
+        /// <summary>
+        /// Gets/sets a value indicating whether or not to allow discriminator value support.
+        /// </summary>
+        public bool EnableDiscriminatorValue { get; set; } = false;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings();
@@ -121,6 +126,7 @@ namespace Microsoft.OpenApi.OData
             newSettings.EnableUriEscapeFunctionCall = this.EnableUriEscapeFunctionCall;
             newSettings.EnablePagination = this.EnablePagination;
             newSettings.PageableOperationName = this.PageableOperationName;
+            newSettings.EnableDiscriminatorValue = this.EnableDiscriminatorValue;
 
             return newSettings;
         }


### PR DESCRIPTION
Related to: https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/196

Proposes:
- Adding support to OpenApi for PowerShell/AutoREST consumption.
  - This adds an `x-ms-discriminator-value` extension to the derived types of a response schema, and
  - a `Discriminator` object to response schemas.  
- Creating a config. setting to toggle this feature on/off.