### PR TITLE
Fixes potential duplicate operationIds in action/function paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -66,7 +66,13 @@ namespace Microsoft.OpenApi.OData.Operation
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
-                string operationId = String.Join(".", Path.Segments.Where(s => !(s is ODataKeySegment)).Select(s => s.Identifier));
+                // When the key segment is available, its EntityType name will be used
+                // in the operationId to avoid potential duplicates in entity vs entityset functions/actions
+                string operationId = string.Join(".",
+                    Path.Segments.Take(1).Select(s => s.Identifier)
+                    .Union(Path.Segments.Where(s => s is ODataKeySegment).Select(s => s.EntityType.Name))
+                    .Union(Path.Segments.Where(s => s is not ODataKeySegment).Select(s => s.Identifier).Skip(1))); // 1st segment qualifies too, skip it
+
                 if (EdmOperation.IsAction())
                 {
                     operation.OperationId = operationId;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -3,10 +3,8 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
@@ -66,12 +64,25 @@ namespace Microsoft.OpenApi.OData.Operation
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
-                // When the key segment is available, its EntityType name will be used
-                // in the operationId to avoid potential duplicates in entity vs entityset functions/actions
-                string operationId = string.Join(".",
-                    Path.Segments.Take(1).Select(s => s.Identifier)
-                    .Union(Path.Segments.Where(s => s is ODataKeySegment).Select(s => s.EntityType.Name))
-                    .Union(Path.Segments.Where(s => s is not ODataKeySegment).Select(s => s.Identifier).Skip(1))); // 1st segment qualifies too, skip it
+                // When the key segment is available,
+                // its EntityType name will be used
+                // in the operationId to avoid potential
+                // duplicates in entity vs entityset functions/actions
+
+                List<string> identifiers = new();
+                foreach (ODataSegment segment in Path.Segments)
+                {
+                    if (segment is not ODataKeySegment)
+                    {
+                        identifiers.Add(segment.Identifier);
+                    }
+                    else
+                    {
+                        identifiers.Add(segment.EntityType.Name);
+                    }
+                }
+
+                string operationId = string.Join(".", identifiers);
 
                 if (EdmOperation.IsAction())
                 {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
@@ -116,19 +116,25 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 new ODataKeySegment(customer),
                 new ODataOperationSegment(action));
 
+            ODataPath path2 = new ODataPath(new ODataNavigationSourceSegment(customers),
+                new ODataOperationSegment(action));
+
             // Act
             var operation = _operationHandler.CreateOperation(context, path);
+            var operation2 = _operationHandler.CreateOperation(context, path2);
 
             // Assert
             Assert.NotNull(operation);
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.MyAction", operation.OperationId);
+                Assert.Equal("Customers.Customer.MyAction", operation.OperationId);
+                Assert.Equal("Customers.MyAction", operation2.OperationId);
             }
             else
             {
                 Assert.Null(operation.OperationId);
+                Assert.Null(operation2.OperationId);
             }
         }
 
@@ -171,7 +177,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.NS.VipCustomer.MyAction", operation.OperationId);
+                Assert.Equal("Customers.Customer.NS.VipCustomer.MyAction", operation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -116,19 +116,25 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 new ODataKeySegment(customer),
                 new ODataOperationSegment(function));
 
+            ODataPath path2 = new ODataPath(new ODataNavigationSourceSegment(customers),
+                new ODataOperationSegment(function));
+
             // Act
             var operation = _operationHandler.CreateOperation(context, path);
+            var operation2 = _operationHandler.CreateOperation(context, path2);
 
             // Assert
             Assert.NotNull(operation);
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.MyFunction", operation.OperationId);
+                Assert.Equal("Customers.Customer.MyFunction", operation.OperationId);
+                Assert.Equal("Customers.MyFunction", operation2.OperationId);
             }
             else
             {
                 Assert.Null(operation.OperationId);
+                Assert.Null(operation2.OperationId);
             }
         }
 
