### PR TITLE
[Fix] Generate paths for stream properties in base types of entities

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -219,7 +219,7 @@ namespace Microsoft.OpenApi.OData.Edm
             Debug.Assert(currentPath != null);
 
             bool createValuePath = true;
-            foreach (IEdmStructuralProperty sp in entityType.DeclaredStructuralProperties())
+            foreach (IEdmStructuralProperty sp in entityType.StructuralProperties())
             {
                 if (sp.Type.AsPrimitive().IsStream())
                 {
@@ -228,7 +228,7 @@ namespace Microsoft.OpenApi.OData.Edm
                     currentPath.Pop();
                 }
 
-                if (sp.Name.Equals("content", System.StringComparison.OrdinalIgnoreCase))
+                if (sp.Name.Equals("content", StringComparison.OrdinalIgnoreCase))
                 {
                     createValuePath = false;
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -26,15 +26,9 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary
-            if (IsNavigationPropertyPath)
-            {
-                operation.Summary = $"Get media content for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}";
-            }
-            else
-            {
-                IEdmEntityType entityType = EntitySet.EntityType();
-                operation.Summary = $"Get media content for {entityType.Name} from {EntitySet.Name}";
-            }
+            operation.Summary = IsNavigationPropertyPath
+                ? $"Get media content for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}"
+                : $"Get media content for {NavigationSourceSegment.EntityType.Name} from {NavigationSourceSegment.Identifier}";
 
             // Description
             IEdmVocabularyAnnotatable annotatableElement = GetAnnotatableElement();
@@ -73,9 +67,8 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            ReadRestrictionsType read = EntitySet != null
-                ? Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions)
-                : Context.Model.GetRecord<ReadRestrictionsType>(Singleton, CapabilitiesConstants.ReadRestrictions);
+            IEdmVocabularyAnnotatable annotatableNavigationSource = (IEdmVocabularyAnnotatable)NavigationSourceSegment.NavigationSource;
+            ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(annotatableNavigationSource, CapabilitiesConstants.ReadRestrictions);
             if (read == null)
             {
                 return;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -26,15 +26,9 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary
-            if (IsNavigationPropertyPath)
-            {
-                operation.Summary = $"Update media content for the navigation property {NavigationProperty.Name} in {NavigationSource.Name}";
-            }
-            else
-            {
-                string typeName = EntitySet.EntityType().Name;
-                operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
-            }
+            operation.Summary = IsNavigationPropertyPath
+                ? $"Update media content for the navigation property {NavigationProperty.Name} in {NavigationSource.Name}"
+                : $"Update media content for {NavigationSourceSegment.EntityType.Name} in {NavigationSourceSegment.Identifier}";
 
             // Description
             IEdmVocabularyAnnotatable annotatableElement = GetAnnotatableElement();
@@ -79,9 +73,8 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            UpdateRestrictionsType update = EntitySet != null
-                ? Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions)
-                : Context.Model.GetRecord<UpdateRestrictionsType>(Singleton, CapabilitiesConstants.UpdateRestrictions);
+            IEdmVocabularyAnnotatable annotatableNavigationSource = (IEdmVocabularyAnnotatable)NavigationSourceSegment.NavigationSource;
+            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(annotatableNavigationSource, CapabilitiesConstants.UpdateRestrictions);
             if (update == null || update.Permissions == null)
             {
                 return;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -450,41 +450,52 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         }
 
         [Theory]
-        [InlineData(true, "Logo")]
-        [InlineData(false, "Logo")]
-        [InlineData(true, "Content")]
-        [InlineData(false, "Content")]
+        [InlineData(true, "logo")]
+        [InlineData(false, "logo")]
+        [InlineData(true, "content")]
+        [InlineData(false, "content")]
         public void GetPathsWithStreamPropertyAndWithEntityHasStreamWorks(bool hasStream, string streamPropName)
         {
             // Arrange
             IEdmModel model = GetEdmModel(hasStream, streamPropName);
             ODataPathProvider provider = new ODataPathProvider();
             var settings = new OpenApiConvertSettings();
+            const string TodosContentPath = "/todos({id})/content";
+            const string TodosValuePath = "/todos({id})/$value";
+            const string TodosLogoPath = "/todos({id})/logo";
 
             // Act
-            var paths = provider.GetPaths(model,settings);
+            var paths = provider.GetPaths(model, settings);
 
             // Assert
             Assert.NotNull(paths);
+            Assert.Contains("/catalog/content", paths.Select(p => p.GetPathItemName()));
+            Assert.Contains("/catalog/thumbnailPhoto", paths.Select(p => p.GetPathItemName()));
+            Assert.Contains("/me/photo/$value", paths.Select(p => p.GetPathItemName()));
 
-            if (hasStream && !streamPropName.Equals("Content", StringComparison.OrdinalIgnoreCase))
+            if (streamPropName.Equals("logo"))
             {
-                Assert.Equal(7, paths.Count());
-                Assert.Equal(new[] { "/me", "/me/photo", "/me/photo/$value", "/Todos", "/Todos({Id})", "/Todos({Id})/$value", "/Todos({Id})/Logo" },
-                    paths.Select(p => p.GetPathItemName()));
+                if (hasStream)
+                {
+                    Assert.Equal(12, paths.Count());
+                    Assert.Contains(TodosValuePath, paths.Select(p => p.GetPathItemName()));
+                    Assert.Contains(TodosLogoPath, paths.Select(p => p.GetPathItemName()));
+                    Assert.DoesNotContain(TodosContentPath, paths.Select(p => p.GetPathItemName()));
+                }
+                else
+                {
+                    Assert.Equal(11, paths.Count());
+                    Assert.Contains(TodosLogoPath, paths.Select(p => p.GetPathItemName()));
+                    Assert.DoesNotContain(TodosContentPath, paths.Select(p => p.GetPathItemName()));
+                    Assert.DoesNotContain(TodosValuePath, paths.Select(p => p.GetPathItemName()));
+                }
             }
-            else if ((hasStream && streamPropName.Equals("Content", StringComparison.OrdinalIgnoreCase)) ||
-                    (!hasStream && streamPropName.Equals("Content", StringComparison.OrdinalIgnoreCase)))
+            else if (streamPropName.Equals("content"))
             {
-                Assert.Equal(6, paths.Count());
-                Assert.Equal(new[] { "/me", "/me/photo", "/me/photo/$value", "/Todos", "/Todos({Id})", "/Todos({Id})/Content" },
-                    paths.Select(p => p.GetPathItemName()));
-            }
-            else // !hasStream && !streamPropName.Equals("Content")
-            {
-                Assert.Equal(6, paths.Count());
-                Assert.Equal(new[] { "/me", "/me/photo", "/me/photo/$value", "/Todos", "/Todos({Id})", "/Todos({Id})/Logo"},
-                    paths.Select(p => p.GetPathItemName()));
+                Assert.Equal(11, paths.Count());
+                Assert.Contains(TodosContentPath, paths.Select(p => p.GetPathItemName()));
+                Assert.DoesNotContain(TodosLogoPath, paths.Select(p => p.GetPathItemName()));
+                Assert.DoesNotContain(TodosValuePath, paths.Select(p => p.GetPathItemName()));
             }
         }
 
@@ -576,13 +587,13 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""microsoft.graph"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
-      <EntityType Name=""Todo"" HasStream=""{0}"">
+      <EntityType Name=""todo"" HasStream=""{0}"">
         <Key>
-          <PropertyRef Name=""Id"" />
+          <PropertyRef Name=""id"" />
         </Key>
-        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""id"" Type=""Edm.Int32"" Nullable=""false"" />
         <Property Name=""{1}"" Type=""Edm.Stream""/>
-        <Property Name = ""Description"" Type = ""Edm.String"" />
+        <Property Name = ""description"" Type = ""Edm.String"" />
       </EntityType>
       <EntityType Name=""user"" OpenType=""true"">
         <NavigationProperty Name = ""photo"" Type = ""microsoft.graph.profilePhoto"" ContainsTarget = ""true"" />
@@ -591,9 +602,17 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         <Property Name = ""height"" Type = ""Edm.Int32"" />
         <Property Name = ""width"" Type = ""Edm.Int32"" />
       </EntityType >
+      <EntityType Name=""document"">
+        <Property Name=""content"" Type=""Edm.Stream""/>
+        <Property Name=""thumbnailPhoto"" Type=""Edm.Stream""/>
+      </EntityType>
+      <EntityType Name=""catalog"" BaseType=""microsoft.graph.document"">
+        <NavigationProperty Name=""reports"" Type = ""Collection(microsoft.graph.report)"" />
+      </EntityType>
       <EntityContainer Name =""GraphService"">
-        <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+        <EntitySet Name=""todos"" EntityType=""microsoft.graph.todo"" />
         <Singleton Name=""me"" Type=""microsoft.graph.user"" />
+        <Singleton Name=""catalog"" Type=""microsoft.graph.catalog"" />
       </EntityContainer>
     </Schema>
   </edmx:DataServices>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -55,13 +55,13 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.NotNull(me);
 
             IEdmEntityType todo = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Todo");
-            IEdmStructuralProperty sp = todo.DeclaredStructuralProperties().First(c => c.Name == "Logo");
+            IEdmStructuralProperty sp = todo.StructuralProperties().First(c => c.Name == "Logo");
             ODataPath path = new ODataPath(new ODataNavigationSourceSegment(todos),
                 new ODataKeySegment(todos.EntityType()),
                 new ODataStreamPropertySegment(sp.Name));
 
             IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
-            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "photo");
+            IEdmNavigationProperty navProperty = user.NavigationProperties().First(c => c.Name == "photo");
             ODataPath path2 = new ODataPath(new ODataNavigationSourceSegment(me),
                 new ODataNavigationPropertySegment(navProperty),
                 new ODataStreamContentSegment());

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -52,13 +52,13 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.NotNull(todos);
 
             IEdmEntityType todo = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Todo");
-            IEdmStructuralProperty sp = todo.DeclaredStructuralProperties().First(c => c.Name == "Logo");
+            IEdmStructuralProperty sp = todo.StructuralProperties().First(c => c.Name == "Logo");
             ODataPath path = new ODataPath(new ODataNavigationSourceSegment(todos),
                 new ODataKeySegment(todos.EntityType()),
                 new ODataStreamPropertySegment(sp.Name));
 
             IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
-            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "photo");
+            IEdmNavigationProperty navProperty = user.NavigationProperties().First(c => c.Name == "photo");
             ODataPath path2 = new ODataPath(new ODataNavigationSourceSegment(me),
                 new ODataNavigationPropertySegment(navProperty),
                 new ODataStreamContentSegment());


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/109
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/637

This PR:
- Updates the `ODataPathProvider.cs` to ensure  generation of paths for stream properties declared both in the target type definitions and their base types. 
- Updates the `ODataPathProviderTests.cs` to validate the above. Also refactors the target test for readability and conciseness.
- Refactors the `MediaEntityOperationalHandler.cs` class and its derived classes to use the abstraction - 
`ODataNavigationSourceSegment` to define the `NavigationSourceSegment` for a path. This helps in general maintainability and code conciseness.