### PR TITLE
fixes a bug where OData Count path items would be missing from the description

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,16 @@
    "version": "0.2.0",
    "configurations": [
         {
+            "name": "Launch Update Docs",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/tool/UpdateDocs/bin/Debug/net6.0/UpdateDocs.dll",
+            "cwd": "${workspaceFolder}/tool/UpdateDocs/bin/Debug/net6.0",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",

--- a/Microsoft.OpenApi.OData.sln
+++ b/Microsoft.OpenApi.OData.sln
@@ -16,6 +16,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tool", "tool", "{DE8F8E75-A119-4CF3-AFDD-4132B55DAE76}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UpdateDocs", "tool\UpdateDocs\UpdateDocs.csproj", "{AAC31ECB-05F9-444A-9B86-42ECD50AA468}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,11 +42,18 @@ Global
 		{79B190E8-EDB0-4C03-8FD8-EB48E4807CFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79B190E8-EDB0-4C03-8FD8-EB48E4807CFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79B190E8-EDB0-4C03-8FD8-EB48E4807CFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAC31ECB-05F9-444A-9B86-42ECD50AA468}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAC31ECB-05F9-444A-9B86-42ECD50AA468}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAC31ECB-05F9-444A-9B86-42ECD50AA468}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAC31ECB-05F9-444A-9B86-42ECD50AA468}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9AE22713-F94E-45CA-81F4-0806CA195B69}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{AAC31ECB-05F9-444A-9B86-42ECD50AA468} = {DE8F8E75-A119-4CF3-AFDD-4132B55DAE76}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -79,6 +79,7 @@ namespace Microsoft.OpenApi.OData.Common
         /// extension for discriminator value support
         /// </summary>
         public static string xMsDiscriminatorValue = "x-ms-discriminator-value";
+
         /// <summary>
         /// Name used for the OpenAPI referenced schema for OData Count operations responses.
         /// </summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -79,5 +79,9 @@ namespace Microsoft.OpenApi.OData.Common
         /// extension for discriminator value support
         /// </summary>
         public static string xMsDiscriminatorValue = "x-ms-discriminator-value";
