### PR TITLE
Describes path operations descriptions from vocabulary annotations

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationImportOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationImportOperationHandler.cs
@@ -45,6 +45,8 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             operation.Summary = "Invoke " + (EdmOperationImport.IsActionImport() ? "actionImport " : "functionImport ") + EdmOperationImport.Name;
 
+            operation.Description = Context.Model.GetDescriptionAnnotation(EdmOperationImport);
+
             if (Context.Settings.EnableOperationId)
             {
                 if (EdmOperationImport.IsActionImport())

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -61,6 +61,9 @@ namespace Microsoft.OpenApi.OData.Operation
             // Summary
             operation.Summary = "Invoke " + (EdmOperation.IsAction() ? "action " : "function ") + EdmOperation.Name;
 
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(EdmOperation);
+
             // OperationId
             if (Context.Settings.EnableOperationId)
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
@@ -29,14 +29,17 @@ namespace Microsoft.OpenApi.OData.Operation
             // Summary
             operation.Summary = "Delete entity from " + EntitySet.Name;
 
+            IEdmEntityType entityType = EntitySet.EntityType();
+
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(entityType);
+
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
-                string typeName = EntitySet.EntityType().Name;
+                string typeName = entityType.Name;
                 operation.OperationId = EntitySet.Name + "." + typeName + ".Delete" + Utils.UpperFirstChar(typeName);
             }
-
-            base.SetBasicInfo(operation);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -30,14 +30,17 @@ namespace Microsoft.OpenApi.OData.Operation
             // Summary
             operation.Summary = "Get entity from " + EntitySet.Name + " by key";
 
+            IEdmEntityType entityType = EntitySet.EntityType();
+
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(entityType);
+
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
-                string typeName = EntitySet.EntityType().Name;
+                string typeName = entityType.Name;
                 operation.OperationId = EntitySet.Name + "." + typeName + ".Get" + Utils.UpperFirstChar(typeName);
             }
-
-            base.SetBasicInfo(operation);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPatchOperationHandler.cs
@@ -30,14 +30,17 @@ namespace Microsoft.OpenApi.OData.Operation
             // Summary
             operation.Summary = "Update entity in " + EntitySet.Name;
 
+            IEdmEntityType entityType = EntitySet.EntityType();
+
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(entityType);
+
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
-                string typeName = EntitySet.EntityType().Name;
+                string typeName = entityType.Name;
                 operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
             }
-
-            base.SetBasicInfo(operation);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetOperationHandler.cs
@@ -33,6 +33,15 @@ namespace Microsoft.OpenApi.OData.Operation
         }
 
         /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(EntitySet);
+
+            base.SetBasicInfo(operation);
+        }
+
+        /// <inheritdoc/>
         protected override void SetTags(OpenApiOperation operation)
         {
             OpenApiTag tag = new OpenApiTag

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -29,13 +29,11 @@ namespace Microsoft.OpenApi.OData.Operation
             if (IsNavigationPropertyPath)
             {
                 operation.Summary = $"Get media content for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}";
-               // description = Context.Model.GetDescriptionAnnotation(NavigationProperty);
             }
             else
             {
                 IEdmEntityType entityType = EntitySet.EntityType();
                 operation.Summary = $"Get media content for {entityType.Name} from {EntitySet.Name}";
-               // description = Context.Model.GetDescriptionAnnotation(entityType);
             }
 
             // Description

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -28,11 +29,20 @@ namespace Microsoft.OpenApi.OData.Operation
             if (IsNavigationPropertyPath)
             {
                 operation.Summary = $"Get media content for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}";
+               // description = Context.Model.GetDescriptionAnnotation(NavigationProperty);
             }
             else
             {
-                string typeName = EntitySet.EntityType().Name;
-                operation.Summary = $"Get media content for {typeName} from {EntitySet.Name}";
+                IEdmEntityType entityType = EntitySet.EntityType();
+                operation.Summary = $"Get media content for {entityType.Name} from {EntitySet.Name}";
+               // description = Context.Model.GetDescriptionAnnotation(entityType);
+            }
+
+            // Description
+            IEdmVocabularyAnnotatable annotatableElement = GetAnnotatableElement();
+            if (annotatableElement != null)
+            {
+                operation.Description = Context.Model.GetDescriptionAnnotation(annotatableElement);
             }
 
             // OperationId
@@ -41,8 +51,6 @@ namespace Microsoft.OpenApi.OData.Operation
                 string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
                 operation.OperationId = GetOperationId("Get", identifier);
             }
-
-            base.SetBasicInfo(operation);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -31,8 +32,15 @@ namespace Microsoft.OpenApi.OData.Operation
             }
             else
             {
-                string typeName = EntitySet.EntityType().Name;
-                operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
+                IEdmEntityType entityType = EntitySet.EntityType();
+                operation.Summary = $"Update media content for {entityType.Name} in {EntitySet.Name}";
+            }
+
+            // Description
+            IEdmVocabularyAnnotatable annotatableElement = GetAnnotatableElement();
+            if (annotatableElement != null)
+            {
+                operation.Description = Context.Model.GetDescriptionAnnotation(annotatableElement);
             }
 
             // OperationId
@@ -41,8 +49,6 @@ namespace Microsoft.OpenApi.OData.Operation
                 string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
                 operation.OperationId = GetOperationId("Update", identifier);
             }
-
-            base.SetBasicInfo(operation);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -32,8 +32,8 @@ namespace Microsoft.OpenApi.OData.Operation
             }
             else
             {
-                IEdmEntityType entityType = EntitySet.EntityType();
-                operation.Summary = $"Update media content for {entityType.Name} in {EntitySet.Name}";
+                string typeName = EntitySet.EntityType().Name;
+                operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
             }
 
             // Description

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -85,6 +85,15 @@ namespace Microsoft.OpenApi.OData.Operation
         }
 
         /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(NavigationProperty);