@@ -171,7 +177,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.NS.VipCustomer.MyFunction", operation.OperationId);
+                Assert.Equal("Customers.Customer.NS.VipCustomer.MyFunction", operation.OperationId);
             }
             else
             {
@@ -222,7 +228,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.MyFunction-28ae", operation.OperationId);
+                Assert.Equal("Customers.Customer.MyFunction-28ae", operation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -594,7 +594,7 @@
           "Documents.Actions"
         ],
         "summary": "Invoke action Upload",
-        "operationId": "Documents.Upload",
+        "operationId": "Documents.DocumentDto.Upload",
         "produces": [
           "application/json"
         ],
@@ -2381,7 +2381,7 @@
           "Tasks.Actions"
         ],
         "summary": "Invoke action Upload",
-        "operationId": "Tasks.Upload",
+        "operationId": "Tasks.DocumentDto.Upload",
         "produces": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -416,7 +416,7 @@ paths:
       tags:
         - Documents.Actions
       summary: Invoke action Upload
-      operationId: Documents.Upload
+      operationId: Documents.DocumentDto.Upload
       produces:
         - application/json
       parameters:
@@ -1720,7 +1720,7 @@ paths:
       tags:
         - Tasks.Actions
       summary: Invoke action Upload
-      operationId: Tasks.Upload
+      operationId: Tasks.DocumentDto.Upload
       produces:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -667,7 +667,7 @@
           "Documents.Actions"
         ],
         "summary": "Invoke action Upload",
-        "operationId": "Documents.Upload",
+        "operationId": "Documents.DocumentDto.Upload",
         "parameters": [
           {
             "name": "Id",
@@ -2718,7 +2718,7 @@
           "Tasks.Actions"
         ],
         "summary": "Invoke action Upload",
-        "operationId": "Tasks.Upload",
+        "operationId": "Tasks.DocumentDto.Upload",
         "parameters": [
           {
             "name": "Id",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -462,7 +462,7 @@ paths:
       tags:
         - Documents.Actions
       summary: Invoke action Upload
-      operationId: Documents.Upload
+      operationId: Documents.DocumentDto.Upload
       parameters:
         - name: Id
           in: path
@@ -1935,7 +1935,7 @@ paths:
       tags:
         - Tasks.Actions
       summary: Invoke action Upload
-      operationId: Tasks.Upload
+      operationId: Tasks.DocumentDto.Upload
       parameters:
         - name: Id
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1564,7 +1564,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "Me.Trip.Trips.GetInvolvedPeople",
+        "operationId": "Me.Trips.Trip.GetInvolvedPeople",
         "produces": [
           "application/json"
         ],
@@ -3161,7 +3161,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "NewComePeople.Person.Trip.Trips.GetInvolvedPeople",
+        "operationId": "NewComePeople.Person.Trips.Trip.GetInvolvedPeople",
         "produces": [
           "application/json"
         ],
@@ -4790,7 +4790,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "People.Person.Trip.Trips.GetInvolvedPeople",
+        "operationId": "People.Person.Trips.Trip.GetInvolvedPeople",
         "produces": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1564,7 +1564,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "Me.Trips.GetInvolvedPeople",
+        "operationId": "Me.Trip.Trips.GetInvolvedPeople",
         "produces": [
           "application/json"
         ],
@@ -2598,7 +2598,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "NewComePeople.GetFavoriteAirline",
+        "operationId": "NewComePeople.Person.GetFavoriteAirline",
         "produces": [
           "application/json"
         ],
@@ -2632,7 +2632,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "NewComePeople.GetFriendsTrips",
+        "operationId": "NewComePeople.Person.GetFriendsTrips",
         "produces": [
           "application/json"
         ],
@@ -2676,7 +2676,7 @@
           "NewComePeople.Actions"
         ],
         "summary": "Invoke action GetPeersForTrip",
-        "operationId": "NewComePeople.GetPeersForTrip",
+        "operationId": "NewComePeople.Person.GetPeersForTrip",
         "consumes": [
           "application/json"
         ],
@@ -2736,7 +2736,7 @@
           "NewComePeople.Actions"
         ],
         "summary": "Invoke action ShareTrip",
-        "operationId": "NewComePeople.ShareTrip",
+        "operationId": "NewComePeople.Person.ShareTrip",
         "consumes": [
           "application/json"
         ],
@@ -2787,7 +2787,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "NewComePeople.UpdatePersonLastName",
+        "operationId": "NewComePeople.Person.UpdatePersonLastName",
         "produces": [
           "application/json"
         ],
@@ -3161,7 +3161,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "NewComePeople.Trips.GetInvolvedPeople",
+        "operationId": "NewComePeople.Person.Trip.Trips.GetInvolvedPeople",
         "produces": [
           "application/json"
         ],
@@ -4227,7 +4227,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "People.GetFavoriteAirline",
+        "operationId": "People.Person.GetFavoriteAirline",
         "produces": [
           "application/json"
         ],
@@ -4261,7 +4261,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "People.GetFriendsTrips",
+        "operationId": "People.Person.GetFriendsTrips",
         "produces": [
           "application/json"
         ],
@@ -4305,7 +4305,7 @@
           "People.Actions"
         ],
         "summary": "Invoke action GetPeersForTrip",