+        /// <summary>
+        /// Name used for the OpenAPI referenced schema for OData Count operations responses.
+        /// </summary>
+        public static string DollarCountSchemaName = "ODataCountResponse";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
@@ -12,6 +12,10 @@ namespace Microsoft.OpenApi.OData.Edm
     /// </summary>
     public class ODataDollarCountSegment : ODataSegment
     {
+        /// <summary>
+        /// Get the static instance of $count segment.
+        /// </summary>
+        internal static ODataDollarCountSegment Instance = new();
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.DollarCount;
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
@@ -16,6 +16,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// Get the static instance of $count segment.
         /// </summary>
         internal static ODataDollarCountSegment Instance = new();
+
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.DollarCount;
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
@@ -146,8 +146,8 @@ namespace Microsoft.OpenApi.OData.Edm
 
             // From Open API spec, parameter name is case sensitive, so don't use the IgnoreCase HashSet.
             // HashSet<string> parameters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            HashSet<string> parameters = new HashSet<string>();
-            StringBuilder sb = new StringBuilder();
+            HashSet<string> parameters = new();
+            StringBuilder sb = new();
 
             if (!string.IsNullOrWhiteSpace(settings.PathPrefix))
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.OData.Edm
            {
                if (CanFilter(entitySet))
                {
-                   RetrieveNavigationSourcePaths(entitySet);
+                   RetrieveNavigationSourcePaths(entitySet, settings);
                }
            }
 
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.OData.Edm
            {
                if (CanFilter(singleton))
                {
-                   RetrieveNavigationSourcePaths(singleton);
+                   RetrieveNavigationSourcePaths(singleton, settings);
                }
            }
 
@@ -169,7 +169,8 @@ namespace Microsoft.OpenApi.OData.Edm
         /// Retrieve the paths for <see cref="IEdmNavigationSource"/>.
         /// </summary>
         /// <param name="navigationSource">The navigation source.</param>
-        private void RetrieveNavigationSourcePaths(IEdmNavigationSource navigationSource)
+        /// <param name="convertSettings">The settings for the current conversion.</param>
+        private void RetrieveNavigationSourcePaths(IEdmNavigationSource navigationSource, OpenApiConvertSettings convertSettings)
         {
             Debug.Assert(navigationSource != null);
 
@@ -183,7 +184,7 @@ namespace Microsoft.OpenApi.OData.Edm
             // for entity set, create a path with key and a $count path
             if (entitySet != null)
             {
-                CreateCountPath(path);
+                CreateCountPath(path, convertSettings);
 
                 path.Push(new ODataKeySegment(entityType));
                 AppendPath(path.Clone());
@@ -197,7 +198,7 @@ namespace Microsoft.OpenApi.OData.Edm
             {
                 if (CanFilter(np))
                 {
-                    RetrieveNavigationPropertyPaths(np, path);
+                    RetrieveNavigationPropertyPaths(np, path, convertSettings);
                 }
             }
 
@@ -252,7 +253,8 @@ namespace Microsoft.OpenApi.OData.Edm
         /// </summary>
         /// <param name="navigationProperty">The navigation property.</param>
         /// <param name="currentPath">The current OData path.</param>
-        private void RetrieveNavigationPropertyPaths(IEdmNavigationProperty navigationProperty, ODataPath currentPath)
+        /// <param name="convertSettings">The settings for the current conversion.</param>
+        private void RetrieveNavigationPropertyPaths(IEdmNavigationProperty navigationProperty, ODataPath currentPath, OpenApiConvertSettings convertSettings)
         {
             Debug.Assert(navigationProperty != null);
             Debug.Assert(currentPath != null);
@@ -282,7 +284,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 if (targetsMany)
                 {
                     // ~/entityset/{key}/collection-valued-Nav/$count
-                    CreateCountPath(currentPath);
+                    CreateCountPath(currentPath, convertSettings);
                 }
 
                 if (!navigationProperty.ContainsTarget)
@@ -321,7 +323,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         {
                             if (CanFilter(subNavProperty))
                             {
-                                RetrieveNavigationPropertyPaths(subNavProperty, currentPath);
+                                RetrieveNavigationPropertyPaths(subNavProperty, currentPath, convertSettings);
                             }
                         }
                     }
@@ -373,8 +375,11 @@ namespace Microsoft.OpenApi.OData.Edm
         /// Create $count paths.
         /// </summary>
         /// <param name="currentPath">The current OData path.</param>
-        private void CreateCountPath(ODataPath currentPath) {
+        /// <param name="convertSettings">The settings for the current conversion.</param>
+        private void CreateCountPath(ODataPath currentPath, OpenApiConvertSettings convertSettings) {
             if(currentPath == null) throw new ArgumentNullException(nameof(currentPath));
+            if(convertSettings == null) throw new ArgumentNullException(nameof(convertSettings));
+            if(!convertSettings.IncludeDollarCountPathSegments) return;
             var countPath = currentPath.Clone();
             countPath.Push(ODataDollarCountSegment.Instance);
             AppendPath(countPath);

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -377,12 +377,14 @@ namespace Microsoft.OpenApi.OData.Edm
             newPath.Push(ODataRefSegment.Instance); // $ref
             AppendPath(newPath);
         }
+
         /// <summary>
         /// Create $count paths.
         /// </summary>
         /// <param name="currentPath">The current OData path.</param>
         /// <param name="convertSettings">The settings for the current conversion.</param>
-        private void CreateCountPath(ODataPath currentPath, OpenApiConvertSettings convertSettings) {
+        private void CreateCountPath(ODataPath currentPath, OpenApiConvertSettings convertSettings)
+        {
             if(currentPath == null) throw new ArgumentNullException(nameof(currentPath));
             if(convertSettings == null) throw new ArgumentNullException(nameof(convertSettings));
             if(!convertSettings.IncludeDollarCountPathSegments) return;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -387,7 +387,7 @@ namespace Microsoft.OpenApi.OData.Edm
         {
             if(currentPath == null) throw new ArgumentNullException(nameof(currentPath));
             if(convertSettings == null) throw new ArgumentNullException(nameof(convertSettings));
-            if(!convertSettings.IncludeDollarCountPathSegments) return;
+            if(!convertSettings.EnableDollarCountPath) return;
             var countPath = currentPath.Clone();
             countPath.Push(ODataDollarCountSegment.Instance);
             AppendPath(countPath);

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/RecordExpressionExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/RecordExpressionExtensions.cs
@@ -29,20 +29,10 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            if (record.Properties != null)
-            {
-                IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-                if (property != null)
-                {
-                    IEdmIntegerConstantExpression value = property.Value as IEdmIntegerConstantExpression;
-                    if (value != null)
-                    {
-                        return value.Value;
-                    }
-                }
-            }
-
-            return null;
+            return (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmIntegerConstantExpression value) ?
+                value.Value :
+                null;
         }
 
         /// <summary>
@@ -56,20 +46,10 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            if (record.Properties != null)
-            {
-                IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-                if (property != null)
-                {
-                    IEdmStringConstantExpression value = property.Value as IEdmStringConstantExpression;
-                    if (value != null)
-                    {
-                        return value.Value;
-                    }
-                }
-            }
-
-            return null;
+            return (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+            property.Value is IEdmStringConstantExpression value) ?
+                value.Value :
+                null;
         }
 
         /// <summary>
@@ -83,20 +63,10 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            if (record.Properties != null)
-            {
-                IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-                if (property != null)
-                {
-                    IEdmBooleanConstantExpression value = property.Value as IEdmBooleanConstantExpression;
-                    if (value != null)
-                    {
-                        return value.Value;
-                    }
-                }
-            }
-
-            return null;
+            return (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmBooleanConstantExpression value) ?
+                value.Value :
+                null;
         }
 
         /// <summary>
@@ -112,25 +82,13 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            if (record.Properties != null)
-            {
-                IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-                if (property != null)
-                {
-                    IEdmEnumMemberExpression value = property.Value as IEdmEnumMemberExpression;
-                    if (value != null && value.EnumMembers != null && value.EnumMembers.Any())
-                    {
-                        IEdmEnumMember member = value.EnumMembers.First();
-                        T result;
-                        if (Enum.TryParse(member.Name, out result))
-                        {
-                            return result;
-                        }
-                    }
-                }
-            }
-
-            return null;
+            return (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmEnumMemberExpression value &&
+                value.EnumMembers != null &&
+                value.EnumMembers.Any() &&
+                Enum.TryParse(value.EnumMembers.First().Name, out T result)) ?
+                result :
+                null;
         }
 
         /// <summary>
@@ -146,16 +104,12 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-            if (property != null)
+            if (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmRecordExpression recordValue)
             {
-                IEdmRecordExpression recordValue = property.Value as IEdmRecordExpression;
-                if (recordValue != null)
-                {
-                    T a = new T();
-                    a.Initialize(recordValue);
-                    return a;
-                }
+                T a = new();
+                a.Initialize(recordValue);
+                return a;
             }
 
             return default;
@@ -172,20 +126,10 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            if (record.Properties != null)
-            {
-                IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-                if (property != null)
-                {
-                    IEdmPathExpression value = property.Value as IEdmPathExpression;
-                    if (value != null)
-                    {
-                        return value.Path;
-                    }
-                }
-            }
-
-            return null;
+            return (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmPathExpression value) ?
+                value.Path :
+                null;
         }
 
         /// <summary>
@@ -199,25 +143,18 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            if (record.Properties != null)
+            if (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmCollectionExpression value && value.Elements != null)
             {
-                IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-                if (property != null)
-                {
-                    IEdmCollectionExpression value = property.Value as IEdmCollectionExpression;
-                    if (value != null && value.Elements != null)
-                    {
-                        IList<string> properties = new List<string>();
-                        foreach (var path in value.Elements.Select(e => e as IEdmPathExpression))
-                        {
-                            properties.Add(path.Path);
-                        }
+                IList<string> properties = 
+                    value.Elements
+                        .OfType<IEdmPathExpression>()
+                        .Select(x => x.Path)
+                        .ToList();
 
-                        if (properties.Any())
-                        {
-                            return properties;
-                        }
-                    }
+                if (properties.Any())
+                {
+                    return properties;
                 }
             }
 
@@ -235,21 +172,14 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-            if (property != null)
+            if (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmCollectionExpression collection && collection.Elements != null)
             {
-                IEdmCollectionExpression collection = property.Value as IEdmCollectionExpression;
-                if (collection != null && collection.Elements != null)
-                {
-                    IList<string> items = new List<string>();
-                    foreach (var item in collection.Elements)
-                    {
-                        IEdmStringConstantExpression itemRecord = item as IEdmStringConstantExpression;
-                        items.Add(itemRecord.Value);
-                    }
-
-                    return items;
-                }
+                IList<string> items = collection.Elements
+                                    .OfType<IEdmStringConstantExpression>()
+                    .Select(x => x.Value)
+                    .ToList();
+                return items;
             }
 
             return null;
@@ -268,22 +198,18 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(record, nameof(record));
             Utils.CheckArgumentNull(propertyName, nameof(propertyName));
 
-            IEdmPropertyConstructor property = record.Properties.FirstOrDefault(e => e.Name == propertyName);
-            if (property != null)
+            if (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmCollectionExpression collection && collection.Elements != null)
             {
-                IEdmCollectionExpression collection = property.Value as IEdmCollectionExpression;
-                if (collection != null && collection.Elements != null)
+                IList<T> items = new List<T>();
+                foreach (IEdmRecordExpression item in collection.Elements.OfType<IEdmRecordExpression>())
                 {
-                    IList<T> items = new List<T>();
-                    foreach (IEdmRecordExpression item in collection.Elements.OfType<IEdmRecordExpression>())
-                    {
-                        T a = new T();
-                        a.Initialize(item);
-                        items.Add(a);
-                    }
-
-                    return items;
+                    T a = new();
+                    a.Initialize(item);
+                    items.Add(a);
                 }
+
+                return items;
             }
 
             return null;

--- a/src/Microsoft.OpenApi.OData.Reader/EdmModelOpenApiExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/EdmModelOpenApiExtensions.cs
@@ -42,21 +42,20 @@ namespace Microsoft.OpenApi.OData
 
             if (settings.VerifyEdmModel)
             {
-                IEnumerable<EdmError> errors;
-                if (!model.Validate(out errors))
-                {
-                    OpenApiDocument document = new OpenApiDocument();
-                    int index = 1;
-                    foreach (var error in errors)
-                    {
-                        document.Extensions.Add(Constants.xMsEdmModelError + index++, new OpenApiString(error.ToString()));
-                    }
+				if (!model.Validate(out var errors))
+				{
+					OpenApiDocument document = new();
+					int index = 1;
+					foreach (var error in errors)
+					{
+						document.Extensions.Add(Constants.xMsEdmModelError + index++, new OpenApiString(error.ToString()));
+					}
 
-                    return document;
-                }
-            }
+					return document;
+				}
+			}
 
-            ODataContext context = new ODataContext(model, settings);
+            ODataContext context = new(model, settings);
             return context.CreateDocument();
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.OData.Generator
 
             if (settings.ShowRootPath)
             {
-                OpenApiPathItem rootPath = new OpenApiPathItem()
+                OpenApiPathItem rootPath = new()
                 {
                     Operations = new Dictionary<OperationType, OpenApiOperation> {
                         {

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -67,6 +67,11 @@ namespace Microsoft.OpenApi.OData.Generator
                 schemas[schema.Key] = schema.Value;
             }
 
+            schemas[Constants.DollarCountSchemaName] = new OpenApiSchema {
+                Type = "integer",
+                Format = "int32"
+            };
+
             return schemas;
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -67,10 +67,11 @@ namespace Microsoft.OpenApi.OData.Generator
                 schemas[schema.Key] = schema.Value;
             }
 
-            schemas[Constants.DollarCountSchemaName] = new OpenApiSchema {
-                Type = "integer",
-                Format = "int32"
-            };
+            if(context.Settings.IncludeDollarCountPathSegments)
+                schemas[Constants.DollarCountSchemaName] = new OpenApiSchema {
+                    Type = "integer",
+                    Format = "int32"
+                };
 
             return schemas;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 schemas[schema.Key] = schema.Value;
             }
 
-            if(context.Settings.IncludeDollarCountPathSegments)
+            if(context.Settings.EnableDollarCountPath)
                 schemas[Constants.DollarCountSchemaName] = new OpenApiSchema {
                     Type = "integer",
                     Format = "int32"

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -183,6 +183,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public IODataPathProvider PathProvider { get; set; }
 
+        /// <summary>
+        /// Gets/sets a value indicating whether or not add OData $count segments in the description for collections.
+        /// </summary>
+        public bool IncludeDollarCountPathSegments { get; set; } = true;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -212,7 +217,8 @@ namespace Microsoft.OpenApi.OData
                 RequireDerivedTypesConstraintForBoundOperations = this.RequireDerivedTypesConstraintForBoundOperations,
                 ShowSchemaExamples = this.ShowSchemaExamples,
                 ShowRootPath = this.ShowRootPath,
-                PathProvider = this.PathProvider
+                PathProvider = this.PathProvider,
+                IncludeDollarCountPathSegments = this.IncludeDollarCountPathSegments,
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -186,7 +186,7 @@ namespace Microsoft.OpenApi.OData
         /// <summary>
         /// Gets/sets a value indicating whether or not add OData $count segments in the description for collections.
         /// </summary>
-        public bool IncludeDollarCountPathSegments { get; set; } = true;
+        public bool EnableDollarCountPath { get; set; } = true;
 
         internal OpenApiConvertSettings Clone()
         {
@@ -218,7 +218,7 @@ namespace Microsoft.OpenApi.OData
                 ShowSchemaExamples = this.ShowSchemaExamples,
                 ShowRootPath = this.ShowRootPath,
                 PathProvider = this.PathProvider,
-                IncludeDollarCountPathSegments = this.IncludeDollarCountPathSegments,
+                EnableDollarCountPath = this.EnableDollarCountPath,
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// this segment could be "entity set", "Collection property", "Composable function whose return is collection",etc.
         /// </summary>
         internal ODataSegment LastSecondSegment { get; set; }
-
+        private const int SecondLastSegmentIndex = 2;
         /// <inheritdoc/>
         protected override void Initialize(ODataContext context, ODataPath path)
         {
@@ -33,7 +33,8 @@ namespace Microsoft.OpenApi.OData.Operation
 
             // get the last second segment
             int count = path.Segments.Count;
-            LastSecondSegment = path.Segments.ElementAt(count - 1);
+            if(count >= SecondLastSegmentIndex)
+                LastSecondSegment = path.Segments.ElementAt(count - SecondLastSegmentIndex);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -54,10 +54,12 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            OpenApiSchema schema = new OpenApiSchema
-            {
-                Type = "integer",
-                Format = "int32"
+            OpenApiSchema schema = new()
+			{
+                Reference = new() {
+                    Type = ReferenceType.Schema,
+                    Id = Constants.DollarCountSchemaName
+                }
             };
 
             operation.Responses = new OpenApiResponses

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -14,88 +14,82 @@ namespace Microsoft.OpenApi.OData.Operation
     /// </summary>
     internal class OperationHandlerProvider : IOperationHandlerProvider
     {
-        private IDictionary<ODataPathKind, IDictionary<OperationType, IOperationHandler>> _handlers;
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="OperationHandlerProvider"/> class.
-        /// </summary>
-        public OperationHandlerProvider()
-        {
-            _handlers = new Dictionary<ODataPathKind, IDictionary<OperationType, IOperationHandler>>();
+        private readonly IDictionary<ODataPathKind, IDictionary<OperationType, IOperationHandler>> _handlers
+            = new Dictionary<ODataPathKind, IDictionary<OperationType, IOperationHandler>>{
 
             // entity set (Get/Post)
-            _handlers[ODataPathKind.EntitySet] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.EntitySet, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new EntitySetGetOperationHandler() },
                 {OperationType.Post, new EntitySetPostOperationHandler() }
-            };
+            }},
 
             // entity (Get/Patch/Delete)
-            _handlers[ODataPathKind.Entity] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.Entity, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new EntityGetOperationHandler() },
                 {OperationType.Patch, new EntityPatchOperationHandler() },
                 {OperationType.Delete, new EntityDeleteOperationHandler() }
-            };
+            }},
 
             // singleton (Get/Patch)
-            _handlers[ODataPathKind.Singleton] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.Singleton, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new SingletonGetOperationHandler() },
                 {OperationType.Patch, new SingletonPatchOperationHandler() }
-            };
+            }},
 
             // edm operation (Get|Post)