+
+            base.SetBasicInfo(operation);
+        }
+
+        /// <inheritdoc/>
         protected override void SetTags(OpenApiOperation operation)
         {
             IList<string> items = new List<string>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonOperationHandler.cs
@@ -33,6 +33,15 @@ namespace Microsoft.OpenApi.OData.Operation
         }
 
         /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(Singleton);
+
+            base.SetBasicInfo(operation);
+        }
+
+        /// <inheritdoc/>
         protected override void SetTags(OpenApiOperation operation)
         {
             // In this SDK, we use "[Singleton Name].[Singleton Entity Type Name]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionImportOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionImportOperationHandlerTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Invoke actionImport ResetDataSource", operation.Summary);
+            Assert.Equal("Resets the data source to default values.", operation.Description);
             Assert.NotNull(operation.Tags);
 
             Assert.NotNull(operation.Parameters);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Invoke action ShareTrip", operation.Summary);
+            Assert.Equal("Details of the shared trip.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Actions", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Invoke functionImport GetPersonWithMostFriends", operation.Summary);
+            Assert.Equal("The person with most friends.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -74,6 +74,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal($"Invoke function {functionName}", operation.Summary);
+            Assert.Equal("Collection of contract attachments.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal($"{entitySetName}.Functions", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityDeleteOperationHandlerTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(delete);
             Assert.Equal("Delete entity from Customers", delete.Summary);
+            Assert.Equal("A business customer.", delete.Description);
             Assert.NotNull(delete.Tags);
             var tag = Assert.Single(delete.Tags);
             Assert.Equal("Customers.Customer", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityGetOperationHandlerTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(get);
             Assert.Equal("Get entity from Customers by key", get.Summary);
+            Assert.Equal("A business customer.", get.Description);
             Assert.NotNull(get.Tags);
             var tag = Assert.Single(get.Tags);
             Assert.Equal("Customers.Customer", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(patch);
             Assert.Equal("Update entity in Customers", patch.Summary);
+            Assert.Equal("A business customer.", patch.Description);
             Assert.NotNull(patch.Tags);
             var tag = Assert.Single(patch.Tags);
             Assert.Equal("Customers.Customer", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetGetOperationHandlerTests.cs
@@ -332,13 +332,16 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
   <edmx:DataServices>
     <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
       <EntityType Name=""Customer"">
+        <Annotation Term=""Org.OData.Core.V1.Description"" String=""A business customer."" />
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
-         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+        <EntitySet Name=""Customers"" EntityType=""NS.Customer"">
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""Collection of business customers."" />
+        </EntitySet>
       </EntityContainer>
       <Annotations Target=""NS.Default/Customers"">
         {0}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -59,6 +59,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(post);
             Assert.Equal("Add new entity to " + entitySet.Name, post.Summary);
+            Assert.Equal("Collection of business customers.", post.Description);
             Assert.NotNull(post.Tags);
             var tag = Assert.Single(post.Tags);
             Assert.Equal("Customers.Customer", tag.Name);
@@ -240,7 +241,9 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
-         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+        <EntitySet Name=""Customers"" EntityType=""NS.Customer"">
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""Collection of business customers."" />
+        </EntitySet>
       </EntityContainer>
       <Annotations Target=""NS.Customer"">
        {1}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 <String>image/png</String>
                 <String>image/jpeg</String>
               </Collection>
-            </Annotation>";
+            </Annotation>
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""The logo image."" />";
 
             // Assert
             VerifyMediaEntityGetOperation("", enableOperationId);
@@ -74,6 +75,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.NotNull(getOperation2);
             Assert.Equal("Get media content for Todo from Todos", getOperation.Summary);
             Assert.Equal("Get media content for the navigation property photo from me", getOperation2.Summary);
+            Assert.Equal("The user's profile photo.", getOperation2.Description);
             Assert.NotNull(getOperation.Tags);
             Assert.NotNull(getOperation2.Tags);
 
@@ -94,6 +96,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.Equal(2, getOperation.Responses[Constants.StatusCode200].Content.Keys.Count);
                 Assert.True(getOperation.Responses[Constants.StatusCode200].Content.ContainsKey("image/png"));
                 Assert.True(getOperation.Responses[Constants.StatusCode200].Content.ContainsKey("image/jpeg"));
+                Assert.Equal("The logo image.", getOperation.Description);
 
                 Assert.Equal(1, getOperation2.Responses[Constants.StatusCode200].Content.Keys.Count);
                 Assert.True(getOperation2.Responses[Constants.StatusCode200].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
@@ -132,7 +135,9 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         <Property Name = ""Description"" Type = ""Edm.String"" />
       </EntityType>
       <EntityType Name=""user"" OpenType=""true"">
-        <NavigationProperty Name = ""photo"" Type = ""microsoft.graph.profilePhoto"" ContainsTarget = ""true"" />
+        <NavigationProperty Name = ""photo"" Type = ""microsoft.graph.profilePhoto"" ContainsTarget = ""true"" >
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""The user's profile photo."" />
+        </NavigationProperty>
       </EntityType>
       <EntityType Name=""profilePhoto"" HasStream=""true"">
         <Property Name = ""height"" Type = ""Edm.Int32"" />

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 <String>image/png</String>
                 <String>image/jpeg</String>
               </Collection>
-            </Annotation>";
+            </Annotation>
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""The logo image."" />";
 
             // Assert
             VerifyMediaEntityPutOperation("", enableOperationId);
@@ -71,6 +72,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.NotNull(putOperation2);
             Assert.Equal("Update media content for Todo in Todos", putOperation.Summary);
             Assert.Equal("Update media content for the navigation property photo in me", putOperation2.Summary);
+            Assert.Equal("The user's profile photo.", putOperation2.Description);
             Assert.NotNull(putOperation.Tags);
             Assert.NotNull(putOperation2.Tags);
 
@@ -91,6 +93,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.Equal(2, putOperation.RequestBody.Content.Keys.Count);
                 Assert.True(putOperation.RequestBody.Content.ContainsKey("image/png"));
                 Assert.True(putOperation.RequestBody.Content.ContainsKey("image/jpeg"));
+                Assert.Equal("The logo image.", putOperation.Description);
 
                 Assert.Equal(1, putOperation2.RequestBody.Content.Keys.Count);
                 Assert.True(putOperation2.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyDeleteOperationHandlerTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Delete navigation property Trips for People", operation.Summary);
+            Assert.Equal("Collection of trips.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Trip", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Get Trips from People", operation.Summary);
+            Assert.Equal("Collection of trips.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Trip", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Update the navigation property BestFriend in People", operation.Summary);
+            Assert.Equal("The best friend.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Person", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Create new navigation property to Trips for People", operation.Summary);
+            Assert.Equal("Collection of trips.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Trip", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefDeleteOperationHandlerTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Delete ref of navigation property Trips for People", operation.Summary);
+            Assert.Equal("Collection of trips.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Trip", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefGetOperationHandlerTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Get ref of Trips from People", operation.Summary);
+            Assert.Equal("Collection of trips.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Trip", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPostOperationHandlerTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Create new navigation property ref to Trips for People", operation.Summary);
+            Assert.Equal("Collection of trips.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Trip", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPutOperationHandlerTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation);
             Assert.Equal("Update the ref of navigation property BestFriend in People", operation.Summary);
+            Assert.Equal("The best friend.", operation.Description);
             Assert.NotNull(operation.Tags);
             var tag = Assert.Single(operation.Tags);
             Assert.Equal("People.Person", tag.Name);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonGetOperationHandlerTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(get);
             Assert.Equal("Get Me", get.Summary);
+            Assert.Equal("My signed-in instance.", get.Description);
             Assert.NotNull(get.Tags);
             var tag = Assert.Single(get.Tags);
             Assert.Equal("Me.Customer", tag.Name);
@@ -249,7 +250,9 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
-         <Singleton Name=""Me"" Type=""NS.Customer"" />
+        <Singleton Name=""Me"" Type=""NS.Customer"">
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""My signed-in instance."" />
+        </Singleton>
       </EntityContainer>
       <Annotations Target=""NS.Default/Me"">
         {0}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -599,6 +599,7 @@
           "People.Person"
         ],
         "summary": "Get entities from People",
+        "description": "People's description.",
         "operationId": "People.Person.ListPerson",
         "produces": [
           "application/json"
@@ -692,6 +693,7 @@
           "People.Person"
         ],
         "summary": "Add new entity to People",
+        "description": "People's description.",
         "operationId": "People.Person.CreatePerson",
         "consumes": [
           "application/json"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -394,6 +394,7 @@ paths:
       tags:
         - People.Person
       summary: Get entities from People
+      description: People's description.
       operationId: People.Person.ListPerson
       produces:
         - application/json
@@ -454,6 +455,7 @@ paths:
       tags:
         - People.Person
       summary: Add new entity to People
+      description: People's description.
       operationId: People.Person.CreatePerson
       consumes:
         - application/json

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -672,6 +672,7 @@
           "People.Person"
         ],
         "summary": "Get entities from People",
+        "description": "People's description.",
         "operationId": "People.Person.ListPerson",
         "parameters": [
           {
@@ -781,6 +782,7 @@
           "People.Person"
         ],
         "summary": "Add new entity to People",
+        "description": "People's description.",
         "operationId": "People.Person.CreatePerson",
         "requestBody": {
           "description": "New entity",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -441,6 +441,7 @@ paths:
       tags:
         - People.Person
       summary: Get entities from People
+      description: People's description.
       operationId: People.Person.ListPerson
       parameters:
         - $ref: '#/components/parameters/top'
@@ -513,6 +514,7 @@ paths:
       tags:
         - People.Person
       summary: Add new entity to People
+      description: People's description.
       operationId: People.Person.CreatePerson
       requestBody:
         description: New entity

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Contract.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Contract.OData.xml
@@ -19,7 +19,7 @@
         <Property Name="size" Type="Edm.Int64" />
         <Property Name="type" Type="Edm.String" />
         <Property Name="date" Type="Edm.DateTimeOffset" />
-        <Property Name="comment" Type="Edm.String" />				
+        <Property Name="comment" Type="Edm.String" />
         </ComplexType>
       <EntityType Name="AccountApiModel" BaseType="Microsoft.OData.Service.Sample.Contract.BaseEntityApiModel">
         <Property Name="priority" Type="Edm.Int32" />
@@ -31,6 +31,7 @@
     </Schema>
     <Schema Namespace="Default" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <Function Name="Attachments" IsBound="true">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Collection of contract attachments." />
         <Parameter Name="bindingParameter" Type="Microsoft.OData.Service.Sample.Contract.BaseEntityApiModel" />
         <ReturnType Type="Collection(Microsoft.OData.Service.Sample.Contract.AttachmentApiModel)" />
       </Function>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -18,8 +18,12 @@
         <Property Name="FavoriteFeature" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature" Nullable="false" />
         <Property Name="Features" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature)" Nullable="false" />
         <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" />
-        <NavigationProperty Name="BestFriend" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" ContainsTarget="true"/>
+        <NavigationProperty Name="BestFriend" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+          <Annotation Term="Org.OData.Core.V1.Description" String="The best friend." />
+        </NavigationProperty>
+        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" ContainsTarget="true">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Collection of trips." />
+        </NavigationProperty>
       </EntityType>
       <EntityType Name="Airline">
         <Key>
@@ -137,6 +141,7 @@
         <ReturnType Type="Edm.Boolean" Nullable="false" />
       </Function>
       <Action Name="ShareTrip" IsBound="true">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Details of the shared trip." />
         <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
         <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
@@ -164,9 +169,13 @@
         <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
         <EntitySet Name="NewComePeople" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Singleton Name="Me" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <FunctionImport Name="GetPersonWithMostFriends" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPersonWithMostFriends" EntitySet="People" />
+        <FunctionImport Name="GetPersonWithMostFriends" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPersonWithMostFriends" EntitySet="People">
+          <Annotation Term="Org.OData.Core.V1.Description" String="The person with most friends." />
+        </FunctionImport>
         <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetNearestAirport" EntitySet="Airports" />
-        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.Service.Sample.TrippinInMemory.Models.ResetDataSource" />
+        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.Service.Sample.TrippinInMemory.Models.ResetDataSource">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Resets the data source to default values." />
+        </ActionImport>
       </EntityContainer>
     </Schema>
   </edmx:DataServices>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -571,6 +571,7 @@
           "People"
         ],
         "summary": "Invoke functionImport GetPersonWithMostFriends",
+        "description": "The person with most friends.",
         "operationId": "FunctionImport.GetPersonWithMostFriends",
         "produces": [
           "application/json"
@@ -691,6 +692,7 @@
           "Me.Person"
         ],
         "summary": "Get BestFriend from Me",
+        "description": "The best friend.",
         "operationId": "Me.GetBestFriend",
         "produces": [
           "application/json"
@@ -757,6 +759,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of BestFriend from Me",
+        "description": "The best friend.",
         "operationId": "Me.GetRefBestFriend",
         "produces": [
           "application/json"
@@ -779,6 +782,7 @@
           "Me.Person"
         ],
         "summary": "Update the ref of navigation property BestFriend in Me",
+        "description": "The best friend.",
         "operationId": "Me.UpdateRefBestFriend",
         "consumes": [
           "application/json"
@@ -812,6 +816,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for Me",
+        "description": "The best friend.",
         "operationId": "Me.DeleteRefBestFriend",
         "parameters": [
           {
@@ -1195,6 +1200,7 @@
           "Me.Actions"
         ],
         "summary": "Invoke action ShareTrip",
+        "description": "Details of the shared trip.",
         "operationId": "Me.ShareTrip",
         "consumes": [
           "application/json"
@@ -1272,6 +1278,7 @@
           "Me.Trip"
         ],
         "summary": "Get Trips from Me",
+        "description": "Collection of trips.",
         "operationId": "Me.ListTrips",
         "produces": [
           "application/json"
@@ -1380,6 +1387,7 @@
           "Me.Trip"
         ],
         "summary": "Create new navigation property to Trips for Me",
+        "description": "Collection of trips.",
         "operationId": "Me.CreateTrips",
         "consumes": [
           "application/json"
@@ -1418,6 +1426,7 @@
           "Me.Trip"
         ],
         "summary": "Get Trips from Me",
+        "description": "Collection of trips.",
         "operationId": "Me.GetTrips",
         "produces": [
           "application/json"
@@ -1486,6 +1495,7 @@
           "Me.Trip"
         ],
         "summary": "Update the navigation property Trips in Me",
+        "description": "Collection of trips.",
         "operationId": "Me.UpdateTrips",
         "consumes": [
           "application/json"
@@ -1527,6 +1537,7 @@
           "Me.Trip"
         ],
         "summary": "Delete navigation property Trips for Me",
+        "description": "Collection of trips.",
         "operationId": "Me.DeleteTrips",
         "parameters": [
           {
@@ -2148,6 +2159,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get BestFriend from NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.GetBestFriend",
         "produces": [
           "application/json"
@@ -2222,6 +2234,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get ref of BestFriend from NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.GetRefBestFriend",
         "produces": [
           "application/json"
@@ -2254,6 +2267,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Update the ref of navigation property BestFriend in NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.UpdateRefBestFriend",
         "consumes": [
           "application/json"
@@ -2295,6 +2309,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.DeleteRefBestFriend",
         "parameters": [
           {
@@ -2736,6 +2751,7 @@
           "NewComePeople.Actions"
         ],
         "summary": "Invoke action ShareTrip",
+        "description": "Details of the shared trip.",
         "operationId": "NewComePeople.Person.ShareTrip",
         "consumes": [
           "application/json"
@@ -2829,6 +2845,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Get Trips from NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.ListTrips",
         "produces": [
           "application/json"
@@ -2945,6 +2962,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Create new navigation property to Trips for NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.CreateTrips",
         "consumes": [
           "application/json"
@@ -2991,6 +3009,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Get Trips from NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.GetTrips",
         "produces": [
           "application/json"
@@ -3067,6 +3086,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Update the navigation property Trips in NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.UpdateTrips",
         "consumes": [
           "application/json"
@@ -3116,6 +3136,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Delete navigation property Trips for NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.DeleteTrips",
         "parameters": [
           {
@@ -3777,6 +3798,7 @@
           "People.Person"
         ],
         "summary": "Get BestFriend from People",
+        "description": "The best friend.",
         "operationId": "People.GetBestFriend",
         "produces": [
           "application/json"
@@ -3851,6 +3873,7 @@
           "People.Person"
         ],
         "summary": "Get ref of BestFriend from People",
+        "description": "The best friend.",
         "operationId": "People.GetRefBestFriend",
         "produces": [
           "application/json"
@@ -3883,6 +3906,7 @@
           "People.Person"
         ],
         "summary": "Update the ref of navigation property BestFriend in People",
+        "description": "The best friend.",
         "operationId": "People.UpdateRefBestFriend",
         "consumes": [
           "application/json"
@@ -3924,6 +3948,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for People",
+        "description": "The best friend.",
         "operationId": "People.DeleteRefBestFriend",
         "parameters": [
           {
@@ -4365,6 +4390,7 @@
           "People.Actions"
         ],
         "summary": "Invoke action ShareTrip",
+        "description": "Details of the shared trip.",
         "operationId": "People.Person.ShareTrip",
         "consumes": [
           "application/json"
@@ -4458,6 +4484,7 @@
           "People.Trip"
         ],
         "summary": "Get Trips from People",
+        "description": "Collection of trips.",
         "operationId": "People.ListTrips",
         "produces": [
           "application/json"
@@ -4574,6 +4601,7 @@
           "People.Trip"
         ],
         "summary": "Create new navigation property to Trips for People",
+        "description": "Collection of trips.",
         "operationId": "People.CreateTrips",
         "consumes": [
           "application/json"
@@ -4620,6 +4648,7 @@
           "People.Trip"
         ],
         "summary": "Get Trips from People",
+        "description": "Collection of trips.",
         "operationId": "People.GetTrips",
         "produces": [
           "application/json"
@@ -4696,6 +4725,7 @@
           "People.Trip"
         ],
         "summary": "Update the navigation property Trips in People",
+        "description": "Collection of trips.",
         "operationId": "People.UpdateTrips",
         "consumes": [
           "application/json"
@@ -4745,6 +4775,7 @@
           "People.Trip"
         ],
         "summary": "Delete navigation property Trips for People",
+        "description": "Collection of trips.",
         "operationId": "People.DeleteTrips",
         "parameters": [
           {
@@ -5104,6 +5135,7 @@
           "ResetDataSource"
         ],
         "summary": "Invoke actionImport ResetDataSource",
+        "description": "Resets the data source to default values.",
         "operationId": "ActionImport.ResetDataSource",
         "responses": {
           "204": {
@@ -5174,6 +5206,7 @@
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
         },
         "Trips": {
+          "description": "Collection of trips.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -380,6 +380,7 @@ paths:
       tags:
         - People
       summary: Invoke functionImport GetPersonWithMostFriends
+      description: The person with most friends.
       operationId: FunctionImport.GetPersonWithMostFriends
       produces:
         - application/json
@@ -465,6 +466,7 @@ paths:
       tags:
         - Me.Person
       summary: Get BestFriend from Me
+      description: The best friend.
       operationId: Me.GetBestFriend
       produces:
         - application/json
@@ -514,6 +516,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of BestFriend from Me
+      description: The best friend.
       operationId: Me.GetRefBestFriend
       produces:
         - application/json
@@ -529,6 +532,7 @@ paths:
       tags:
         - Me.Person
       summary: Update the ref of navigation property BestFriend in Me
+      description: The best friend.
       operationId: Me.UpdateRefBestFriend
       consumes:
         - application/json
@@ -551,6 +555,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property BestFriend for Me
+      description: The best friend.
       operationId: Me.DeleteRefBestFriend
       parameters:
         - in: header
@@ -815,6 +820,7 @@ paths:
       tags:
         - Me.Actions
       summary: Invoke action ShareTrip
+      description: Details of the shared trip.
       operationId: Me.ShareTrip
       consumes:
         - application/json
@@ -867,6 +873,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get Trips from Me
+      description: Collection of trips.
       operationId: Me.ListTrips
       produces:
         - application/json
@@ -942,6 +949,7 @@ paths:
       tags:
         - Me.Trip
       summary: Create new navigation property to Trips for Me
+      description: Collection of trips.
       operationId: Me.CreateTrips
       consumes:
         - application/json
@@ -967,6 +975,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get Trips from Me
+      description: Collection of trips.
       operationId: Me.GetTrips
       produces:
         - application/json
@@ -1017,6 +1026,7 @@ paths:
       tags:
         - Me.Trip
       summary: Update the navigation property Trips in Me
+      description: Collection of trips.
       operationId: Me.UpdateTrips
       consumes:
         - application/json
@@ -1046,6 +1056,7 @@ paths:
       tags:
         - Me.Trip
       summary: Delete navigation property Trips for Me
+      description: Collection of trips.
       operationId: Me.DeleteTrips
       parameters:
         - in: path
@@ -1478,6 +1489,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get BestFriend from NewComePeople
+      description: The best friend.
       operationId: NewComePeople.GetBestFriend
       produces:
         - application/json
@@ -1533,6 +1545,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get ref of BestFriend from NewComePeople
+      description: The best friend.
       operationId: NewComePeople.GetRefBestFriend
       produces:
         - application/json
@@ -1555,6 +1568,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Update the ref of navigation property BestFriend in NewComePeople
+      description: The best friend.
       operationId: NewComePeople.UpdateRefBestFriend
       consumes:
         - application/json
@@ -1583,6 +1597,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Delete ref of navigation property BestFriend for NewComePeople
+      description: The best friend.
       operationId: NewComePeople.DeleteRefBestFriend
       parameters:
         - in: path
@@ -1890,6 +1905,7 @@ paths:
       tags:
         - NewComePeople.Actions
       summary: Invoke action ShareTrip
+      description: Details of the shared trip.
       operationId: NewComePeople.Person.ShareTrip
       consumes:
         - application/json
@@ -1954,6 +1970,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Get Trips from NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.ListTrips
       produces:
         - application/json
@@ -2035,6 +2052,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Create new navigation property to Trips for NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.CreateTrips
       consumes:
         - application/json
@@ -2066,6 +2084,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Get Trips from NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.GetTrips
       produces:
         - application/json
@@ -2122,6 +2141,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Update the navigation property Trips in NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.UpdateTrips
       consumes:
         - application/json
@@ -2157,6 +2177,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Delete navigation property Trips for NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.DeleteTrips
       parameters:
         - in: path
@@ -2619,6 +2640,7 @@ paths:
       tags:
         - People.Person
       summary: Get BestFriend from People
+      description: The best friend.
       operationId: People.GetBestFriend
       produces:
         - application/json
@@ -2674,6 +2696,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of BestFriend from People
+      description: The best friend.
       operationId: People.GetRefBestFriend
       produces:
         - application/json
@@ -2696,6 +2719,7 @@ paths:
       tags:
         - People.Person
       summary: Update the ref of navigation property BestFriend in People
+      description: The best friend.
       operationId: People.UpdateRefBestFriend
       consumes:
         - application/json
@@ -2724,6 +2748,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property BestFriend for People
+      description: The best friend.
       operationId: People.DeleteRefBestFriend
       parameters:
         - in: path
@@ -3031,6 +3056,7 @@ paths:
       tags:
         - People.Actions
       summary: Invoke action ShareTrip
+      description: Details of the shared trip.
       operationId: People.Person.ShareTrip
       consumes:
         - application/json
@@ -3095,6 +3121,7 @@ paths:
       tags:
         - People.Trip
       summary: Get Trips from People
+      description: Collection of trips.
       operationId: People.ListTrips
       produces:
         - application/json
@@ -3176,6 +3203,7 @@ paths:
       tags:
         - People.Trip
       summary: Create new navigation property to Trips for People
+      description: Collection of trips.
       operationId: People.CreateTrips
       consumes:
         - application/json
@@ -3207,6 +3235,7 @@ paths:
       tags:
         - People.Trip
       summary: Get Trips from People
+      description: Collection of trips.
       operationId: People.GetTrips
       produces:
         - application/json
@@ -3263,6 +3292,7 @@ paths:
       tags:
         - People.Trip
       summary: Update the navigation property Trips in People
+      description: Collection of trips.
       operationId: People.UpdateTrips
       consumes:
         - application/json
@@ -3298,6 +3328,7 @@ paths:
       tags:
         - People.Trip
       summary: Delete navigation property Trips for People
+      description: Collection of trips.
       operationId: People.DeleteTrips
       parameters:
         - in: path
@@ -3545,6 +3576,7 @@ paths:
       tags:
         - ResetDataSource
       summary: Invoke actionImport ResetDataSource
+      description: Resets the data source to default values.
       operationId: ActionImport.ResetDataSource
       responses:
         '204':
@@ -3592,6 +3624,7 @@ definitions:
       BestFriend:
         $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
       Trips:
+        description: Collection of trips.
         type: array
         items:
           $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -675,6 +675,7 @@
           "People"
         ],
         "summary": "Invoke functionImport GetPersonWithMostFriends",
+        "description": "The person with most friends.",
         "operationId": "FunctionImport.GetPersonWithMostFriends",
         "responses": {
           "200": {
@@ -809,6 +810,7 @@
           "Me.Person"
         ],
         "summary": "Get BestFriend from Me",
+        "description": "The best friend.",
         "operationId": "Me.GetBestFriend",
         "parameters": [
           {
@@ -886,6 +888,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of BestFriend from Me",
+        "description": "The best friend.",
         "operationId": "Me.GetRefBestFriend",
         "responses": {
           "200": {
@@ -909,6 +912,7 @@
           "Me.Person"
         ],
         "summary": "Update the ref of navigation property BestFriend in Me",
+        "description": "The best friend.",
         "operationId": "Me.UpdateRefBestFriend",
         "requestBody": {
           "description": "New navigation property ref values",
@@ -939,6 +943,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for Me",
+        "description": "The best friend.",
         "operationId": "Me.DeleteRefBestFriend",
         "parameters": [
           {
@@ -1361,6 +1366,7 @@
           "Me.Actions"
         ],
         "summary": "Invoke action ShareTrip",
+        "description": "Details of the shared trip.",
         "operationId": "Me.ShareTrip",
         "requestBody": {
           "description": "Action parameters",
@@ -1438,6 +1444,7 @@
           "Me.Trip"
         ],
         "summary": "Get Trips from Me",
+        "description": "Collection of trips.",
         "operationId": "Me.ListTrips",
         "parameters": [
           {
@@ -1562,6 +1569,7 @@
           "Me.Trip"
         ],
         "summary": "Create new navigation property to Trips for Me",
+        "description": "Collection of trips.",
         "operationId": "Me.CreateTrips",
         "requestBody": {
           "description": "New navigation property",
@@ -1598,6 +1606,7 @@
           "Me.Trip"
         ],
         "summary": "Get Trips from Me",
+        "description": "Collection of trips.",
         "operationId": "Me.GetTrips",
         "parameters": [
           {
@@ -1679,6 +1688,7 @@
           "Me.Trip"
         ],
         "summary": "Update the navigation property Trips in Me",
+        "description": "Collection of trips.",
         "operationId": "Me.UpdateTrips",
         "parameters": [
           {
@@ -1721,6 +1731,7 @@
           "Me.Trip"
         ],
         "summary": "Delete navigation property Trips for Me",
+        "description": "Collection of trips.",
         "operationId": "Me.DeleteTrips",
         "parameters": [
           {
@@ -2414,6 +2425,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get BestFriend from NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.GetBestFriend",
         "parameters": [
           {
@@ -2501,6 +2513,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get ref of BestFriend from NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.GetRefBestFriend",
         "parameters": [
           {
@@ -2536,6 +2549,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Update the ref of navigation property BestFriend in NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.UpdateRefBestFriend",
         "parameters": [
           {
@@ -2578,6 +2592,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for NewComePeople",
+        "description": "The best friend.",
         "operationId": "NewComePeople.DeleteRefBestFriend",
         "parameters": [
           {
@@ -3076,6 +3091,7 @@
           "NewComePeople.Actions"
         ],
         "summary": "Invoke action ShareTrip",
+        "description": "Details of the shared trip.",
         "operationId": "NewComePeople.Person.ShareTrip",
         "parameters": [
           {
@@ -3175,6 +3191,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Get Trips from NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.ListTrips",
         "parameters": [
           {
@@ -3309,6 +3326,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Create new navigation property to Trips for NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.CreateTrips",
         "parameters": [
           {
@@ -3357,6 +3375,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Get Trips from NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.GetTrips",
         "parameters": [
           {
@@ -3448,6 +3467,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Update the navigation property Trips in NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.UpdateTrips",
         "parameters": [
           {
@@ -3500,6 +3520,7 @@
           "NewComePeople.Trip"
         ],
         "summary": "Delete navigation property Trips for NewComePeople",
+        "description": "Collection of trips.",
         "operationId": "NewComePeople.DeleteTrips",
         "parameters": [
           {
@@ -4243,6 +4264,7 @@
           "People.Person"
         ],
         "summary": "Get BestFriend from People",
+        "description": "The best friend.",
         "operationId": "People.GetBestFriend",
         "parameters": [
           {
@@ -4330,6 +4352,7 @@
           "People.Person"
         ],
         "summary": "Get ref of BestFriend from People",
+        "description": "The best friend.",
         "operationId": "People.GetRefBestFriend",
         "parameters": [
           {
@@ -4365,6 +4388,7 @@
           "People.Person"
         ],
         "summary": "Update the ref of navigation property BestFriend in People",
+        "description": "The best friend.",
         "operationId": "People.UpdateRefBestFriend",
         "parameters": [
           {
@@ -4407,6 +4431,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for People",
+        "description": "The best friend.",
         "operationId": "People.DeleteRefBestFriend",
         "parameters": [
           {
@@ -4905,6 +4930,7 @@
           "People.Actions"
         ],
         "summary": "Invoke action ShareTrip",
+        "description": "Details of the shared trip.",
         "operationId": "People.Person.ShareTrip",
         "parameters": [
           {
@@ -5004,6 +5030,7 @@
           "People.Trip"
         ],
         "summary": "Get Trips from People",
+        "description": "Collection of trips.",
         "operationId": "People.ListTrips",
         "parameters": [
           {
@@ -5138,6 +5165,7 @@
           "People.Trip"
         ],
         "summary": "Create new navigation property to Trips for People",
+        "description": "Collection of trips.",
         "operationId": "People.CreateTrips",
         "parameters": [
           {
@@ -5186,6 +5214,7 @@
           "People.Trip"
         ],
         "summary": "Get Trips from People",
+        "description": "Collection of trips.",
         "operationId": "People.GetTrips",
         "parameters": [
           {
@@ -5277,6 +5306,7 @@
           "People.Trip"
         ],
         "summary": "Update the navigation property Trips in People",
+        "description": "Collection of trips.",
         "operationId": "People.UpdateTrips",
         "parameters": [
           {
@@ -5329,6 +5359,7 @@
           "People.Trip"
         ],
         "summary": "Delete navigation property Trips for People",
+        "description": "Collection of trips.",
         "operationId": "People.DeleteTrips",
         "parameters": [
           {
@@ -5738,6 +5769,7 @@
           "ResetDataSource"
         ],
         "summary": "Invoke actionImport ResetDataSource",
+        "description": "Resets the data source to default values.",
         "operationId": "ActionImport.ResetDataSource",
         "responses": {
           "204": {
@@ -5845,13 +5877,15 @@
                 "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
               }
             ],
+            "description": "The best friend.",
             "nullable": true
           },
           "Trips": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
-            }
+            },
+            "description": "Collection of trips."
           }
         }
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -438,6 +438,7 @@ paths:
       tags:
         - People
       summary: Invoke functionImport GetPersonWithMostFriends
+      description: The person with most friends.
       operationId: FunctionImport.GetPersonWithMostFriends
       responses:
         '200':
@@ -531,6 +532,7 @@ paths:
       tags:
         - Me.Person
       summary: Get BestFriend from Me
+      description: The best friend.
       operationId: Me.GetBestFriend
       parameters:
         - name: $select
@@ -588,6 +590,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of BestFriend from Me
+      description: The best friend.
       operationId: Me.GetRefBestFriend
       responses:
         '200':
@@ -603,6 +606,7 @@ paths:
       tags:
         - Me.Person
       summary: Update the ref of navigation property BestFriend in Me
+      description: The best friend.
       operationId: Me.UpdateRefBestFriend
       requestBody:
         description: New navigation property ref values
@@ -623,6 +627,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property BestFriend for Me
+      description: The best friend.
       operationId: Me.DeleteRefBestFriend
       parameters:
         - name: If-Match
@@ -907,6 +912,7 @@ paths:
       tags:
         - Me.Actions
       summary: Invoke action ShareTrip
+      description: Details of the shared trip.
       operationId: Me.ShareTrip
       requestBody:
         description: Action parameters
@@ -958,6 +964,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get Trips from Me
+      description: Collection of trips.
       operationId: Me.ListTrips
       parameters:
         - $ref: '#/components/parameters/top'
@@ -1045,6 +1052,7 @@ paths:
       tags:
         - Me.Trip
       summary: Create new navigation property to Trips for Me
+      description: Collection of trips.
       operationId: Me.CreateTrips
       requestBody:
         description: New navigation property
@@ -1068,6 +1076,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get Trips from Me
+      description: Collection of trips.
       operationId: Me.GetTrips
       parameters:
         - name: TripId
@@ -1127,6 +1136,7 @@ paths:
       tags:
         - Me.Trip
       summary: Update the navigation property Trips in Me
+      description: Collection of trips.
       operationId: Me.UpdateTrips
       parameters:
         - name: TripId
@@ -1156,6 +1166,7 @@ paths:
       tags:
         - Me.Trip
       summary: Delete navigation property Trips for Me
+      description: Collection of trips.
       operationId: Me.DeleteTrips
       parameters:
         - name: TripId
@@ -1632,6 +1643,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get BestFriend from NewComePeople
+      description: The best friend.
       operationId: NewComePeople.GetBestFriend
       parameters:
         - name: UserName
@@ -1696,6 +1708,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get ref of BestFriend from NewComePeople
+      description: The best friend.
       operationId: NewComePeople.GetRefBestFriend
       parameters:
         - name: UserName
@@ -1719,6 +1732,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Update the ref of navigation property BestFriend in NewComePeople
+      description: The best friend.
       operationId: NewComePeople.UpdateRefBestFriend
       parameters:
         - name: UserName
@@ -1747,6 +1761,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Delete ref of navigation property BestFriend for NewComePeople
+      description: The best friend.
       operationId: NewComePeople.DeleteRefBestFriend
       parameters:
         - name: UserName
@@ -2083,6 +2098,7 @@ paths:
       tags:
         - NewComePeople.Actions
       summary: Invoke action ShareTrip
+      description: Details of the shared trip.
       operationId: NewComePeople.Person.ShareTrip
       parameters:
         - name: UserName
@@ -2149,6 +2165,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Get Trips from NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.ListTrips
       parameters:
         - name: UserName
@@ -2243,6 +2260,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Create new navigation property to Trips for NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.CreateTrips
       parameters:
         - name: UserName
@@ -2274,6 +2292,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Get Trips from NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.GetTrips
       parameters:
         - name: UserName
@@ -2340,6 +2359,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Update the navigation property Trips in NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.UpdateTrips
       parameters:
         - name: UserName
@@ -2376,6 +2396,7 @@ paths:
       tags:
         - NewComePeople.Trip
       summary: Delete navigation property Trips for NewComePeople
+      description: Collection of trips.
       operationId: NewComePeople.DeleteTrips
       parameters:
         - name: UserName
@@ -2887,6 +2908,7 @@ paths:
       tags:
         - People.Person
       summary: Get BestFriend from People
+      description: The best friend.
       operationId: People.GetBestFriend
       parameters:
         - name: UserName
@@ -2951,6 +2973,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of BestFriend from People
+      description: The best friend.
       operationId: People.GetRefBestFriend
       parameters:
         - name: UserName
@@ -2974,6 +2997,7 @@ paths:
       tags:
         - People.Person
       summary: Update the ref of navigation property BestFriend in People
+      description: The best friend.
       operationId: People.UpdateRefBestFriend
       parameters:
         - name: UserName
@@ -3002,6 +3026,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property BestFriend for People
+      description: The best friend.
       operationId: People.DeleteRefBestFriend
       parameters:
         - name: UserName
@@ -3338,6 +3363,7 @@ paths:
       tags:
         - People.Actions
       summary: Invoke action ShareTrip
+      description: Details of the shared trip.
       operationId: People.Person.ShareTrip
       parameters:
         - name: UserName
@@ -3404,6 +3430,7 @@ paths:
       tags:
         - People.Trip
       summary: Get Trips from People
+      description: Collection of trips.
       operationId: People.ListTrips
       parameters:
         - name: UserName
@@ -3498,6 +3525,7 @@ paths:
       tags:
         - People.Trip
       summary: Create new navigation property to Trips for People
+      description: Collection of trips.
       operationId: People.CreateTrips
       parameters:
         - name: UserName
@@ -3529,6 +3557,7 @@ paths:
       tags:
         - People.Trip
       summary: Get Trips from People
+      description: Collection of trips.
       operationId: People.GetTrips
       parameters:
         - name: UserName
@@ -3595,6 +3624,7 @@ paths:
       tags:
         - People.Trip
       summary: Update the navigation property Trips in People
+      description: Collection of trips.
       operationId: People.UpdateTrips
       parameters:
         - name: UserName
@@ -3631,6 +3661,7 @@ paths:
       tags:
         - People.Trip
       summary: Delete navigation property Trips for People
+      description: Collection of trips.
       operationId: People.DeleteTrips
       parameters:
         - name: UserName
@@ -3906,6 +3937,7 @@ paths:
       tags:
         - ResetDataSource
       summary: Invoke actionImport ResetDataSource
+      description: Resets the data source to default values.
       operationId: ActionImport.ResetDataSource
       responses:
         '204':
@@ -3968,11 +4000,13 @@ components:
         BestFriend:
           anyOf:
             - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+          description: The best friend.
           nullable: true
         Trips:
           type: array
           items:
             $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+          description: Collection of trips.
     Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline:
       title: Airline
       type: object


### PR DESCRIPTION
Closes https://github.com/microsoft/OpenAPI.NET.OData/issues/103
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/529

- Retrieves operation descriptions from vocabulary annotations of `IEdmVocabularyAnnotatable` elements.
- Tests have been updated to validate this feature.