-        "operationId": "People.GetPeersForTrip",
+        "operationId": "People.Person.GetPeersForTrip",
         "consumes": [
           "application/json"
         ],
@@ -4365,7 +4365,7 @@
           "People.Actions"
         ],
         "summary": "Invoke action ShareTrip",
-        "operationId": "People.ShareTrip",
+        "operationId": "People.Person.ShareTrip",
         "consumes": [
           "application/json"
         ],
@@ -4416,7 +4416,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "People.UpdatePersonLastName",
+        "operationId": "People.Person.UpdatePersonLastName",
         "produces": [
           "application/json"
         ],
@@ -4790,7 +4790,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "People.Trips.GetInvolvedPeople",
+        "operationId": "People.Person.Trip.Trips.GetInvolvedPeople",
         "produces": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1072,7 +1072,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: Me.Trips.GetInvolvedPeople
+      operationId: Me.Trip.Trips.GetInvolvedPeople
       produces:
         - application/json
       parameters:
@@ -1796,7 +1796,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: NewComePeople.GetFavoriteAirline
+      operationId: NewComePeople.Person.GetFavoriteAirline
       produces:
         - application/json
       parameters:
@@ -1819,7 +1819,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: NewComePeople.GetFriendsTrips
+      operationId: NewComePeople.Person.GetFriendsTrips
       produces:
         - application/json
       parameters:
@@ -1849,7 +1849,7 @@ paths:
       tags:
         - NewComePeople.Actions
       summary: Invoke action GetPeersForTrip
-      operationId: NewComePeople.GetPeersForTrip
+      operationId: NewComePeople.Person.GetPeersForTrip
       consumes:
         - application/json
       produces:
@@ -1890,7 +1890,7 @@ paths:
       tags:
         - NewComePeople.Actions
       summary: Invoke action ShareTrip
-      operationId: NewComePeople.ShareTrip
+      operationId: NewComePeople.Person.ShareTrip
       consumes:
         - application/json
       parameters:
@@ -1925,7 +1925,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: NewComePeople.UpdatePersonLastName
+      operationId: NewComePeople.Person.UpdatePersonLastName
       produces:
         - application/json
       parameters:
@@ -2189,7 +2189,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: NewComePeople.Trips.GetInvolvedPeople
+      operationId: NewComePeople.Person.Trip.Trips.GetInvolvedPeople
       produces:
         - application/json
       parameters:
@@ -2937,7 +2937,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: People.GetFavoriteAirline
+      operationId: People.Person.GetFavoriteAirline
       produces:
         - application/json
       parameters:
@@ -2960,7 +2960,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: People.GetFriendsTrips
+      operationId: People.Person.GetFriendsTrips
       produces:
         - application/json
       parameters:
@@ -2990,7 +2990,7 @@ paths:
       tags:
         - People.Actions
       summary: Invoke action GetPeersForTrip
-      operationId: People.GetPeersForTrip
+      operationId: People.Person.GetPeersForTrip
       consumes:
         - application/json
       produces:
@@ -3031,7 +3031,7 @@ paths:
       tags:
         - People.Actions
       summary: Invoke action ShareTrip
-      operationId: People.ShareTrip
+      operationId: People.Person.ShareTrip
       consumes:
         - application/json
       parameters:
@@ -3066,7 +3066,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: People.UpdatePersonLastName
+      operationId: People.Person.UpdatePersonLastName
       produces:
         - application/json
       parameters:
@@ -3330,7 +3330,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: People.Trips.GetInvolvedPeople
+      operationId: People.Person.Trip.Trips.GetInvolvedPeople
       produces:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1072,7 +1072,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: Me.Trip.Trips.GetInvolvedPeople