-            _handlers[ODataPathKind.Operation] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.Operation, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new EdmFunctionOperationHandler() },
                 {OperationType.Post, new EdmActionOperationHandler() }
-            };
+            }},
 
             // edm operation import (Get|Post)
-            _handlers[ODataPathKind.OperationImport] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.OperationImport, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new EdmFunctionImportOperationHandler() },
                 {OperationType.Post, new EdmActionImportOperationHandler() }
-            };
+            }},
 
             // navigation property (Get/Patch/Post/Delete)
-            _handlers[ODataPathKind.NavigationProperty] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.NavigationProperty, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new NavigationPropertyGetOperationHandler() },
                 {OperationType.Patch, new NavigationPropertyPatchOperationHandler() },
                 {OperationType.Post, new NavigationPropertyPostOperationHandler() },
                 {OperationType.Delete, new NavigationPropertyDeleteOperationHandler() }
-            };
+            }},
 
             // navigation property ref (Get/Post/Put/Delete)
-            _handlers[ODataPathKind.Ref] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.Ref, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new RefGetOperationHandler() },
                 {OperationType.Put, new RefPutOperationHandler() },
                 {OperationType.Post, new RefPostOperationHandler() },
                 {OperationType.Delete, new RefDeleteOperationHandler() }
-            };
+            }},
 
             // media entity operation (Get|Put)
