### PR TITLE
Fixes structured & collection-valued parameters of functions

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -94,13 +94,28 @@ namespace Microsoft.OpenApi.OData.Generator
                         Name = parameterNameMapping == null ? edmParameter.Name : parameterNameMapping[edmParameter.Name],
                         In = ParameterLocation.Query, // as query option
                         Required = true,
-                        Schema = new OpenApiSchema
-                        {
-                            Type = "string",
 
-                            // These Parameter Objects optionally can contain the field description,
-                            // whose value is the value of the unqualified annotation Core.Description of the parameter.
-                            Description = context.Model.GetDescriptionAnnotation(edmParameter)
+                        // Create schema in the Content property to indicate that the parameters are serialized as JSON
+                        Content = new Dictionary<string, OpenApiMediaType>
+                        {
+                            {
+                                Constants.ApplicationJsonMediaType,
+                                new OpenApiMediaType
+                                {
+                                    Schema = new OpenApiSchema
+                                    {
+                                        Type = "array",
+                                        Items = new OpenApiSchema
+                                        {
+                                            Type = "string"
+                                        },
+
+                                        // These Parameter Objects optionally can contain the field description,
+                                        // whose value is the value of the unqualified annotation Core.Description of the parameter.
+                                        Description = context.Model.GetDescriptionAnnotation(edmParameter)
+                                    }
+                                }
+                            }
                         },
 
                         // The parameter description describes the format this URL-encoded JSON object or array, and/or reference to [OData-URL].

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Graph.Beta.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Graph.Beta.OData.xml
@@ -9356,6 +9356,16 @@
                 <Property Name="failureCategory" Type="microsoft.graph.deviceEnrollmentFailureReason" Nullable="false" />
                 <Property Name="failureReason" Type="Edm.String" Unicode="false" />
             </EntityType>
+            <Function Name="getRoleScopeTagsByIds" IsBound="true">
+              <Parameter Name="bindingParameter" Type="graph.deviceManagement" />
+              <Parameter Name="ids" Type="Collection(Edm.String)" Unicode="false" />
+              <ReturnType Type="Collection(graph.roleScopeTag)" />
+            </Function>
+            <Function Name="getRoleScopeTagsByResource" IsBound="true">
+              <Parameter Name="bindingParameter" Type="graph.deviceManagement" />
+              <Parameter Name="resource" Type="Edm.String" Unicode="false" />
+              <ReturnType Type="Collection(graph.roleScopeTag)" />
+            </Function>
             <Function Name="delta" IsBound="true">
                 <Parameter Name="bindingParameter" Type="Collection(microsoft.graph.user)" />
                 <ReturnType Type="Collection(microsoft.graph.user)" />


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/122

This PR:
- Adds a `Content` property and a media type object to the structured & collection-valued parameters property of functions to indicate that the parameter values are serialized as JSON.
- Adds test for the above.