### PR TITLE
[Enhancement] Creates DELETE operation for collection-valued nav. props $ref paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -274,17 +274,14 @@ namespace Microsoft.OpenApi.OData.Edm
 
             if (restriction == null || restriction.IndexableByKey == true)
             {
-                IEdmEntityType navEntityType = navigationProperty.ToEntityType();
+              //  IEdmEntityType navEntityType = navigationProperty.ToEntityType();
 
-                if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
-                {
-                    // Append a navigation property key.
-                    currentPath.Push(new ODataKeySegment(navEntityType));
-                    AppendPath(currentPath.Clone());
-                }
-
-                // Get possible stream paths for the navigation entity type
-                RetrieveMediaEntityStreamPaths(navEntityType, currentPath);
+                //if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
+                //{
+                //    // Append a navigation property key.
+                //    currentPath.Push(new ODataKeySegment(navEntityType));
+                //    AppendPath(currentPath.Clone());
+                //}
 
                 if (!navigationProperty.ContainsTarget)
                 {
@@ -294,9 +291,34 @@ namespace Microsoft.OpenApi.OData.Edm
                     ODataPath newPath = currentPath.Clone();
                     newPath.Push(ODataRefSegment.Instance); // $ref
                     AppendPath(newPath);
+
+                    if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
+                    {
+
+                    }
                 }
                 else
                 {
+                    IEdmEntityType navEntityType = navigationProperty.ToEntityType();
+
+                    // append a navigation property key.
+                    if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
+                    {
+                        currentPath.Push(new ODataKeySegment(navEntityType));
+                        AppendPath(currentPath.Clone());
+
+                        if (!navigationProperty.ContainsTarget)
+                        {
+                            // TODO: Shall we add "$ref" after {key}, and only support delete?
+                            // ODataPath newPath = currentPath.Clone();
+                            // newPath.Push(ODataRefSegment.Instance); // $ref
+                            // AppendPath(newPath);
+                        }
+                    }
+
+                    // Get possible stream paths for the navigation entity type
+                    RetrieveMediaEntityStreamPaths(navEntityType, currentPath);
+
                     if (shouldExpand)
                     {
                         // expand to sub navigation properties
@@ -308,11 +330,11 @@ namespace Microsoft.OpenApi.OData.Edm
                             }
                         }
                     }
-                }
 
-                if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
-                {
-                    currentPath.Pop();
+                    if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
+                    {
+                        currentPath.Pop();
+                    }
                 }
             }
             currentPath.Pop();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -285,9 +285,8 @@ namespace Microsoft.OpenApi.OData.Edm
 
                     if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
                     {
-                        CreateEntityPath(navEntityType, currentPath);
-
                         // Collection-valued: DELETE ~/entityset/{key}/collection-valued-Nav/{key}/$ref
+                        currentPath.Push(new ODataKeySegment(navEntityType));
                         CreateRefPath(currentPath);
                     }
 
@@ -299,7 +298,8 @@ namespace Microsoft.OpenApi.OData.Edm
                     // append a navigation property key.
                     if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
                     {
-                        CreateEntityPath(navEntityType, currentPath);
+                        currentPath.Push(new ODataKeySegment(navEntityType));
+                        AppendPath(currentPath.Clone());
                     }
 
                     // Get possible stream paths for the navigation entity type
@@ -359,17 +359,6 @@ namespace Microsoft.OpenApi.OData.Edm
             ODataPath newPath = currentPath.Clone();
             newPath.Push(ODataRefSegment.Instance); // $ref
             AppendPath(newPath);
-        }
-
-        /// <summary>
-        /// Create entity paths.
-        /// </summary>
-        /// <param name="entityType">The entity type.</param>
-        /// <param name="currentPath">The current OData path.</param>
-        private void CreateEntityPath(IEdmEntityType entityType, ODataPath currentPath)
-        {
-            currentPath.Push(new ODataKeySegment(entityType));
-            AppendPath(currentPath.Clone());
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
@@ -84,6 +84,8 @@ namespace Microsoft.OpenApi.OData.PathItem
                 {
                     AddOperation(item, OperationType.Post);
                 }
+
+                // TODO: Add delete operation
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17313, paths.Count());
+            Assert.Equal(17401, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(13642, paths.Count());
+            Assert.Equal(13730, paths.Count());
         }
 
         [Fact]
@@ -409,13 +409,14 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(8, paths.Count());
+            Assert.Equal(9, paths.Count());
 
             var pathItems = paths.Select(p => p.GetPathItemName()).ToList();
             Assert.Contains("/Orders({id})/MultipleCustomers", pathItems);
             Assert.Contains("/Orders({id})/SingleCustomer", pathItems);
             Assert.Contains("/Orders({id})/SingleCustomer/$ref", pathItems);
             Assert.Contains("/Orders({id})/MultipleCustomers/$ref", pathItems);
+            Assert.Contains("/Orders({id})/MultipleCustomers({ID})/$ref", pathItems);
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Theory]
+        [InlineData(true, new OperationType[] { OperationType.Delete})]
         [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Post})]
         [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
         public void CreateNavigationPropertyRefPathItemReturnsCorrectPathItem(bool collectionNav, OperationType[] expected)
@@ -73,10 +74,23 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
                 (collectionNav ? c.TargetMultiplicity() == EdmMultiplicity.Many : c.TargetMultiplicity() != EdmMultiplicity.Many));
             Assert.NotNull(property);
 
-            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet),
+            ODataPath path;
+            if (collectionNav && expected.Contains(OperationType.Delete))
+            {
+                // DELETE ~/entityset/{key}/collection-valued-Nav/{key}/$ref
+                path = new ODataPath(new ODataNavigationSourceSegment(entitySet),
+                new ODataKeySegment(entityType),
+                new ODataNavigationPropertySegment(property),
+                new ODataKeySegment(property.ToEntityType()),
+                ODataRefSegment.Instance);
+            }
+            else
+            {
+                path = new ODataPath(new ODataNavigationSourceSegment(entitySet),
                 new ODataKeySegment(entityType),
                 new ODataNavigationPropertySegment(property),
                 ODataRefSegment.Instance);
+            }
 
             // Act
             var pathItem = _pathItemHandler.CreatePathItem(context, path);


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/111
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/567

This PR:
- Updates the `ODataPathProvider.cs` class to ensure generation of collection-valued nav. props `$ref` paths with `ODataKeySegment` before the `$ref` segment
- Updates the `ODataPathProviderTests.cs` to validate the above.
- Updates the `RefPathItemHandler.cs` class to ensure generation of DELETE operations for the above paths. Refactors operation generation into separate methods.
- Updates `RefPathItemHandlerTests.cs` test class to validate the above.