-            _handlers[ODataPathKind.MediaEntity] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.MediaEntity, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new MediaEntityGetOperationHandler() },
                 {OperationType.Put, new MediaEntityPutOperationHandler() }
-            };
+            }},
 
             // $metadata operation (Get)
-            _handlers[ODataPathKind.Metadata] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.Metadata, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new MetadataGetOperationHandler() }
-            };
+            }},
 
             // $count operation (Get)
-            _handlers[ODataPathKind.DollarCount] = new Dictionary<OperationType, IOperationHandler>
+            {ODataPathKind.DollarCount, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new DollarCountGetOperationHandler() }
-            };
-        }
+            }},
+        };
 
         /// <inheritdoc/>
         public IOperationHandler GetHandler(ODataPathKind pathKind, OperationType operationType)

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -14,7 +14,6 @@ using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.Any;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
-using System.Drawing;
 
 namespace Microsoft.OpenApi.OData.PathItem
 {
@@ -46,8 +45,8 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// </summary>
         protected bool LastSegmentIsRefSegment { get; private set; }
 
-        /// <inheritdoc/>
-        protected override void SetOperations(OpenApiPathItem item)
+		/// <inheritdoc/>
+		protected override void SetOperations(OpenApiPathItem item)
         {
             IEdmEntitySet entitySet = NavigationSource as IEdmEntitySet;
             IEdmVocabularyAnnotatable target = entitySet;
@@ -79,7 +78,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 }
             }
 
-            // contaiment: Get / (Post - Collection | Patch - Single)
+            // containment: Get / (Post - Collection | Patch - Single)
             // non-containment: Get
             AddGetOperation(item, restriction);
 
@@ -216,18 +215,17 @@ namespace Microsoft.OpenApi.OData.PathItem
                     continue;
                 }
 
-                ODataNavigationSourceSegment navigationSourceSegment = path.FirstSegment as ODataNavigationSourceSegment;
-                if (NavigationSource != navigationSourceSegment.NavigationSource)
+                if (path.FirstSegment is ODataNavigationSourceSegment navigationSourceSegment &&
+                    NavigationSource != navigationSourceSegment.NavigationSource)
                 {
                     continue;
                 }
 
-                ODataNavigationPropertySegment npSegment = path.LastSegment as ODataNavigationPropertySegment;
-                if (npSegment == null)
-                {
-                    npSegment = path.Segments[path.Count - 2] as ODataNavigationPropertySegment;
-                }
-                if (NavigationProperty != npSegment.NavigationProperty)
+				if (path.LastSegment is not ODataNavigationPropertySegment npSegment)
+				{
+					npSegment = path.Segments[path.Count - 2] as ODataNavigationPropertySegment;
+				}
+				if (NavigationProperty != npSegment.NavigationProperty)
                 {
                     continue;
                 }
