### PR TITLE
Added simple PathPrefix to ConvertSettings to match ODataRoute prefix without affecting 'servers' declaration in OAS file.

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
@@ -146,6 +146,13 @@ namespace Microsoft.OpenApi.OData.Edm
 
             HashSet<string> parameters = new HashSet<string>();
             StringBuilder sb = new StringBuilder();
+
+            if (!string.IsNullOrWhiteSpace(settings.PathPrefix))
+            {
+                sb.Append("/");
+                sb.Append(settings.PathPrefix);
+            }
+
             foreach (var segment in Segments)
             {
                 string pathItemName = segment.GetPathItemName(settings, parameters);

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -115,6 +115,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool EnableDerivedTypesReferencesForRequestBody { get; set; } = false;
 
+        /// <summary>
+        /// Gets/sets a value that specifies a prefix to be prepended to all generated paths.
+        /// </summary>
+        public string PathPrefix { get; set; } = string.Empty;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -138,7 +143,8 @@ namespace Microsoft.OpenApi.OData
                 PageableOperationName = this.PageableOperationName,
                 EnableDiscriminatorValue = this.EnableDiscriminatorValue,
                 EnableDerivedTypesReferencesForResponses = this.EnableDerivedTypesReferencesForResponses,
-                EnableDerivedTypesReferencesForRequestBody = this.EnableDerivedTypesReferencesForRequestBody
+                EnableDerivedTypesReferencesForRequestBody = this.EnableDerivedTypesReferencesForRequestBody,
+                PathPrefix = this.PathPrefix
             };
 
             return newSettings;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
@@ -68,6 +68,35 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
         }
 
         [Fact]
+        public void CreatePathsReturnsForBasicModelWithPrefix()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.BasicEdmModel;
+            OpenApiConvertSettings settings = new OpenApiConvertSettings
+            {
+                EnableKeyAsSegment = true,
+                PathPrefix = "some/prefix"
+            };
+            ODataContext context = new ODataContext(model, settings);
+
+            // Act
+            var paths = context.CreatePaths();
+
+            // Assert
+            Assert.NotNull(paths);
+            Assert.Equal(7, paths.Count);
+
+            Assert.Contains("/some/prefix/People", paths.Keys);
+            Assert.Contains("/some/prefix/People/{UserName}", paths.Keys);
+            Assert.Contains("/some/prefix/City", paths.Keys);
+            Assert.Contains("/some/prefix/City/{Name}", paths.Keys);
+            Assert.Contains("/some/prefix/CountryOrRegion", paths.Keys);
+            Assert.Contains("/some/prefix/CountryOrRegion/{Name}", paths.Keys);
+            Assert.Contains("/some/prefix/Me", paths.Keys);
+        }
+
+
+        [Fact]
         public void CreatePathsReturnsForContractModelWithHierarhicalClass()
         {
             // Arrange


### PR DESCRIPTION
Fixes #60 

Added simple PathPrefix to ConvertSettings to match ODataRoute prefix without affecting 'servers' declaration in OAS file.

Add test to match.

This aids with mocking tools that only understand absolute paths and cannot parse server entries to split DNS segments from path segments.