### PR TITLE
Add support for EdmTypeKind.TypeDefinition

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiExampleGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiExampleGenerator.cs
@@ -175,8 +175,11 @@ namespace Microsoft.OpenApi.OData.Generator
                     array.Add(GetTypeNameForExample(elementType));
                     return array;
 
-                case EdmTypeKind.Untyped:
                 case EdmTypeKind.TypeDefinition:
+                    var typedef = edmTypeReference.AsTypeDefinition().TypeDefinition();
+                    return GetTypeNameForExample(new EdmPrimitiveTypeReference(typedef.UnderlyingType, edmTypeReference.IsNullable));
+
+                case EdmTypeKind.Untyped:
                 case EdmTypeKind.EntityReference:
                 default:
                     throw new OpenApiException("Not support for the type kind " + edmTypeReference.TypeKind());


### PR DESCRIPTION
We have an OData model with TypeDefinition.

```
<TypeDefinition Name="MyID" UnderlyingType="Edm.Int64" />
```

Currently this crashes with `OpenApiException` ("Not supported") in `OpenApiExampleGenerator.GetTypeNameForExample`.

I made a change handling `EdmTypeKind.TypeDefinition` by extracting the underlying (primitive) type. I'm not 100% sure if this is the correct way of handling it, but at least it now doesn't crash and generates valid OpenAPI schema.

Please let me know if I should write tests or make some other changes.