@@ -237,7 +235,7 @@ namespace Microsoft.OpenApi.OData.PathItem
 
             if (samePaths.Any())
             {
-                OpenApiArray array = new OpenApiArray();
+                OpenApiArray array = new();
                 OpenApiConvertSettings settings = Context.Settings.Clone();
                 settings.EnableKeyAsSegment = Context.KeyAsSegment;
                 foreach (var p in samePaths)

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandlerProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenApi.OData.PathItem
     /// </summary>
     internal class PathItemHandlerProvider : IPathItemHandlerProvider
     {
-        private IDictionary<ODataPathKind, IPathItemHandler> _handlers = new Dictionary<ODataPathKind, IPathItemHandler>
+        private readonly IDictionary<ODataPathKind, IPathItemHandler> _handlers = new Dictionary<ODataPathKind, IPathItemHandler>
         {
             // EntitySet
             { ODataPathKind.EntitySet, new EntitySetPathItemHandler() },

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -128,6 +128,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.PathPrefix.get -> string
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PathPrefix.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PathProvider.get -> Microsoft.OpenApi.OData.Edm.IODataPathProvider
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PathProvider.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeDollarCountPathSegments.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeDollarCountPathSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PrefixEntityTypeNameBeforeKey.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PrefixEntityTypeNameBeforeKey.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireDerivedTypesConstraintForBoundOperations.get -> bool

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -128,8 +128,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.PathPrefix.get -> string
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PathPrefix.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PathProvider.get -> Microsoft.OpenApi.OData.Edm.IODataPathProvider
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PathProvider.set -> void
-Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeDollarCountPathSegments.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeDollarCountPathSegments.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDollarCountPath.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDollarCountPath.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PrefixEntityTypeNameBeforeKey.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.PrefixEntityTypeNameBeforeKey.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireDerivedTypesConstraintForBoundOperations.get -> bool

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/CountRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/CountRestrictionsType.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// Test the target supports count.
         /// </summary>
         /// <returns>True/false.</returns>
-        public bool IsCountable => Countable == null || Countable.Value;
+        public bool IsCountable => !Countable.HasValue || Countable.Value;
 
         /// <summary>
         /// Test the input property path which do not allow /$count segments.
@@ -45,7 +45,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// <returns>True/False.</returns>
         public bool IsNonCountableProperty(string propertyPath)
         {
-            return NonCountableProperties != null ? NonCountableProperties.Any(a => a == propertyPath) : false;
+            return NonCountableProperties != null && NonCountableProperties.Any(a => a == propertyPath);
         }
 
         /// <summary>
@@ -55,9 +55,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// <returns>True/False.</returns>
         public bool IsNonCountableNavigationProperty(string navigationPropertyPath)
         {
-            return NonCountableNavigationProperties != null ?
-                NonCountableNavigationProperties.Any(a => a == navigationPropertyPath) :
-                false;
+            return NonCountableNavigationProperties != null && NonCountableNavigationProperties.Any(a => a == navigationPropertyPath);
         }
 
         /// <summary>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17194, paths.Count());
+            Assert.Equal(17178, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17179, paths.Count());
+            Assert.Equal(17163, paths.Count());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             IEdmModel model = GetInheritanceModel(string.Empty);
             ODataPathProvider provider = new ODataPathProvider();
             var settings = new OpenApiConvertSettings {
-              IncludeDollarCountPathSegments = false,
+              EnableDollarCountPath = false,
             };
 
             // Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(13727, paths.Count());
+            Assert.Equal(17194, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(13712, paths.Count());
+            Assert.Equal(17179, paths.Count());
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(3, paths.Count());
+            Assert.Equal(4, paths.Count());
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(2, paths.Count());
+            Assert.Equal(3, paths.Count());
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var paths = provider.GetPaths(model, settings);
 
             // Assert
-            Assert.Equal(3, paths.Count());
+            Assert.Equal(4, paths.Count());
         }
 
 #if DEBUG
@@ -151,7 +151,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(4, paths.Count());
+            Assert.Equal(5, paths.Count());
         }
 
         [Fact]
@@ -170,7 +170,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(3, paths.Count());
+            Assert.Equal(4, paths.Count());
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(4, paths.Count());
+            Assert.Equal(5, paths.Count());
         }
 
         [Fact]
@@ -211,8 +211,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(2, paths.Count());
-            Assert.Equal(new[] { "/Customers", "/Customers({ID})" }, paths.Select(p => p.GetPathItemName()));
+            Assert.Equal(3, paths.Count());
+            Assert.Equal(new[] { "/Customers", "/Customers({ID})", "/Customers/$count" }, paths.Select(p => p.GetPathItemName()));
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(3, paths.Count());
+            Assert.Equal(4, paths.Count());
             Assert.Contains("/Me", paths.Select(p => p.GetPathItemName()));
         }
 
@@ -250,7 +250,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(3, paths.Count());
+            Assert.Equal(4, paths.Count());
             Assert.Contains("/Customers/NS.delta()", paths.Select(p => p.GetPathItemName()));
         }
 
@@ -272,7 +272,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(3, paths.Count());
+            Assert.Equal(4, paths.Count());
             Assert.Contains("/Customers({ID})/NS.renew", paths.Select(p => p.GetPathItemName()));
         }
 
@@ -301,7 +301,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(4, paths.Count());
+            Assert.Equal(5, paths.Count());
 
             if (containsTarget)
             {
@@ -338,7 +338,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(4, paths.Count());
+            Assert.Equal(5, paths.Count());
 
             if (containsTarget)
             {
@@ -373,7 +373,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(4, paths.Count());
+            Assert.Equal(5, paths.Count());
             Assert.Contains("/GetNearestCustomers()", paths.Select(p => p.GetPathItemName()));
             Assert.Contains("/ResetDataSource", paths.Select(p => p.GetPathItemName()));
         }
@@ -410,7 +410,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(7, paths.Count());
+            Assert.Equal(10, paths.Count());
 
             var pathItems = paths.Select(p => p.GetPathItemName()).ToList();
             Assert.DoesNotContain("/Orders({id})/SingleCustomer", pathItems);
@@ -453,7 +453,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(7, paths.Count());
+            Assert.Equal(9, paths.Count());
 
             var pathItems = paths.Select(p => p.GetPathItemName()).ToList();
             Assert.DoesNotContain("/Orders({id})/MultipleCustomers({ID})", pathItems);
@@ -483,7 +483,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(9, paths.Count());
+            Assert.Equal(12, paths.Count());
 
             var pathItems = paths.Select(p => p.GetPathItemName()).ToList();
             Assert.Contains("/Orders({id})/MultipleCustomers", pathItems);
@@ -516,7 +516,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(7, paths.Count());
+            Assert.Equal(10, paths.Count());
 
             var pathItems = paths.Select(p => p.GetPathItemName()).ToList();
             Assert.Contains("/Orders({id})/MultipleCustomers", pathItems);
@@ -552,14 +552,14 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             {
                 if (hasStream)
                 {
-                    Assert.Equal(13, paths.Count());
+                    Assert.Equal(15, paths.Count());
                     Assert.Contains(TodosValuePath, paths.Select(p => p.GetPathItemName()));
                     Assert.Contains(TodosLogoPath, paths.Select(p => p.GetPathItemName()));
                     Assert.DoesNotContain(TodosContentPath, paths.Select(p => p.GetPathItemName()));
                 }
                 else
                 {
-                    Assert.Equal(12, paths.Count());
+                    Assert.Equal(14, paths.Count());
                     Assert.Contains(TodosLogoPath, paths.Select(p => p.GetPathItemName()));
                     Assert.DoesNotContain(TodosContentPath, paths.Select(p => p.GetPathItemName()));
                     Assert.DoesNotContain(TodosValuePath, paths.Select(p => p.GetPathItemName()));
@@ -567,7 +567,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             }
             else if (streamPropName.Equals("content"))
             {
-                Assert.Equal(12, paths.Count());
+                Assert.Equal(14, paths.Count());
                 Assert.Contains(TodosContentPath, paths.Select(p => p.GetPathItemName()));
                 Assert.DoesNotContain(TodosLogoPath, paths.Select(p => p.GetPathItemName()));
                 Assert.DoesNotContain(TodosValuePath, paths.Select(p => p.GetPathItemName()));

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -87,6 +87,24 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         }
 
         [Fact]
+        public void GetPathsDoesntReturnPathsForCountWhenDisabled()
+        {
+            // Arrange
+            IEdmModel model = GetInheritanceModel(string.Empty);
+            ODataPathProvider provider = new ODataPathProvider();
+            var settings = new OpenApiConvertSettings {
+              IncludeDollarCountPathSegments = false,
+            };
+
+            // Act
+            var paths = provider.GetPaths(model, settings);
+
+            // Assert
+            Assert.NotNull(paths);
+            Assert.Equal(3, paths.Count());
+        }
+
+        [Fact]
         public void GetPathsForInheritanceModelWithDerivedTypesConstraintNoAnnotationReturnsFewer()
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
@@ -57,13 +57,16 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(pathItems);
-            Assert.Equal(7, pathItems.Count);
+            Assert.Equal(10, pathItems.Count);
 
             Assert.Contains("/People", pathItems.Keys);
+            Assert.Contains("/People/$count", pathItems.Keys);
             Assert.Contains("/People/{UserName}", pathItems.Keys);
             Assert.Contains("/City", pathItems.Keys);
+            Assert.Contains("/City/$count", pathItems.Keys);
             Assert.Contains("/City/{Name}", pathItems.Keys);
             Assert.Contains("/CountryOrRegion", pathItems.Keys);
+            Assert.Contains("/CountryOrRegion/$count", pathItems.Keys);
             Assert.Contains("/CountryOrRegion/{Name}", pathItems.Keys);
             Assert.Contains("/Me", pathItems.Keys);
         }
@@ -114,9 +117,10 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(pathItems);
-            Assert.Equal(3, pathItems.Count);
+            Assert.Equal(4, pathItems.Count);
 
             Assert.Contains("/Customers", pathItems.Keys);
+            Assert.Contains("/Customers/$count", pathItems.Keys);
             Assert.Contains("/Customers({ID})", pathItems.Keys);
             Assert.Contains(expected, pathItems.Keys);
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
@@ -56,13 +56,16 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(7, paths.Count);
+            Assert.Equal(10, paths.Count);
 
             Assert.Contains("/People", paths.Keys);
+            Assert.Contains("/People/$count", paths.Keys);
             Assert.Contains("/People/{UserName}", paths.Keys);
             Assert.Contains("/City", paths.Keys);
+            Assert.Contains("/City/$count", paths.Keys);
             Assert.Contains("/City/{Name}", paths.Keys);
             Assert.Contains("/CountryOrRegion", paths.Keys);
+            Assert.Contains("/CountryOrRegion/$count", paths.Keys);
             Assert.Contains("/CountryOrRegion/{Name}", paths.Keys);
             Assert.Contains("/Me", paths.Keys);
         }
