### PR TITLE
Fix: Removes example property in path parameter objects

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -187,8 +187,6 @@ namespace Microsoft.OpenApi.OData.Operation
             foreach (var param in customParameters)
             {
                 string documentationUrl = null;
-                string paramDescription;
-
                 if (param.DocumentationURL != null)
                 {
                     documentationUrl = $" Documentation URL: {param.DocumentationURL}";
@@ -196,7 +194,7 @@ namespace Microsoft.OpenApi.OData.Operation
 
                 // DocumentationURL value is to be appended to
                 // the parameter Description property
-               string paramDescription = (param.Description == null) ? documentationUrl?.Remove(0, 1) : param.Description + documentationUrl;
+                string paramDescription = (param.Description == null) ? documentationUrl?.Remove(0, 1) : param.Description + documentationUrl;
 
                 OpenApiParameter parameter = new OpenApiParameter
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -186,22 +186,36 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             foreach (var param in customParameters)
             {
+                string documentationUrl = null;
+                string paramDescription;
+
+                if (param.DocumentationURL != null)
+                {
+                    documentationUrl = $" Documentation URL: {param.DocumentationURL}";
+                }
+
+                // DocumentationURL value is to be appended to
+                // the parameter Description property
+                if (param.Description == null)
+                {
+                    paramDescription = documentationUrl?.Remove(0, 1);
+                }
+                else
+                {
+                    paramDescription = param.Description + documentationUrl;
+                }
+
                 OpenApiParameter parameter = new OpenApiParameter
                 {
                     In = location,
                     Name = param.Name,
-                    Description = param.Description,
+                    Description = paramDescription,
                     Schema = new OpenApiSchema
                     {
                         Type = "string"
                     },
                     Required = param.Required ?? false
                 };
-
-                if (param.DocumentationURL != null)
-                {
-                    parameter.Example = new OpenApiString(param.DocumentationURL ?? "N/A");
-                }
 
                 if (param.ExampleValues != null)
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -196,7 +196,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 // the parameter Description property
                 string paramDescription = (param.Description == null) ? documentationUrl?.Remove(0, 1) : param.Description + documentationUrl;
 
-                OpenApiParameter parameter = new OpenApiParameter
+                OpenApiParameter parameter = new()
                 {
                     In = location,
                     Name = param.Name,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -196,14 +196,7 @@ namespace Microsoft.OpenApi.OData.Operation
 
                 // DocumentationURL value is to be appended to
                 // the parameter Description property
-                if (param.Description == null)
-                {
-                    paramDescription = documentationUrl?.Remove(0, 1);
-                }
-                else
-                {
-                    paramDescription = param.Description + documentationUrl;
-                }
+               string paramDescription = (param.Description == null) ? documentationUrl?.Remove(0, 1) : param.Description + documentationUrl;
 
                 OpenApiParameter parameter = new OpenApiParameter
                 {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
@@ -173,7 +173,31 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
           <PropertyValue Property=""Name"" String=""myhead1"" />
           <PropertyValue Property=""Required"" Bool=""true"" />
         </Record>
-      </Collection>
+        <Record>
+          <PropertyValue Property=""Name"" String=""myhead2"" />
+          <PropertyValue Property = ""Description"" String = ""This is the description for myhead2."" />
+          <PropertyValue Property = ""Required"" Bool = ""false"" />
+        </Record>
+        <Record>
+          <PropertyValue Property=""Name"" String=""myhead3"" />
+          <PropertyValue Property = ""DocumentationURL"" String = ""https://foo.bar.com/myhead3"" />
+          <PropertyValue Property = ""Required"" Bool = ""false"" />
+        </Record>
+        <Record>
+          <PropertyValue Property=""Name"" String=""myhead4"" />
+          <PropertyValue Property = ""Description"" String = ""This is the description for myhead4."" />
+          <PropertyValue Property = ""DocumentationURL"" String = ""https://foo.bar.com/myhead4"" />
+          <PropertyValue Property = ""Required"" Bool = ""false"" />
+          <PropertyValue Property = ""ExampleValues"" >
+            <Collection>
+              <Record>
+                 <PropertyValue Property = ""Value"" String = ""sample"" />
+                 <PropertyValue Property = ""Description"" String = ""The sample description."" />
+                 </Record>
+            </Collection>
+          </PropertyValue>
+        </Record>
+       </Collection>
     </PropertyValue>
     <PropertyValue Property=""Permissions"">
       <Collection>
@@ -262,6 +286,49 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       }
     }
 ".ChangeLineBreaks(), json);
+
+                // Assert with no DocumentationURL value
+                Assert.Contains(@"
+    {
+      ""name"": ""myhead2"",
+      ""in"": ""header"",
+      ""description"": ""This is the description for myhead2."",
+      ""schema"": {
+        ""type"": ""string""
+      }
+    }
+".ChangeLineBreaks(), json);
+
+                // Assert with no Description value
+                Assert.Contains(@"
+    {
+      ""name"": ""myhead3"",
+      ""in"": ""header"",
+      ""description"": ""Documentation URL: https://foo.bar.com/myhead3"",
+      ""schema"": {
+        ""type"": ""string""
+      }
+    }
+".ChangeLineBreaks(), json);
+
+                // Assert with both DocumentationURL and Description values
+                Assert.Contains(@"
+    {
+      ""name"": ""myhead4"",
+      ""in"": ""header"",
+      ""description"": ""This is the description for myhead4. Documentation URL: https://foo.bar.com/myhead4"",
+      ""schema"": {
+        ""type"": ""string""
+      },
+      ""examples"": {
+        ""example-1"": {
+          ""description"": ""The sample description."",
+          ""value"": ""sample""
+        }
+      }
+    }
+".ChangeLineBreaks(), json);
+
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/91
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/511

- The current _Example_ property defined under parameters is currently only used to define the _DocumentationURL_ property value. This can be appended to the _Description_ property. This will help in preventing the potential occurrences of both _example_ and _examples_ properties, which are mutually exclusive. 
- Tests have been added to validate this fix.