+      operationId: Me.Trips.Trip.GetInvolvedPeople
       produces:
         - application/json
       parameters:
@@ -2189,7 +2189,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: NewComePeople.Person.Trip.Trips.GetInvolvedPeople
+      operationId: NewComePeople.Person.Trips.Trip.GetInvolvedPeople
       produces:
         - application/json
       parameters:
@@ -3330,7 +3330,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: People.Person.Trip.Trips.GetInvolvedPeople
+      operationId: People.Person.Trips.Trip.GetInvolvedPeople
       produces:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1762,7 +1762,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "Me.Trips.GetInvolvedPeople",
+        "operationId": "Me.Trip.Trips.GetInvolvedPeople",
         "parameters": [
           {
             "name": "TripId",
@@ -2913,7 +2913,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "NewComePeople.GetFavoriteAirline",
+        "operationId": "NewComePeople.Person.GetFavoriteAirline",
         "parameters": [
           {
             "name": "UserName",
@@ -2955,7 +2955,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "NewComePeople.GetFriendsTrips",
+        "operationId": "NewComePeople.Person.GetFriendsTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -3009,7 +3009,7 @@
           "NewComePeople.Actions"
         ],
         "summary": "Invoke action GetPeersForTrip",
-        "operationId": "NewComePeople.GetPeersForTrip",
+        "operationId": "NewComePeople.Person.GetPeersForTrip",
         "parameters": [
           {
             "name": "UserName",
@@ -3076,7 +3076,7 @@
           "NewComePeople.Actions"
         ],
         "summary": "Invoke action ShareTrip",
-        "operationId": "NewComePeople.ShareTrip",
+        "operationId": "NewComePeople.Person.ShareTrip",
         "parameters": [
           {
             "name": "UserName",
@@ -3128,7 +3128,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "NewComePeople.UpdatePersonLastName",
+        "operationId": "NewComePeople.Person.UpdatePersonLastName",
         "parameters": [
           {
             "name": "UserName",
@@ -3551,7 +3551,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "NewComePeople.Trips.GetInvolvedPeople",
+        "operationId": "NewComePeople.Person.Trip.Trips.GetInvolvedPeople",
         "parameters": [
           {
             "name": "UserName",
@@ -4742,7 +4742,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFavoriteAirline",
-        "operationId": "People.GetFavoriteAirline",
+        "operationId": "People.Person.GetFavoriteAirline",
         "parameters": [
           {
             "name": "UserName",
@@ -4784,7 +4784,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetFriendsTrips",
-        "operationId": "People.GetFriendsTrips",
+        "operationId": "People.Person.GetFriendsTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -4838,7 +4838,7 @@
           "People.Actions"
         ],
         "summary": "Invoke action GetPeersForTrip",
-        "operationId": "People.GetPeersForTrip",
+        "operationId": "People.Person.GetPeersForTrip",
         "parameters": [
           {
             "name": "UserName",
@@ -4905,7 +4905,7 @@
           "People.Actions"
         ],
         "summary": "Invoke action ShareTrip",
-        "operationId": "People.ShareTrip",
+        "operationId": "People.Person.ShareTrip",
         "parameters": [
           {
             "name": "UserName",
@@ -4957,7 +4957,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function UpdatePersonLastName",
-        "operationId": "People.UpdatePersonLastName",
+        "operationId": "People.Person.UpdatePersonLastName",
         "parameters": [
           {
             "name": "UserName",
@@ -5380,7 +5380,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "People.Trips.GetInvolvedPeople",
+        "operationId": "People.Person.Trip.Trips.GetInvolvedPeople",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1762,7 +1762,7 @@
           "Me.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "Me.Trip.Trips.GetInvolvedPeople",
+        "operationId": "Me.Trips.Trip.GetInvolvedPeople",
         "parameters": [
           {
             "name": "TripId",
@@ -3551,7 +3551,7 @@
           "NewComePeople.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "NewComePeople.Person.Trip.Trips.GetInvolvedPeople",
+        "operationId": "NewComePeople.Person.Trips.Trip.GetInvolvedPeople",
         "parameters": [
           {
             "name": "UserName",
@@ -5380,7 +5380,7 @@
           "People.Functions"
         ],
         "summary": "Invoke function GetInvolvedPeople",
-        "operationId": "People.Person.Trip.Trips.GetInvolvedPeople",
+        "operationId": "People.Person.Trips.Trip.GetInvolvedPeople",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -1184,7 +1184,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: Me.Trips.GetInvolvedPeople
+      operationId: Me.Trip.Trips.GetInvolvedPeople
       parameters:
         - name: TripId
           in: path
@@ -1980,7 +1980,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: NewComePeople.GetFavoriteAirline
+      operationId: NewComePeople.Person.GetFavoriteAirline
       parameters:
         - name: UserName
           in: path
@@ -2006,7 +2006,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: NewComePeople.GetFriendsTrips
+      operationId: NewComePeople.Person.GetFriendsTrips
       parameters:
         - name: UserName
           in: path
@@ -2040,7 +2040,7 @@ paths:
       tags:
         - NewComePeople.Actions
       summary: Invoke action GetPeersForTrip
-      operationId: NewComePeople.GetPeersForTrip
+      operationId: NewComePeople.Person.GetPeersForTrip
       parameters:
         - name: UserName
           in: path
@@ -2083,7 +2083,7 @@ paths:
       tags:
         - NewComePeople.Actions
       summary: Invoke action ShareTrip
-      operationId: NewComePeople.ShareTrip
+      operationId: NewComePeople.Person.ShareTrip
       parameters:
         - name: UserName
           in: path
@@ -2118,7 +2118,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: NewComePeople.UpdatePersonLastName
+      operationId: NewComePeople.Person.UpdatePersonLastName
       parameters:
         - name: UserName
           in: path
@@ -2411,7 +2411,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: NewComePeople.Trips.GetInvolvedPeople
+      operationId: NewComePeople.Person.Trip.Trips.GetInvolvedPeople
       parameters:
         - name: UserName
           in: path
@@ -3235,7 +3235,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFavoriteAirline
-      operationId: People.GetFavoriteAirline
+      operationId: People.Person.GetFavoriteAirline
       parameters:
         - name: UserName
           in: path
@@ -3261,7 +3261,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetFriendsTrips
-      operationId: People.GetFriendsTrips
+      operationId: People.Person.GetFriendsTrips
       parameters:
         - name: UserName
           in: path
@@ -3295,7 +3295,7 @@ paths:
       tags:
         - People.Actions
       summary: Invoke action GetPeersForTrip
-      operationId: People.GetPeersForTrip
+      operationId: People.Person.GetPeersForTrip
       parameters:
         - name: UserName
           in: path
@@ -3338,7 +3338,7 @@ paths:
       tags:
         - People.Actions
       summary: Invoke action ShareTrip
-      operationId: People.ShareTrip
+      operationId: People.Person.ShareTrip
       parameters:
         - name: UserName
           in: path
@@ -3373,7 +3373,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function UpdatePersonLastName
-      operationId: People.UpdatePersonLastName
+      operationId: People.Person.UpdatePersonLastName
       parameters:
         - name: UserName
           in: path
@@ -3666,7 +3666,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: People.Trips.GetInvolvedPeople
+      operationId: People.Person.Trip.Trips.GetInvolvedPeople
       parameters:
         - name: UserName
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -1184,7 +1184,7 @@ paths:
       tags:
         - Me.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: Me.Trip.Trips.GetInvolvedPeople
+      operationId: Me.Trips.Trip.GetInvolvedPeople
       parameters:
         - name: TripId
           in: path
@@ -2411,7 +2411,7 @@ paths:
       tags:
         - NewComePeople.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: NewComePeople.Person.Trip.Trips.GetInvolvedPeople
+      operationId: NewComePeople.Person.Trips.Trip.GetInvolvedPeople
       parameters:
         - name: UserName
           in: path
@@ -3666,7 +3666,7 @@ paths:
       tags:
         - People.Functions
       summary: Invoke function GetInvolvedPeople
-      operationId: People.Person.Trip.Trips.GetInvolvedPeople
+      operationId: People.Person.Trips.Trip.GetInvolvedPeople
       parameters:
         - name: UserName
           in: path


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/97
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/510

- Appends the `EntityType` name of an`ODataKeySegment` in entity action/function paths. This should help in preventing possible duplicate `operationIds` in entity vs entityset action/function paths.
- Tests have been updated to validate this fix.