@@ -84,13 +87,16 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(7, paths.Count);
+            Assert.Equal(10, paths.Count);
 
             Assert.Contains("/some/prefix/People", paths.Keys);
+            Assert.Contains("/some/prefix/People/$count", paths.Keys);
             Assert.Contains("/some/prefix/People/{UserName}", paths.Keys);
             Assert.Contains("/some/prefix/City", paths.Keys);
+            Assert.Contains("/some/prefix/City/$count", paths.Keys);
             Assert.Contains("/some/prefix/City/{Name}", paths.Keys);
             Assert.Contains("/some/prefix/CountryOrRegion", paths.Keys);
+            Assert.Contains("/some/prefix/CountryOrRegion/$count", paths.Keys);
             Assert.Contains("/some/prefix/CountryOrRegion/{Name}", paths.Keys);
             Assert.Contains("/some/prefix/Me", paths.Keys);
         }
@@ -112,9 +118,10 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(4, paths.Count);
+            Assert.Equal(5, paths.Count);
 
             Assert.Contains("/Accounts", paths.Keys);
+            Assert.Contains("/Accounts/$count", paths.Keys);
             Assert.Contains("/Accounts/{id}", paths.Keys);
             Assert.Contains("/Accounts/{id}/Attachments()", paths.Keys);
             Assert.Contains("/Accounts/{id}/AttachmentsAdd", paths.Keys);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -260,6 +260,26 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/City/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.City",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/CountryOrRegion": {
       "get": {
         "tags": [
@@ -508,6 +528,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/CountryOrRegion/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.CountryOrRegion",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/Me": {
@@ -856,6 +896,26 @@
         },
         "x-ms-docs-operation-type": "operation"
       }
+    },
+    "/People/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.People",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -1029,6 +1089,10 @@
           "type": "string"
         }
       }
+    },
+    "ODataCountResponse": {
+      "format": "int32",
+      "type": "integer"
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -170,6 +170,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /City/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.City
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /CountryOrRegion:
     get:
       tags:
@@ -333,6 +346,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /CountryOrRegion/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.CountryOrRegion
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /Me:
     get:
       tags:
@@ -566,6 +592,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /People/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.People
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
 definitions:
   DefaultNs.Color:
     title: Color
@@ -679,6 +718,9 @@ definitions:
         type: string
       target:
         type: string
+  ODataCountResponse:
+    format: int32
+    type: integer
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -293,6 +293,27 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/City/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.City",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/CountryOrRegion": {
       "get": {
         "tags": [
@@ -573,6 +594,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/CountryOrRegion/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.CountryOrRegion",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Me": {
@@ -961,6 +1003,27 @@
         },
         "x-ms-docs-operation-type": "operation"
       }
+    },
+    "/People/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.People",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1135,6 +1198,10 @@
             "type": "string"
           }
         }
+      },
+      "ODataCountResponse": {
+        "type": "integer",
+        "format": "int32"
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -190,6 +190,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /City/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.City
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /CountryOrRegion:
     get:
       tags:
@@ -374,6 +387,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /CountryOrRegion/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.CountryOrRegion
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Me:
     get:
       tags:
@@ -634,6 +660,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /People/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.People
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
 components:
   schemas:
     DefaultNs.Color:
@@ -748,6 +787,9 @@ components:
           type: string
         target:
           type: string
+    ODataCountResponse:
+      type: integer
+      format: int32
   responses:
     error:
       description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "OData Service for namespace ",
@@ -67,6 +67,10 @@
           "type": "string"
         }
       }
+    },
+    "ODataCountResponse": {
+      "format": "int32",
+      "type": "integer"
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -1,4 +1,4 @@
-﻿swagger: '2.0'
+swagger: '2.0'
 info:
   title: 'OData Service for namespace '
   description: This OData service is located at http://localhost
@@ -46,6 +46,9 @@ definitions:
         type: string
       target:
         type: string
+  ODataCountResponse:
+    format: int32
+    type: integer
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "openapi": "3.0.1",
   "info": {
     "title": "OData Service for namespace ",
@@ -69,6 +69,10 @@
             "type": "string"
           }
         }
+      },
+      "ODataCountResponse": {
+        "type": "integer",
+        "format": "int32"
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -1,4 +1,4 @@
-﻿openapi: 3.0.1
+openapi: 3.0.1
 info:
   title: 'OData Service for namespace '
   description: This OData service is located at http://localhost
@@ -46,6 +46,9 @@ components:
           type: string
         target:
           type: string
+    ODataCountResponse:
+      type: integer
+      format: int32
   responses:
     error:
       description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "OData Service for namespace Default",
@@ -287,6 +287,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Categories/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Categories",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/Documents": {
@@ -827,6 +847,39 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Documents({Id})/Revisions/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Revisions",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/Documents({Id})/Revisions/$ref": {
       "get": {
         "tags": [
@@ -981,6 +1034,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Documents/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Documents",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/Libraries": {
@@ -1483,6 +1556,39 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Libraries({Id})/Documents/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Documents",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/Libraries({Id})/Documents/$ref": {
       "get": {
         "tags": [
@@ -1623,6 +1729,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Libraries/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Libraries",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/Revisions": {
@@ -2184,6 +2310,26 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Revisions/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Revisions",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/Tasks": {
       "get": {
         "tags": [
@@ -2722,6 +2868,39 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Tasks({Id})/Revisions/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Revisions",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/Tasks({Id})/Revisions/$ref": {
       "get": {
         "tags": [
@@ -2876,6 +3055,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Tasks/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tasks",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     }
   },
@@ -4637,6 +4836,10 @@
           "type": "string"
         }
       }
+    },
+    "ODataCountResponse": {
+      "format": "int32",
+      "type": "integer"
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -1,4 +1,4 @@
-﻿swagger: '2.0'
+swagger: '2.0'
 info:
   title: OData Service for namespace Default
   description: This OData service is located at http://localhost
@@ -199,6 +199,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Categories/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Categories
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /Documents:
     get:
       tags:
@@ -588,6 +601,29 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/Documents({Id})/Revisions/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Revisions
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/Documents({Id})/Revisions/$ref':
     get:
       tags:
@@ -701,6 +737,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Documents/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Documents
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /Libraries:
     get:
       tags:
@@ -1063,6 +1112,29 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/Libraries({Id})/Documents/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Documents
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of LibraryDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/Libraries({Id})/Documents/$ref':
     get:
       tags:
@@ -1162,6 +1234,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Libraries/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Libraries
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /Revisions:
     get:
       tags:
@@ -1581,6 +1666,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Revisions/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Revisions
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /Tasks:
     get:
       tags:
@@ -1970,6 +2068,29 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/Tasks({Id})/Revisions/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Revisions
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/Tasks({Id})/Revisions/$ref':
     get:
       tags:
@@ -2083,6 +2204,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Tasks/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tasks
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
 definitions:
   Siterra.Documents.App.DTO.DocumentDto:
     title: DocumentDto
@@ -3439,6 +3573,9 @@ definitions:
         type: string
       target:
         type: string
+  ODataCountResponse:
+    format: int32
+    type: integer
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "openapi": "3.0.1",
   "info": {
     "title": "OData Service for namespace Default",
@@ -320,6 +320,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Categories/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Categories",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Documents": {
@@ -929,6 +950,42 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Documents({Id})/Revisions/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Revisions",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Documents({Id})/Revisions/$ref": {
       "get": {
         "tags": [
@@ -1093,6 +1150,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Documents/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Documents",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Libraries": {
@@ -1661,6 +1739,42 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Libraries({Id})/Documents/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Documents",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "LibraryDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Libraries({Id})/Documents/$ref": {
       "get": {
         "tags": [
@@ -1811,6 +1925,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Libraries/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Libraries",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Revisions": {
@@ -2497,6 +2632,27 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Revisions/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Revisions",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Tasks": {
       "get": {
         "tags": [
@@ -3104,6 +3260,42 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Tasks({Id})/Revisions/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Revisions",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Tasks({Id})/Revisions/$ref": {
       "get": {
         "tags": [
@@ -3268,6 +3460,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Tasks/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tasks",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     }
   },
@@ -5226,6 +5439,10 @@
             "type": "string"
           }
         }
+      },
+      "ODataCountResponse": {
+        "type": "integer",
+        "format": "int32"
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -1,4 +1,4 @@
-﻿openapi: 3.0.1
+openapi: 3.0.1
 info:
   title: OData Service for namespace Default
   description: This OData service is located at http://localhost
@@ -219,6 +219,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Categories/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Categories
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Documents:
     get:
       tags:
@@ -652,6 +665,30 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Documents({Id})/Revisions/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Revisions
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/Documents({Id})/Revisions/$ref':
     get:
       tags:
@@ -770,6 +807,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Documents/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Documents
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Libraries:
     get:
       tags:
@@ -1175,6 +1225,30 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Libraries({Id})/Documents/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Documents
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of LibraryDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: LibraryDto
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/Libraries({Id})/Documents/$ref':
     get:
       tags:
@@ -1279,6 +1353,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Libraries/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Libraries
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Revisions:
     get:
       tags:
@@ -1778,6 +1865,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Revisions/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Revisions
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Tasks:
     get:
       tags:
@@ -2211,6 +2311,30 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Tasks({Id})/Revisions/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Revisions
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/Tasks({Id})/Revisions/$ref':
     get:
       tags:
@@ -2329,6 +2453,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Tasks/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tasks
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
 components:
   schemas:
     Siterra.Documents.App.DTO.DocumentDto:
@@ -3831,6 +3968,9 @@ components:
           type: string
         target:
           type: string
+    ODataCountResponse:
+      type: integer
+      format: int32
   responses:
     error:
       description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models",
@@ -265,6 +265,26 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Airlines/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Airlines",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/Airports": {
       "get": {
         "tags": [
@@ -525,6 +545,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Airports/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Airports",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/GetNearestAirport(lat={lat},lon={lon})": {
@@ -998,6 +1038,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Friends/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Friends",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/Me/Friends/$ref": {
@@ -1836,6 +1896,39 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.PlanItems",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/Me/Trips/{TripId}/PlanItems/$ref": {
       "get": {
         "tags": [
@@ -1966,6 +2059,26 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Trips/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Trips",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/NewComePeople": {
@@ -2632,6 +2745,36 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Friends",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/NewComePeople/{UserName}/Friends/$ref": {
@@ -3592,6 +3735,47 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.PlanItems",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$ref": {
       "get": {
         "tags": [
@@ -3738,6 +3922,56 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Trips/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Trips",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.NewComePeople",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/People": {
@@ -4404,6 +4638,36 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Friends/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Friends",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/People/{UserName}/Friends/$ref": {
@@ -5364,6 +5628,47 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People/{UserName}/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.PlanItems",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "key: TripId of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
     "/People/{UserName}/Trips/{TripId}/PlanItems/$ref": {
       "get": {
         "tags": [
@@ -5510,6 +5815,56 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Trips/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Trips",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.People",
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "schema": {
+              "$ref": "#/definitions/ODataCountResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
       }
     },
     "/ResetDataSource": {
@@ -6135,6 +6490,10 @@
           "type": "string"
         }
       }
+    },
+    "ODataCountResponse": {
+      "format": "int32",
+      "type": "integer"
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1,4 +1,4 @@
-﻿swagger: '2.0'
+swagger: '2.0'
 info:
   title: OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
   description: This OData service is located at http://services.odata.org/TrippinRESTierService
@@ -175,6 +175,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Airlines/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Airlines
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /Airports:
     get:
       tags:
@@ -350,6 +363,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Airports/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Airports
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/GetNearestAirport(lat={lat},lon={lon})':
     get:
       tags:
@@ -684,6 +710,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Me/Friends/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Friends
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /Me/Friends/$ref:
     get:
       tags:
@@ -1261,6 +1300,29 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/Me/Trips/{TripId}/PlanItems/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.PlanItems
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: TripId
+          description: 'key: TripId of Trip'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/Me/Trips/{TripId}/PlanItems/$ref':
     get:
       tags:
@@ -1350,6 +1412,19 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  /Me/Trips/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Trips
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /NewComePeople:
     get:
       tags:
@@ -1825,6 +1900,26 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Friends/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Friends
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/NewComePeople/{UserName}/Friends/$ref':
     get:
       tags:
@@ -2493,6 +2588,35 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.PlanItems
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: 'key: TripId of Trip'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$ref':
     get:
       tags:
@@ -2594,6 +2718,39 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Trips/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Trips
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+  /NewComePeople/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.NewComePeople
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /People:
     get:
       tags:
@@ -3069,6 +3226,26 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Friends/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Friends
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/People/{UserName}/Friends/$ref':
     get:
       tags:
@@ -3737,6 +3914,35 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Trips/{TripId}/PlanItems/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.PlanItems
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: 'key: TripId of Trip'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   '/People/{UserName}/Trips/{TripId}/PlanItems/$ref':
     get:
       tags:
@@ -3838,6 +4044,39 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Trips/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Trips
+      produces:
+        - text/plain
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+  /People/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.People
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: The count of the resource
+          schema:
+            $ref: '#/definitions/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
   /ResetDataSource:
     post:
       tags:
@@ -4244,6 +4483,9 @@ definitions:
         type: string
       target:
         type: string
+  ODataCountResponse:
+    format: int32
+    type: integer
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "openapi": "3.0.1",
   "info": {
     "title": "OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models",
@@ -297,6 +297,27 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Airlines/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Airlines",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Airports": {
       "get": {
         "tags": [
@@ -589,6 +610,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Airports/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Airports",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/GetNearestAirport(lat={lat},lon={lon})": {
@@ -1149,6 +1191,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Friends/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Friends",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Me/Friends/$ref": {
@@ -2074,6 +2137,42 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.PlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "key: TripId of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Me/Trips/{TripId}/PlanItems/$ref": {
       "get": {
         "tags": [
@@ -2214,6 +2313,27 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Trips/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Trips",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/NewComePeople": {
@@ -2959,6 +3079,39 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Friends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/NewComePeople/{UserName}/Friends/$ref": {
@@ -4044,6 +4197,52 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.PlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "key: TripId of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$ref": {
       "get": {
         "tags": [
@@ -4204,6 +4403,60 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Trips/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Trips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.NewComePeople",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/People": {
@@ -4949,6 +5202,39 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Friends/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Friends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/People/{UserName}/Friends/$ref": {
@@ -6034,6 +6320,52 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People/{UserName}/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.PlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "key: TripId of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/People/{UserName}/Trips/{TripId}/PlanItems/$ref": {
       "get": {
         "tags": [
@@ -6194,6 +6526,60 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Trips/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Trips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.People",
+        "responses": {
+          "200": {
+            "description": "The count of the resource",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataCountResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/ResetDataSource": {
@@ -6964,6 +7350,10 @@
             "type": "string"
           }
         }
+      },
+      "ODataCountResponse": {
+        "type": "integer",
+        "format": "int32"
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -1,4 +1,4 @@
-﻿openapi: 3.0.1
+openapi: 3.0.1
 info:
   title: OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
   description: This OData service is located at http://services.odata.org/TrippinRESTierService
@@ -194,6 +194,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Airlines/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Airlines
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Airports:
     get:
       tags:
@@ -390,6 +403,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Airports/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Airports
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/GetNearestAirport(lat={lat},lon={lon})':
     get:
       tags:
@@ -772,6 +798,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Me/Friends/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Friends
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Me/Friends/$ref:
     get:
       tags:
@@ -1396,6 +1435,30 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Me/Trips/{TripId}/PlanItems/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.PlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: 'key: TripId of Trip'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/Me/Trips/{TripId}/PlanItems/$ref':
     get:
       tags:
@@ -1490,6 +1553,19 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Me/Trips/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Trips
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /NewComePeople:
     get:
       tags:
@@ -2015,6 +2091,27 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Friends/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Friends
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Friends/$ref':
     get:
       tags:
@@ -2749,6 +2846,37 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.PlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: 'key: TripId of Trip'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Trips/{TripId}/PlanItems/$ref':
     get:
       tags:
@@ -2857,6 +2985,40 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Trips/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Trips
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /NewComePeople/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.NewComePeople
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /People:
     get:
       tags:
@@ -3382,6 +3544,27 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Friends/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Friends
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/People/{UserName}/Friends/$ref':
     get:
       tags:
@@ -4116,6 +4299,37 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Trips/{TripId}/PlanItems/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.PlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: 'key: TripId of Trip'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/People/{UserName}/Trips/{TripId}/PlanItems/$ref':
     get:
       tags:
@@ -4224,6 +4438,40 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Trips/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Trips
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /People/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.People
+      responses:
+        '200':
+          description: The count of the resource
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /ResetDataSource:
     post:
       tags:
@@ -4698,6 +4946,9 @@ components:
           type: string
         target:
           type: string
+    ODataCountResponse:
+      type: integer
+      format: int32
   responses:
     error:
       description: error


### PR DESCRIPTION
- pattern matching refactoring
- adds launch configuration for update docs tool
- adds update docs to solution file so debug works properly
- code linting
- code linting
- fixes #129 a bug where odata count paths would be missing from the description


## TODO
- [x] https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Capabilities.V1.xml#L210