### PR TITLE
adds support for deprecation

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
@@ -173,9 +173,12 @@ namespace Microsoft.OpenApi.OData.Edm
                 yield return path;
             }
         }
-        internal DeprecatedRevisionsType GetDeprecationInformation(IEdmVocabularyAnnotatable annotable)
+        internal IEnumerable<DeprecatedRevisionsType> GetDeprecationInformations(IEdmVocabularyAnnotatable annotable)
         {
-            return annotable == null ? null : Model?.GetRecord<DeprecatedRevisionsType>(annotable, "Org.OData.Core.V1.Revisions");
+            return annotable == null ?
+                Enumerable.Empty<DeprecatedRevisionsType>() :
+                    (Model?.GetCollection<DeprecatedRevisionsType>(annotable, "Org.OData.Core.V1.Revisions") ?? 
+                    Enumerable.Empty<DeprecatedRevisionsType>());
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
@@ -6,12 +6,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Generator;
 using Microsoft.OpenApi.OData.Operation;
 using Microsoft.OpenApi.OData.PathItem;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 
 namespace Microsoft.OpenApi.OData.Edm
 {
@@ -170,6 +172,10 @@ namespace Microsoft.OpenApi.OData.Edm
 
                 yield return path;
             }
+        }
+        internal DeprecatedRevisionsType GetDeprecationInformation(IEdmVocabularyAnnotatable annotable)
+        {
+            return Model?.GetRecord<DeprecatedRevisionsType>(annotable, "Org.OData.Core.V1.Revisions");
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
@@ -175,7 +175,7 @@ namespace Microsoft.OpenApi.OData.Edm
         }
         internal DeprecatedRevisionsType GetDeprecationInformation(IEdmVocabularyAnnotatable annotable)
         {
-            return Model?.GetRecord<DeprecatedRevisionsType>(annotable, "Org.OData.Core.V1.Revisions");
+            return annotable == null ? null : Model?.GetRecord<DeprecatedRevisionsType>(annotable, "Org.OData.Core.V1.Revisions");
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
@@ -25,6 +25,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$count";
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return Enumerable.Empty<IEdmVocabularyAnnotatable>();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OpenApi.OData.Edm
 {
@@ -23,7 +25,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$count";
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$count";
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$count";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -62,8 +63,13 @@ namespace Microsoft.OpenApi.OData.Edm
             }
         }
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters)
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters)
         {
             Utils.CheckArgumentNull(settings, nameof(settings));
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
@@ -63,6 +63,7 @@ namespace Microsoft.OpenApi.OData.Edm
             }
         }
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return Enumerable.Empty<IEdmVocabularyAnnotatable>();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataMetadataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataMetadataSegment.cs
@@ -20,6 +20,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$metadata";
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return Enumerable.Empty<IEdmVocabularyAnnotatable>();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataMetadataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataMetadataSegment.cs
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OpenApi.OData.Edm
 {
@@ -18,7 +20,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$metadata";
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$metadata";
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$metadata";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationPropertySegment.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -37,7 +38,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => NavigationProperty.Name; }
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => NavigationProperty.Name;
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return new IEdmVocabularyAnnotatable[] { NavigationProperty, EntityType };
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => NavigationProperty.Name;
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationPropertySegment.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
@@ -40,7 +41,7 @@ namespace Microsoft.OpenApi.OData.Edm
 
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
-			return new IEdmVocabularyAnnotatable[] { NavigationProperty, EntityType };
+			return new IEdmVocabularyAnnotatable[] { NavigationProperty, EntityType }.Union(EntityType.FindAllBaseTypes());
 		}
 
 		/// <inheritdoc />

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationPropertySegment.cs
@@ -39,6 +39,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => NavigationProperty.Name; }
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return new IEdmVocabularyAnnotatable[] { NavigationProperty, EntityType }.Union(EntityType.FindAllBaseTypes());

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationSourceSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationSourceSegment.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -37,7 +38,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.NavigationSource;
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => NavigationSource.Name;
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return new IEdmVocabularyAnnotatable[] { NavigationSource as IEdmVocabularyAnnotatable, EntityType };
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => NavigationSource.Name;
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationSourceSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationSourceSegment.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
@@ -40,7 +41,7 @@ namespace Microsoft.OpenApi.OData.Edm
 
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
-			return new IEdmVocabularyAnnotatable[] { NavigationSource as IEdmVocabularyAnnotatable, EntityType };
+			return new IEdmVocabularyAnnotatable[] { NavigationSource as IEdmVocabularyAnnotatable, EntityType }.Union(EntityType.FindAllBaseTypes());
 		}
 
 		/// <inheritdoc />

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationSourceSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataNavigationSourceSegment.cs
@@ -39,6 +39,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.NavigationSource;
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return new IEdmVocabularyAnnotatable[] { NavigationSource as IEdmVocabularyAnnotatable, EntityType }.Union(EntityType.FindAllBaseTypes());

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationImportSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationImportSegment.cs
@@ -54,6 +54,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => OperationImport.Name; }
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return new IEdmVocabularyAnnotatable[] { OperationImport };

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationImportSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationImportSegment.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -53,8 +54,13 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => OperationImport.Name; }
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters)
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return new IEdmVocabularyAnnotatable[] { OperationImport };
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters)
         {
             Utils.CheckArgumentNull(settings, nameof(settings));
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -171,6 +171,7 @@ namespace Microsoft.OpenApi.OData.Edm
             }
         }
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return new IEdmVocabularyAnnotatable[] { Operation };

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -169,5 +170,10 @@ namespace Microsoft.OpenApi.OData.Edm
                 return action.FullName();
             }
         }
-    }
+
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return new IEdmVocabularyAnnotatable[] { Operation };
+		}
+	}
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataRefSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataRefSegment.cs
@@ -32,6 +32,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$ref";
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return Enumerable.Empty<IEdmVocabularyAnnotatable>();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataRefSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataRefSegment.cs
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OpenApi.OData.Edm
 {
@@ -30,7 +32,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$ref";
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$ref";
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$ref";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
@@ -7,8 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
-using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.OpenApiExtensions;
 
 namespace Microsoft.OpenApi.OData.Edm
 {
@@ -121,5 +121,9 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <param name="parameters">The existing parameters.</param>
         /// <returns>The path item name.</returns>
         public abstract string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters);
+        /// <summary>
+        /// Provides any deprecation information for the segment.
+        /// </summary>
+        public OpenApiDeprecationExtension Depreciation { get; set; }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
@@ -124,6 +124,6 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <summary>
         /// Provides any deprecation information for the segment.
         /// </summary>
-        public OpenApiDeprecationExtension Depreciation { get; set; }
+        public OpenApiDeprecationExtension Deprecation { get; set; }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.OpenApiExtensions;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -125,5 +126,9 @@ namespace Microsoft.OpenApi.OData.Edm
         /// Provides any deprecation information for the segment.
         /// </summary>
         public OpenApiDeprecationExtension Deprecation { get; set; }
+        /// <summary>
+        /// Returns the list of <see cref="IEdmVocabularyAnnotatable"/> this segment refers to.
+        /// </summary>
+        public abstract IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables();
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
@@ -122,6 +122,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <param name="parameters">The existing parameters.</param>
         /// <returns>The path item name.</returns>
         public abstract string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters);
+
         /// <summary>
         /// Provides any deprecation information for the segment.
         /// </summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OpenApi.OData.Edm
 {
@@ -18,7 +20,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$value";
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$value";
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$value";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
@@ -20,6 +20,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier => "$value";
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return Enumerable.Empty<IEdmVocabularyAnnotatable>();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
@@ -3,6 +3,8 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -28,7 +30,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => _streamPropertyName; }
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => _streamPropertyName;
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => _streamPropertyName;
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
@@ -30,6 +30,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => _streamPropertyName; }
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return Enumerable.Empty<IEdmVocabularyAnnotatable>();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -32,7 +34,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => EntityType.FullTypeName(); }
 
-        /// <inheritdoc />
-        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => EntityType.FullTypeName();
+		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+		{
+			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+		}
+
+		/// <inheritdoc />
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => EntityType.FullTypeName();
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
@@ -34,6 +34,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
         public override string Identifier { get => EntityType.FullTypeName(); }
 
+        /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
 			return Enumerable.Empty<IEdmVocabularyAnnotatable>();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
@@ -37,7 +36,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
-			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
+			return new IEdmVocabularyAnnotatable[] { EntityType };
 		}
 
 		/// <inheritdoc />

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/RecordExpressionExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/RecordExpressionExtensions.cs
@@ -70,6 +70,23 @@ namespace Microsoft.OpenApi.OData.Edm
         }
 
         /// <summary>
+        /// Get the DateTime value from the record using the given property name.
+        /// </summary>
+        /// <param name="record">The record expression.</param>
+        /// <param name="propertyName">The property name.</param>
+        /// <returns>The DateTime value or null.</returns>
+        public static DateTime? GetDateTime(this IEdmRecordExpression record, string propertyName)
+        {
+            Utils.CheckArgumentNull(record, nameof(record));
+            Utils.CheckArgumentNull(propertyName, nameof(propertyName));
+
+            return (record.Properties?.FirstOrDefault(e => e.Name == propertyName) is IEdmPropertyConstructor property &&
+                property.Value is IEdmDateConstantExpression value) ?
+                value.Value :
+                null;
+        }
+
+        /// <summary>
         /// Get the Enum value from the record using the given property name.
         /// </summary>
         /// <typeparam name="T">The output enum type.</typeparam>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -203,6 +203,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool RequireDerivedTypesConstraintForODataTypeCastSegments { get; set; } = true;
 
+        /// <summary>
+        /// Gets/sets a value indicating whether or not to set the deprecated tag for the operation when a revision is present as well as the "x-ms-deprecation" extension with additional information.
+        /// </summary>
+        public bool EnableDeprecationInformation { get; set; } = true;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -237,6 +242,7 @@ namespace Microsoft.OpenApi.OData
                 AddSingleQuotesForStringParameters = this.AddSingleQuotesForStringParameters,
                 EnableODataTypeCast = this.EnableODataTypeCast,
                 RequireDerivedTypesConstraintForODataTypeCastSegments = this.RequireDerivedTypesConstraintForODataTypeCastSegments,
+                EnableDeprecationInformation = this.EnableDeprecationInformation,
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
@@ -1,6 +1,10 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System;
 using System.Linq;
-using Microsoft.OpenApi;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -10,28 +11,47 @@ namespace Microsoft.OpenApi.OData.OpenApiExtensions;
 /// </summary>
 public class OpenApiDeprecationExtension : IOpenApiExtension
 {
-	/// <summary>
-	/// Name of the extension as used in the description.
-	/// </summary>
-	public string Name => "x-ms-deprecation";
-	/// <summary>
-	/// The date at which the element has been/will be removed entirely from the service.
-	/// </summary>
-	public DateTime? RemovalDate { get; set; }
-	/// <summary>
-	/// The date at which the element has been/will be deprecated.
-	/// </summary>
-	public DateTime? Date { get; set; }
-	/// <summary>
-	/// The version this revision was introduced.
-	/// </summary>
-	public string Version { get; set; }
-	/// <summary>
-	/// The description of the revision.
-	/// </summary>
-	public string Description { get; set; }
-	public void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
-	{
-		throw new System.NotImplementedException();
-	}
+    /// <summary>
+    /// Name of the extension as used in the description.
+    /// </summary>
+    public string Name => "x-ms-deprecation";
+    /// <summary>
+    /// The date at which the element has been/will be removed entirely from the service.
+    /// </summary>
+    public DateTime? RemovalDate { get; set; }
+    /// <summary>
+    /// The date at which the element has been/will be deprecated.
+    /// </summary>
+    public DateTime? Date { get; set; }
+    /// <summary>
+    /// The version this revision was introduced.
+    /// </summary>
+    public string Version { get; set; }
+    /// <summary>
+    /// The description of the revision.
+    /// </summary>
+    public string Description { get; set; }
+    public void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+    {
+        if(writer == null)
+            throw new ArgumentNullException(nameof(writer));
+
+        if(RemovalDate.HasValue || Date.HasValue || !string.IsNullOrEmpty(Version) || !string.IsNullOrEmpty(Description))
+        {
+            writer.WriteStartObject();
+
+            if(RemovalDate.HasValue)
+                writer.WriteProperty(ToFirstCharacterLowerCase(nameof(RemovalDate)), RemovalDate.Value);
+            if(Date.HasValue)
+                writer.WriteProperty(ToFirstCharacterLowerCase(nameof(Date)), Date.Value);
+            if(!string.IsNullOrEmpty(Version))
+                writer.WriteProperty(ToFirstCharacterLowerCase(nameof(Version)), Version);
+            if(!string.IsNullOrEmpty(Description))
+                writer.WriteProperty(ToFirstCharacterLowerCase(nameof(Description)), Description);
+
+            writer.WriteEndObject();
+        }
+    }
+    private static string ToFirstCharacterLowerCase(string input)
+            => string.IsNullOrEmpty(input) ? input : $"{char.ToLowerInvariant(input.FirstOrDefault())}{input.Substring(1)}";
 }

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Writers;
+
+namespace Microsoft.OpenApi.OData.OpenApiExtensions;
+
+/// <summary>
+/// Extension element for OpenAPI to add deprecation information. x-ms-deprecation
+/// </summary>
+public class OpenApiDeprecationExtension : IOpenApiExtension
+{
+	/// <summary>
+	/// Name of the extension as used in the description.
+	/// </summary>
+	public string Name => "x-ms-deprecation";
+	/// <summary>
+	/// The date at which the element has been/will be removed entirely from the service.
+	/// </summary>
+	public DateTime? RemovalDate { get; set; }
+	/// <summary>
+	/// The date at which the element has been/will be deprecated.
+	/// </summary>
+	public DateTime? Date { get; set; }
+	/// <summary>
+	/// The version this revision was introduced.
+	/// </summary>
+	public string Version { get; set; }
+	/// <summary>
+	/// The description of the revision.
+	/// </summary>
+	public string Description { get; set; }
+	public void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+	{
+		throw new System.NotImplementedException();
+	}
+}

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiDeprecationExtension.cs
@@ -31,6 +31,7 @@ public class OpenApiDeprecationExtension : IOpenApiExtension
     /// The description of the revision.
     /// </summary>
     public string Description { get; set; }
+	/// <inheritdoc />
     public void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
     {
         if(writer == null)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -48,22 +47,6 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 operation.OperationId = $"Get.Count.{LastSecondSegment.Identifier}-{Path.GetPathHash(Context.Settings)}";
-            }
-            
-            var annotable = LastSecondSegment switch
-			{
-				ODataNavigationPropertySegment navigationPropertySegment => navigationPropertySegment.NavigationProperty as IEdmVocabularyAnnotatable,
-				_ => throw new System.NotImplementedException(), //TODO other segment types
-			};
-
-            //TODO go up the tree and lookup the type?
-            var deprecationInfo = Context.GetDeprecationInformation(annotable);
-
-            if(deprecationInfo != null)
-            {
-                operation.Deprecated = true;
-                var deprecationDetails = deprecationInfo.GetOpenApiExtension();
-                operation.Extensions.Add(deprecationDetails.Name, deprecationDetails);
             }
 
             base.SetBasicInfo(operation);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -40,6 +40,7 @@ namespace Microsoft.OpenApi.OData.Operation
 
             // Description / Summary / OperationId
             SetBasicInfo(operation);
+            SetDeprecation(operation);
 
             // Security
             SetSecurity(operation);
@@ -63,6 +64,26 @@ namespace Microsoft.OpenApi.OData.Operation
             SetExtensions(operation);
 
             return operation;
+        }
+
+        private void SetDeprecation(OpenApiOperation operation)
+        {
+            if(operation != null && Context.Settings.EnableDeprecationInformation)
+            {
+                var deprecationInfo = Path.SelectMany(x => x.GetAnnotables())
+                                    .SelectMany(x => Context.GetDeprecationInformations(x))
+                                    .Where(x => x != null)
+                                    .OrderByDescending(x => x.Date)
+                                    .ThenByDescending(x => x.RemovalDate)
+                                    .FirstOrDefault();
+
+                if(deprecationInfo != null)
+                {
+                    operation.Deprecated = true;
+                    var deprecationDetails = deprecationInfo.GetOpenApiExtension();
+                    operation.Extensions.Add(deprecationDetails.Name, deprecationDetails);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 
@@ -13,12 +14,28 @@ namespace Microsoft.OpenApi.OData.PathItem;
 /// </summary>
 internal class ODataTypeCastPathItemHandler : PathItemHandler
 {
-	/// <inheritdoc/>
-	protected override ODataPathKind HandleKind => ODataPathKind.TypeCast;
+    /// <inheritdoc/>
+    protected override ODataPathKind HandleKind => ODataPathKind.TypeCast;
 
-	/// <inheritdoc/>
-	protected override void SetOperations(OpenApiPathItem item)
-	{
-		AddOperation(item, OperationType.Get);
-	}
+    /// <inheritdoc/>
+    protected override void SetOperations(OpenApiPathItem item)
+    {
+        AddOperation(item, OperationType.Get);
+    }
+    /// <inheritdoc/>
+    protected override void Initialize(ODataContext context, ODataPath path)
+    {
+        base.Initialize(context, path);
+        if(path.LastSegment is ODataTypeCastSegment castSegment)
+        {
+            EntityType = castSegment.EntityType;
+        }
+    }
+    private IEdmEntityType EntityType { get; set; }
+    /// <inheritdoc/>
+    protected override void SetBasicInfo(OpenApiPathItem pathItem)
+    {
+        base.SetBasicInfo(pathItem);
+        pathItem.Description = $"Casts the previous resource to {EntityType.Name}.";
+    }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 ﻿abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 abstract Microsoft.OpenApi.OData.Edm.ODataSegment.Identifier.get -> string
 abstract Microsoft.OpenApi.OData.Edm.ODataSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
@@ -165,44 +166,57 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.VerifyEdmModel.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.VerifyEdmModel.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.Version.get -> System.Version
 Microsoft.OpenApi.OData.OpenApiConvertSettings.Version.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDeprecationInformation.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDeprecationInformation.set -> void
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataKeySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataKeySegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataKeySegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataKeySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataKeySegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataNavigationPropertySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataNavigationPropertySegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataNavigationPropertySegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataNavigationPropertySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataNavigationPropertySegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataNavigationSourceSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataNavigationSourceSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataNavigationSourceSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataNavigationSourceSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataNavigationSourceSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataPath.ToString() -> string
 override Microsoft.OpenApi.OData.Edm.ODataRefSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataRefSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataRefSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataRefSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 static Microsoft.OpenApi.OData.Common.Utils.GetTermQualifiedName<T>() -> string
 static Microsoft.OpenApi.OData.Common.Utils.GetUniqueName(string input, System.Collections.Generic.HashSet<string> set) -> string
 static Microsoft.OpenApi.OData.Common.Utils.UpperFirstChar(string input) -> string
@@ -222,3 +236,17 @@ virtual Microsoft.OpenApi.OData.Edm.ODataPathProvider.CanFilter(Microsoft.OData.
 virtual Microsoft.OpenApi.OData.Edm.ODataPathProvider.GetPaths(Microsoft.OData.Edm.IEdmModel model, Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> System.Collections.Generic.IEnumerable<Microsoft.OpenApi.OData.Edm.ODataPath>
 virtual Microsoft.OpenApi.OData.Edm.ODataPathProvider.Initialize(Microsoft.OData.Edm.IEdmModel model) -> void
 virtual Microsoft.OpenApi.OData.Edm.ODataSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
+Microsoft.OpenApi.OData.Edm.ODataSegment.Deprecation.get -> Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension
+Microsoft.OpenApi.OData.Edm.ODataSegment.Deprecation.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.OpenApiDeprecationExtension() -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Name.get -> string
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Version.get -> string
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Version.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Description.get -> string
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Description.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.RemovalDate.get -> System.DateTime?
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.RemovalDate.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Date.get -> System.DateTime?
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Date.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Write(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.OpenApiSpecVersion specVersion) -> void

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/DeprecatedRevisionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/DeprecatedRevisionsType.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.OpenApiExtensions;
+
+namespace Microsoft.OpenApi.OData.Vocabulary.Core;
+
+/// <summary>
+/// Specialized type for Org.OData.Core.V1.Revisions to easily access the additional properties.
+/// </summary>
+[Term("Org.OData.Core.V1.Revisions")]
+internal class DeprecatedRevisionsType : RevisionsType
+{
+	/// <summary>
+	/// The date at which the element has been/will be removed entirely from the service.
+	/// </summary>
+	public DateTime? RemovalDate { get; private set; }
+	/// <summary>
+	/// The date at which the element has been/will be deprecated.
+	/// </summary>
+	public DateTime? Date { get; private set; }
+	/// <summary>
+	/// Init the <see cref="DeprecatedRevisionsType"/>.
+	/// </summary>
+	/// <param name="record">The input record.</param>
+	public new void Initialize(IEdmRecordExpression record)
+	{
+		base.Initialize(record);
+		if (Kind != RevisionKind.Deprecated)
+		{
+			throw new InvalidOperationException("The kind of the revision must be Deprecated.");
+		}
+		RemovalDate = record.GetDateTime(nameof(RemovalDate));
+		Date = record.GetDateTime(nameof(Date));
+	}
+	/// <summary>
+	/// Gets a <see cref="OpenApiDeprecationExtension"/> from the current annotation.
+	/// </summary>
+	internal OpenApiDeprecationExtension GetOpenApiExtension()
+	{
+		return new OpenApiDeprecationExtension
+		{
+			Date = Date,
+			RemovalDate = RemovalDate,
+			Description = Description,
+			Version = Version,
+		};
+	}
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/DeprecatedRevisionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/DeprecatedRevisionsType.cs
@@ -23,7 +23,7 @@ internal class DeprecatedRevisionsType : RevisionsType
 	/// Init the <see cref="DeprecatedRevisionsType"/>.
 	/// </summary>
 	/// <param name="record">The input record.</param>
-	public new void Initialize(IEdmRecordExpression record)
+	public override void Initialize(IEdmRecordExpression record)
 	{
 		base.Initialize(record);
 		if (Kind != RevisionKind.Deprecated)

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionKind.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionKind.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.OpenApi.OData.Vocabulary.Core;
+
+internal enum RevisionKind
+{
+	Added = 0,
+	Modified = 1,
+	Deprecated = 2,
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionsType.cs
@@ -27,7 +27,7 @@ internal class RevisionsType : IRecord
 	/// Init the <see cref="RevisionsType"/>.
 	/// </summary>
 	/// <param name="record">The input record.</param>
-	public void Initialize(IEdmRecordExpression record)
+	public virtual void Initialize(IEdmRecordExpression record)
 	{
 		Utils.CheckArgumentNull(record, nameof(record));
 		Kind = record.GetEnum<RevisionKind>(nameof(Kind));

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionsType.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+
+namespace Microsoft.OpenApi.OData.Vocabulary.Core;
+
+/// <summary>
+/// Complex Type: Org.OData.Core.V1.Revisions
+/// </summary>
+[Term("Org.OData.Core.V1.Revisions")]
+internal class RevisionsType : IRecord
+{
+	/// <summary>
+	/// The version this revision was introduced.
+	/// </summary>
+	public string Version { get; private set; }
+	/// <summary>
+	/// The kind of the revision
+	/// </summary>
+	public RevisionKind? Kind { get; private set; }
+	/// <summary>
+	/// The description of the revision.
+	/// </summary>
+	public string Description { get; private set; }
+	/// <summary>
+	/// Init the <see cref="RevisionsType"/>.
+	/// </summary>
+	/// <param name="record">The input record.</param>
+	public void Initialize(IEdmRecordExpression record)
+	{
+		Utils.CheckArgumentNull(record, nameof(record));
+		Kind = record.GetEnum<RevisionKind>(nameof(Kind));
+		Version = record.GetString(nameof(Version));
+		Description = record.GetString(nameof(Description));
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.OpenApi.OData.Reader.Tests</AssemblyName>
     <RootNamespace>Microsoft.OpenApi.OData.Reader.Tests</RootNamespace>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\tool\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/OpenApiExtensions/OpenApiDeprecationExtensionTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/OpenApiExtensions/OpenApiDeprecationExtensionTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Writers;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.OpenApiExtensions.Tests;
+
+public class OpenApiDeprecationExtensionTests
+{
+    [Fact]
+    public void ExtensionNameMatchesExpected()
+    {
+        // Arrange
+        OpenApiDeprecationExtension extension = new();
+
+        // Act
+        string name = extension.Name;
+        string expectedName = "x-ms-deprecation";
+        Assert.Equal(expectedName, name);
+
+        // Assert
+        Assert.Equal(expectedName, name);
+    }
+    [Fact]
+    public void WritesNothingWhenNoValues()
+    {
+        // Arrange
+        OpenApiDeprecationExtension extension = new();
+        using TextWriter sWriter = new StringWriter();
+        OpenApiJsonWriter writer = new(sWriter);
+
+        // Act
+        extension.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+        string result = sWriter.ToString();
+
+        // Assert
+        Assert.Null(extension.Date);
+        Assert.Null(extension.RemovalDate);
+        Assert.Null(extension.Version);
+        Assert.Null(extension.Description);
+        Assert.Empty(result);
+    }
+    [Fact]
+    public void WritesAllValues()
+    {
+        // Arrange
+        OpenApiDeprecationExtension extension = new() {
+            Date = new DateTime(2020, 1, 1),
+            RemovalDate = new DateTime(2021, 1, 1),
+            Version = "1.0.0",
+            Description = "This is a test"
+        };
+        using TextWriter sWriter = new StringWriter();
+        OpenApiJsonWriter writer = new(sWriter);
+
+        // Act
+        extension.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+        string result = sWriter.ToString();
+
+        // Assert
+        Assert.NotNull(extension.Date);
+        Assert.NotNull(extension.RemovalDate);
+        Assert.NotNull(extension.Version);
+        Assert.NotNull(extension.Description);
+        Assert.Contains("2021-01-01T00:00:00.000000", result);
+        Assert.Contains("removalDate", result);
+        Assert.Contains("version", result);
+        Assert.Contains("1.0.0", result);
+        Assert.Contains("description", result);
+        Assert.Contains("This is a test", result);
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/OpenApiExtensions/OpenApiDeprecationExtensionTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/OpenApiExtensions/OpenApiDeprecationExtensionTests.cs
@@ -1,6 +1,10 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System;
 using System.IO;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 using Xunit;
 
@@ -17,11 +21,11 @@ public class OpenApiDeprecationExtensionTests
         // Act
         string name = extension.Name;
         string expectedName = "x-ms-deprecation";
-        Assert.Equal(expectedName, name);
 
         // Assert
         Assert.Equal(expectedName, name);
     }
+
     [Fact]
     public void WritesNothingWhenNoValues()
     {
@@ -41,6 +45,7 @@ public class OpenApiDeprecationExtensionTests
         Assert.Null(extension.Description);
         Assert.Empty(result);
     }
+
     [Fact]
     public void WritesAllValues()
     {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -16,7 +16,58 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 {
     public class EdmFunctionOperationHandlerTests
     {
-        private EdmFunctionOperationHandler _operationHandler = new EdmFunctionOperationHandler();
+        private EdmFunctionOperationHandler _operationHandler = new();
+        #region OperationHandlerTests
+        [Fact]
+        public void SetsDeprecationInformation()
+        {
+          // Arrange
+          IEdmModel model = EdmModelHelper.TripServiceModel;
+          ODataContext context = new(model);
+          IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+          Assert.NotNull(people);
+
+          IEdmFunction function = model.SchemaElements.OfType<IEdmFunction>().First(f => f.Name == "GetFriendsTrips");
+          Assert.NotNull(function);
+
+          ODataPath path = new(new ODataNavigationSourceSegment(people), new ODataKeySegment(people.EntityType()), new ODataOperationSegment(function));
+
+          // Act
+          var operation = _operationHandler.CreateOperation(context, path);
+
+          // Assert
+          Assert.NotNull(operation);
+          Assert.True(operation.Deprecated);
+          Assert.NotEmpty(operation.Extensions);
+          var extension = operation.Extensions["x-ms-deprecation"];
+          Assert.NotNull(extension);
+        }
+        [Fact]
+        public void DoesntSetDeprecationInformation()
+        {
+          // Arrange
+          IEdmModel model = EdmModelHelper.TripServiceModel;
+          ODataContext context = new(model);
+          IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+          Assert.NotNull(people);
+
+          IEdmFunction function = model.SchemaElements.OfType<IEdmFunction>().First(f => f.Name == "GetFavoriteAirline");
+          Assert.NotNull(function);
+
+          ODataPath path = new(new ODataNavigationSourceSegment(people), new ODataKeySegment(people.EntityType()), new ODataOperationSegment(function));
+
+          // Act
+          var operation = _operationHandler.CreateOperation(context, path);
+
+          // Assert
+          Assert.NotNull(operation);
+          Assert.True(operation.Deprecated);
+          Assert.NotEmpty(operation.Extensions);
+          var extension = operation.Extensions["x-ms-deprecation"];
+          Assert.NotNull(extension);
+        }
+
+        #endregion
 
         [Fact]
         public void CreateOperationForEdmFunctionReturnsCorrectOperation()

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
           var extension = operation.Extensions["x-ms-deprecation"];
           Assert.NotNull(extension);
         }
+
         [Fact]
         public void DoesntSetDeprecationInformation()
         {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ODataTypeCastGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ODataTypeCastGetOperationHandlerTests.cs
@@ -56,7 +56,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)
-            Assert.Single(operation.Extensions);
+            Assert.Equal(2, operation.Extensions.Count); //deprecated, pagination
 
         Assert.Equal(2, operation.Responses.Count);
         Assert.Equal(new string[] { "200", "default" }, operation.Responses.Select(e => e.Key));
@@ -114,7 +114,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)
-            Assert.Empty(operation.Extensions);
+            Assert.Single(operation.Extensions); //deprecated
 
         Assert.Equal(2, operation.Responses.Count);
         Assert.Equal(new string[] { "200", "default" }, operation.Responses.Select(e => e.Key));
@@ -167,7 +167,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)
-            Assert.Single(operation.Extensions);
+            Assert.Equal(2, operation.Extensions.Count);
 
         Assert.Equal(2, operation.Responses.Count);
         Assert.Equal(new string[] { "200", "default" }, operation.Responses.Select(e => e.Key));
@@ -222,7 +222,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)
-            Assert.Empty(operation.Extensions);
+            Assert.Single(operation.Extensions); // deprecated
 
         Assert.Equal(2, operation.Responses.Count);
         Assert.Equal(new string[] { "200", "default" }, operation.Responses.Select(e => e.Key));
@@ -279,7 +279,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)
-            Assert.Empty(operation.Extensions);
+            Assert.Single(operation.Extensions); //deprecated
 
         Assert.Equal(2, operation.Responses.Count);
         Assert.Equal(new string[] { "200", "default" }, operation.Responses.Select(e => e.Key));
@@ -332,7 +332,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)
-            Assert.Empty(operation.Extensions);
+            Assert.Single(operation.Extensions); //deprecated
 
         Assert.Equal(2, operation.Responses.Count);
         Assert.Equal(new string[] { "200", "default" }, operation.Responses.Select(e => e.Key));

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -33,6 +33,19 @@
               <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
             </Collection>
           </Annotation>
+          <Annotation Term="Org.OData.Core.V1.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Date="2021-08-24" Property="Date" />
+                <PropertyValue Property="Description" String="The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API." />
+                <PropertyValue Property="Kind">
+                  <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+                </PropertyValue>
+                <PropertyValue Date="2023-03-15" Property="RemovalDate" />
+                <PropertyValue Property="Version" String="2021-05/bestfriend" />
+              </Record>
+            </Collection>
+          </Annotation>
         </NavigationProperty>
         <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" ContainsTarget="true">
           <Annotation Term="Org.OData.Core.V1.Description" String="Collection of trips." />
@@ -142,6 +155,19 @@
         <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
         <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" />
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Date="2021-08-24" Property="Date" />
+              <PropertyValue Property="Description" String="The GetFriendsTrips API is deprecated and will stop returning data on March 2023. Please use the new trips API on friends." />
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Date="2023-03-15" Property="RemovalDate" />
+              <PropertyValue Property="Version" String="2021-05/trips" />
+            </Record>
+          </Collection>
+        </Annotation>
       </Function>
       <Function Name="GetInvolvedPeople" IsBound="true">
         <Parameter Name="trip" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip" />
@@ -182,6 +208,19 @@
               <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
             </Collection>
           </Annotation>
+          <Annotation Term="Org.OData.Core.V1.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Date="2021-08-24" Property="Date" />
+                <PropertyValue Property="Description" String="The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API." />
+                <PropertyValue Property="Kind">
+                  <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+                </PropertyValue>
+                <PropertyValue Date="2023-03-15" Property="RemovalDate" />
+                <PropertyValue Property="Version" String="2021-05/people" />
+              </Record>
+            </Collection>
+          </Annotation>
         </EntitySet>
         <EntitySet Name="Airlines" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline">
           <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
@@ -197,6 +236,19 @@
             <Collection>
               <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
               <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
+            </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Core.V1.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Date="2021-08-24" Property="Date" />
+                <PropertyValue Property="Description" String="The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API." />
+                <PropertyValue Property="Kind">
+                  <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+                </PropertyValue>
+                <PropertyValue Date="2023-03-15" Property="RemovalDate" />
+                <PropertyValue Property="Version" String="2021-05/me" />
+              </Record>
             </Collection>
           </Annotation>
         </Singleton>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -701,6 +701,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -730,6 +737,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -799,6 +813,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
@@ -824,6 +845,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -859,6 +887,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -883,6 +918,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -950,8 +992,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -1073,6 +1123,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
@@ -1118,6 +1175,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -1139,6 +1203,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -1223,6 +1294,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -1261,6 +1339,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -1328,8 +1413,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -1451,6 +1544,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
@@ -1496,6 +1596,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -1517,6 +1624,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -1601,6 +1715,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -1639,6 +1760,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -1764,6 +1892,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
@@ -1804,6 +1939,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -1879,8 +2021,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -2010,6 +2160,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
@@ -2063,6 +2220,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -2094,6 +2258,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -2186,6 +2357,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -2232,6 +2410,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -2307,8 +2492,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -2438,6 +2631,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
@@ -2491,6 +2691,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -2522,6 +2729,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -2614,6 +2828,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -2661,6 +2882,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -2682,6 +2910,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -2766,6 +3001,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -2804,6 +3046,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -2871,8 +3120,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
       "get": {
@@ -2891,6 +3148,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -2957,8 +3221,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
       "get": {
@@ -2977,6 +3249,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -3043,8 +3322,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -3166,6 +3453,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
@@ -3211,6 +3505,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -3232,6 +3533,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -3316,6 +3624,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -3355,6 +3670,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -3379,6 +3701,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -3422,6 +3751,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -3481,6 +3817,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "action"
       },
@@ -3548,8 +3891,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -3671,6 +4022,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
@@ -3716,6 +4074,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -3737,6 +4102,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -3821,6 +4193,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -3860,6 +4239,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -3898,6 +4284,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "action"
       },
@@ -3944,6 +4337,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "action"
       },
       "x-description": "Provides operations to call the ShareTrip method."
@@ -3983,6 +4383,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -4096,6 +4503,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -4132,6 +4546,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -4205,6 +4626,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -4247,6 +4675,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -4282,6 +4717,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -4329,6 +4771,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -4441,6 +4890,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity."
@@ -4496,6 +4952,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -4530,6 +4993,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -4613,6 +5083,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -4663,6 +5140,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -4684,6 +5168,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -5064,6 +5555,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
@@ -5099,6 +5597,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -5142,6 +5647,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -5174,6 +5686,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -5249,8 +5768,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -5380,6 +5907,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
@@ -5432,6 +5966,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -5463,6 +6004,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -5555,6 +6103,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -5601,6 +6156,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -5676,8 +6238,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -5807,6 +6377,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
@@ -5859,6 +6436,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -5890,6 +6474,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -5982,6 +6573,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -6028,6 +6626,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -6293,7 +6898,8 @@
             "$ref": "#/responses/error"
           }
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -6768,7 +7374,8 @@
             "$ref": "#/responses/error"
           }
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -7405,7 +8012,8 @@
             "$ref": "#/responses/error"
           }
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
       "get": {
@@ -7509,7 +8117,8 @@
             "$ref": "#/responses/error"
           }
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
       "get": {
@@ -7623,6 +8232,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/trips",
+          "description": "The GetFriendsTrips API is deprecated and will stop returning data on March 2023. Please use the new trips API on friends."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -8781,6 +9397,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "post": {
@@ -8816,6 +9439,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -8892,6 +9522,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -8930,6 +9567,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -8961,6 +9605,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -9038,6 +9689,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
@@ -9073,6 +9731,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -9116,6 +9781,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -9148,6 +9820,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -9223,8 +9902,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -9354,6 +10041,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
@@ -9407,6 +10101,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -9438,6 +10139,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -9530,6 +10238,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -9576,6 +10291,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -9651,8 +10373,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -9782,6 +10512,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
@@ -9835,6 +10572,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -9866,6 +10610,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -9958,6 +10709,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -10004,6 +10762,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -10137,6 +10902,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
@@ -10185,6 +10957,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -10268,8 +11047,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -10407,6 +11194,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
@@ -10468,6 +11262,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -10507,6 +11308,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -10607,6 +11415,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -10661,6 +11476,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -10744,8 +11566,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -10883,6 +11713,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
@@ -10944,6 +11781,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -10983,6 +11827,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -11083,6 +11934,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -11138,6 +11996,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -11169,6 +12034,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -11261,6 +12133,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -11307,6 +12186,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -11382,8 +12268,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
       "get": {
@@ -11412,6 +12306,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -11486,8 +12387,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
       "get": {
@@ -11516,6 +12425,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -11590,8 +12506,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
@@ -11721,6 +12645,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
@@ -11774,6 +12705,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -11805,6 +12743,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -11897,6 +12842,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -11944,6 +12896,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -11978,6 +12937,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -12029,6 +12995,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -12096,6 +13069,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "action"
       },
@@ -12171,8 +13151,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -12302,6 +13290,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
@@ -12355,6 +13350,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -12386,6 +13388,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -12478,6 +13487,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -12525,6 +13541,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -12571,6 +13594,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "action"
       },
@@ -12625,6 +13655,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "action"
       },
       "x-description": "Provides operations to call the ShareTrip method."
@@ -12672,6 +13709,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -12793,6 +13837,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -12837,6 +13888,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -12918,6 +13976,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -12968,6 +14033,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -13011,6 +14083,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -13066,6 +14145,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       },
@@ -13186,6 +14272,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity."
@@ -13249,6 +14342,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -13291,6 +14391,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -13382,6 +14489,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -13440,6 +14554,13 @@
             "$ref": "#/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
@@ -13471,6 +14592,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -13492,6 +14620,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -13558,8 +14693,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
       "get": {
@@ -13578,6 +14721,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
@@ -13644,8 +14794,16 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
-      }
+      },
+      "x-description": "Casts the previous resource to Manager."
     },
     "/People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
       "get": {
@@ -13664,6 +14822,13 @@
           "default": {
             "$ref": "#/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "x-description": "Provides operations to count the resources in the collection."

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -474,6 +474,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -494,6 +500,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Person singleton.
   /Me/BestFriend:
@@ -545,6 +557,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   /Me/BestFriend/$ref:
@@ -563,6 +581,12 @@ paths:
             type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     put:
       tags:
@@ -586,6 +610,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -603,6 +633,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
@@ -653,6 +689,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Employee.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers:
     get:
       tags:
@@ -741,6 +784,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     x-ms-docs-grouped-path:
@@ -772,6 +821,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
@@ -787,6 +842,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref:
     get:
@@ -844,6 +905,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -870,6 +937,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
@@ -920,6 +993,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Manager.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     get:
       tags:
@@ -1008,6 +1088,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     x-ms-docs-grouped-path:
@@ -1039,6 +1125,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
@@ -1054,6 +1146,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref:
     get:
@@ -1111,6 +1209,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -1137,6 +1241,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Friends:
@@ -1227,6 +1337,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/Me/Friends/{UserName}/$ref':
@@ -1255,6 +1371,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
@@ -1311,6 +1433,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Employee.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     get:
       tags:
@@ -1405,6 +1534,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     x-ms-docs-grouped-path:
@@ -1442,6 +1577,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
@@ -1464,6 +1605,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     get:
@@ -1527,6 +1674,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -1559,6 +1712,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
@@ -1615,6 +1774,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Manager.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -1709,6 +1875,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     x-ms-docs-grouped-path:
@@ -1746,6 +1918,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
@@ -1768,6 +1946,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     get:
@@ -1831,6 +2015,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -1863,6 +2053,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Friends/$count:
@@ -1878,6 +2074,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /Me/Friends/$ref:
     get:
@@ -1935,6 +2137,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -1961,6 +2169,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
@@ -2011,6 +2225,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Employee.
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count:
     get:
       summary: Get the number of the resource
@@ -2024,6 +2245,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
     get:
@@ -2073,6 +2300,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Manager.
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count:
     get:
       summary: Get the number of the resource
@@ -2086,6 +2320,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
     get:
@@ -2135,6 +2375,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Employee.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers:
     get:
       tags:
@@ -2223,6 +2470,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     x-ms-docs-grouped-path:
@@ -2254,6 +2507,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
@@ -2269,6 +2528,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref:
     get:
@@ -2326,6 +2591,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -2352,6 +2623,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline():
@@ -2369,6 +2646,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetFavoriteAirline method.
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName=''{userName}'')':
@@ -2398,6 +2681,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetFriendsTrips method.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip:
@@ -2438,6 +2727,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the GetPeersForTrip method.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
@@ -2488,6 +2783,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Manager.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     get:
       tags:
@@ -2576,6 +2878,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     x-ms-docs-grouped-path:
@@ -2607,6 +2915,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
@@ -2622,6 +2936,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref:
     get:
@@ -2679,6 +2999,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -2705,6 +3031,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire:
@@ -2731,6 +3063,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the Hire method.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip:
@@ -2762,6 +3100,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the ShareTrip method.
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName=''{lastName}'')':
@@ -2789,6 +3133,12 @@ paths:
                 type: boolean
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the UpdatePersonLastName method.
   /Me/Trips:
@@ -2867,6 +3217,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -2892,6 +3248,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/Me/Trips/{TripId}':
@@ -2945,6 +3307,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -2975,6 +3343,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -3001,6 +3375,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
@@ -3034,6 +3414,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetInvolvedPeople method.
   '/Me/Trips/{TripId}/PlanItems':
@@ -3109,6 +3495,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
   '/Me/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
@@ -3149,6 +3541,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/Me/Trips/{TripId}/PlanItems/$count':
@@ -3174,6 +3572,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   '/Me/Trips/{TripId}/PlanItems/$ref':
     get:
@@ -3228,6 +3632,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -3263,6 +3673,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Trips/$count:
@@ -3278,6 +3694,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
   /NewComePeople:
     get:
@@ -3551,6 +3973,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/NewComePeople/{UserName}/BestFriend/$ref':
@@ -3576,6 +4004,12 @@ paths:
             type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     put:
       tags:
@@ -3605,6 +4039,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -3628,6 +4068,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
@@ -3684,6 +4130,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to Employee.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     get:
       tags:
@@ -3778,6 +4231,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     x-ms-docs-grouped-path:
@@ -3814,6 +4273,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
@@ -3836,6 +4301,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     x-description: Provides operations to count the resources in the collection.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     get:
@@ -3899,6 +4370,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -3931,6 +4408,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
@@ -3987,6 +4470,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to Manager.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -4081,6 +4571,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     x-ms-docs-grouped-path:
@@ -4117,6 +4613,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
@@ -4139,6 +4641,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     x-description: Provides operations to count the resources in the collection.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     get:
@@ -4202,6 +4710,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -4234,6 +4748,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/NewComePeople/{UserName}/Friends':
@@ -4426,6 +4946,7 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+    x-description: Casts the previous resource to Employee.
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     get:
       tags:
@@ -4765,6 +5286,7 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+    x-description: Casts the previous resource to Manager.
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -5215,6 +5737,7 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+    x-description: Casts the previous resource to Employee.
   '/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count':
     get:
       summary: Get the number of the resource
@@ -5290,6 +5813,7 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+    x-description: Casts the previous resource to Manager.
   '/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count':
     get:
       summary: Get the number of the resource
@@ -5368,6 +5892,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/trips
+        description: The GetFriendsTrips API is deprecated and will stop returning data on March 2023. Please use the new trips API on friends.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetFriendsTrips method.
   '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
@@ -6181,6 +6711,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
       tags:
         - People.Person
@@ -6204,6 +6740,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}':
@@ -6260,6 +6802,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -6286,6 +6834,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -6308,6 +6862,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/BestFriend':
@@ -6365,6 +6925,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/People/{UserName}/BestFriend/$ref':
@@ -6390,6 +6956,12 @@ paths:
             type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     put:
       tags:
@@ -6419,6 +6991,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -6442,6 +7020,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
@@ -6498,6 +7082,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     get:
       tags:
@@ -6592,6 +7183,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     x-ms-docs-grouped-path:
@@ -6629,6 +7226,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
@@ -6651,6 +7254,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     get:
@@ -6714,6 +7323,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -6746,6 +7361,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
@@ -6802,6 +7423,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -6896,6 +7524,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     x-ms-docs-grouped-path:
@@ -6933,6 +7567,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
@@ -6955,6 +7595,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     get:
@@ -7018,6 +7664,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -7050,6 +7702,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Friends':
@@ -7146,6 +7804,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/People/{UserName}/Friends/{UserName1}/$ref':
@@ -7180,6 +7844,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
@@ -7242,6 +7912,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     get:
       tags:
@@ -7342,6 +8019,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     x-ms-docs-grouped-path:
@@ -7385,6 +8068,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
@@ -7413,6 +8102,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     get:
@@ -7482,6 +8177,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -7520,6 +8221,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
@@ -7582,6 +8289,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -7682,6 +8396,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     x-ms-docs-grouped-path:
@@ -7725,6 +8445,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
@@ -7753,6 +8479,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     get:
@@ -7822,6 +8554,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -7860,6 +8598,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Friends/$count':
@@ -7882,6 +8626,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Friends/$ref':
     get:
@@ -7945,6 +8695,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -7977,6 +8733,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
@@ -8033,6 +8795,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count':
     get:
       summary: Get the number of the resource
@@ -8053,6 +8822,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
     get:
@@ -8108,6 +8883,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count':
     get:
       summary: Get the number of the resource
@@ -8128,6 +8910,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     get:
@@ -8183,6 +8971,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     get:
       tags:
@@ -8277,6 +9072,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     x-ms-docs-grouped-path:
@@ -8314,6 +9115,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
@@ -8336,6 +9143,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     get:
@@ -8399,6 +9212,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -8431,6 +9250,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
@@ -8455,6 +9280,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetFavoriteAirline method.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName=''{userName}'')':
@@ -8490,6 +9321,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetFriendsTrips method.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
@@ -8536,6 +9373,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the GetPeersForTrip method.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
@@ -8592,6 +9435,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -8686,6 +9536,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     x-ms-docs-grouped-path:
@@ -8723,6 +9579,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
@@ -8745,6 +9607,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     get:
@@ -8808,6 +9676,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -8840,6 +9714,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire':
@@ -8872,6 +9752,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the Hire method.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
@@ -8909,6 +9795,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the ShareTrip method.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName=''{lastName}'')':
@@ -8942,6 +9834,12 @@ paths:
                 type: boolean
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the UpdatePersonLastName method.
   '/People/{UserName}/Trips':
@@ -9026,6 +9924,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -9057,6 +9961,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/People/{UserName}/Trips/{TripId}':
@@ -9116,6 +10026,12 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -9152,6 +10068,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -9184,6 +10106,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
@@ -9223,6 +10151,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetInvolvedPeople method.
   '/People/{UserName}/Trips/{TripId}/PlanItems':
@@ -9304,6 +10238,12 @@ paths:
                   $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
   '/People/{UserName}/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
@@ -9350,6 +10290,12 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Trips/{TripId}/PlanItems/$count':
@@ -9381,6 +10327,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Trips/{TripId}/PlanItems/$ref':
     get:
@@ -9441,6 +10393,12 @@ paths:
                   type: string
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -9482,6 +10440,12 @@ paths:
             type: object
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Trips/$count':
@@ -9504,6 +10468,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   /People/$count:
     get:
@@ -9518,6 +10488,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
     get:
@@ -9567,6 +10543,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count:
     get:
       summary: Get the number of the resource
@@ -9580,6 +10563,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
     get:
@@ -9629,6 +10618,13 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count:
     get:
       summary: Get the number of the resource
@@ -9642,6 +10638,12 @@ paths:
             $ref: '#/definitions/ODataCountResponse'
         default:
           $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
   /ResetDataSource:
     post:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -825,6 +825,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -851,6 +858,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -931,6 +945,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -957,6 +978,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -989,6 +1017,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -1016,10 +1051,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -1092,6 +1135,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -1232,6 +1282,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -1283,6 +1340,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -1305,6 +1369,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -1395,6 +1466,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -1432,10 +1510,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -1508,6 +1594,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -1648,6 +1741,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -1699,6 +1799,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -1721,6 +1828,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -1811,6 +1925,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -1847,6 +1968,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -1988,6 +2116,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -2035,10 +2170,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -2121,6 +2264,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -2271,6 +2421,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -2332,6 +2489,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -2366,6 +2530,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -2466,6 +2637,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -2515,10 +2693,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -2601,6 +2787,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -2751,6 +2944,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -2812,6 +3012,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -2846,6 +3053,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -2946,6 +3160,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -2995,6 +3216,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -3017,6 +3245,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -3107,6 +3342,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -3144,10 +3386,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -3220,6 +3470,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -3242,10 +3499,18 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
     "/Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -3318,6 +3583,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -3340,10 +3612,18 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -3416,6 +3696,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -3556,6 +3843,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -3607,6 +3901,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -3629,6 +3930,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -3719,6 +4027,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -3756,6 +4071,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -3786,6 +4108,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -3837,6 +4166,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -3900,10 +4236,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "action"
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -3976,6 +4320,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -4116,6 +4467,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -4167,6 +4525,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -4189,6 +4554,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -4279,6 +4651,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -4315,6 +4694,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -4356,6 +4742,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "action"
       }
@@ -4399,6 +4792,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "action"
       }
     },
@@ -4441,6 +4841,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -4570,6 +4977,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -4604,6 +5018,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -4690,6 +5111,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -4733,6 +5161,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -4772,6 +5207,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -4827,6 +5269,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -4957,6 +5406,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -5020,6 +5476,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -5057,6 +5520,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -5148,6 +5618,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -5200,6 +5677,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -5222,6 +5706,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       }
     },
@@ -5647,6 +6138,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -5685,6 +6183,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -5729,6 +6234,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -5766,10 +6278,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -5852,6 +6372,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
       }
     },
@@ -6002,6 +6529,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -6062,6 +6596,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -6096,6 +6637,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
       }
     },
@@ -6196,6 +6744,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -6245,10 +6800,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -6331,6 +6894,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
       }
     },
@@ -6481,6 +7051,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -6541,6 +7118,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -6575,6 +7159,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
       }
     },
@@ -6675,6 +7266,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -6723,6 +7321,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -6935,6 +7540,7 @@
       }
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -7474,6 +8080,7 @@
       }
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -8196,6 +8803,7 @@
       }
     },
     "/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -8316,6 +8924,7 @@
       }
     },
     "/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -8535,6 +9144,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/trips",
+          "description": "The GetFriendsTrips API is deprecated and will stop returning data on March 2023. Please use the new trips API on friends."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -9835,6 +10451,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
       "post": {
@@ -9868,6 +10491,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -9957,6 +10587,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -9996,6 +10633,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -10031,6 +10675,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -10121,6 +10772,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -10159,6 +10817,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       },
@@ -10203,6 +10868,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -10240,10 +10912,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -10326,6 +11006,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -10476,6 +11163,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -10537,6 +11231,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -10571,6 +11272,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -10671,6 +11379,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -10720,10 +11435,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -10806,6 +11529,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -10956,6 +11686,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -11017,6 +11754,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -11051,6 +11795,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -11151,6 +11902,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -11199,6 +11957,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -11350,6 +12115,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -11407,10 +12179,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -11503,6 +12283,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -11663,6 +12450,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -11734,6 +12528,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -11778,6 +12579,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -11888,6 +12696,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -11947,10 +12762,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -12043,6 +12866,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -12203,6 +13033,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -12274,6 +13111,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -12318,6 +13162,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -12428,6 +13279,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -12487,6 +13345,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -12521,6 +13386,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -12621,6 +13493,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -12670,10 +13549,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
     "/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -12756,6 +13643,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -12790,10 +13684,18 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
     "/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -12876,6 +13778,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -12910,10 +13819,18 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -12996,6 +13913,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -13146,6 +14070,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -13207,6 +14138,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -13241,6 +14179,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -13341,6 +14286,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -13390,6 +14342,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -13432,6 +14391,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -13493,6 +14459,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -13568,10 +14541,18 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "action"
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -13654,6 +14635,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -13804,6 +14792,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "x-ms-docs-grouped-path": [
@@ -13865,6 +14860,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -13899,6 +14901,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -13999,6 +15008,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -14047,6 +15063,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -14100,6 +15123,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "action"
       }
@@ -14155,6 +15185,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "action"
       }
     },
@@ -14207,6 +15244,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -14346,6 +15390,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -14392,6 +15443,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -14488,6 +15546,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "patch": {
@@ -14541,6 +15606,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "delete": {
@@ -14590,6 +15662,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
       }
@@ -14655,6 +15734,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
       }
@@ -14795,6 +15881,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -14868,6 +15961,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -14915,6 +16015,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -15016,6 +16123,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       },
       "post": {
@@ -15078,6 +16192,13 @@
             "$ref": "#/components/responses/error"
           }
         },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
         "x-ms-docs-operation-type": "operation"
       }
     },
@@ -15112,6 +16233,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -15134,10 +16262,18 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
     "/People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
       "get": {
         "tags": [
           "Person.Employee"
@@ -15210,6 +16346,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -15232,10 +16375,18 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
     "/People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
       "get": {
         "tags": [
           "Person.Manager"
@@ -15308,6 +16459,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },
@@ -15330,6 +16488,13 @@
           "default": {
             "$ref": "#/components/responses/error"
           }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       }
     },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -543,6 +543,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -561,6 +567,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/BestFriend:
     description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -620,6 +632,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/BestFriend/$ref:
     description: Provides operations to manage the collection of Person entities.
@@ -638,6 +656,12 @@ paths:
                 type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     put:
       tags:
@@ -659,6 +683,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -677,8 +707,15 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -734,6 +771,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers:
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -835,6 +878,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers'
@@ -869,6 +918,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     description: Provides operations to count the resources in the collection.
@@ -884,6 +939,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -945,6 +1006,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -969,8 +1036,15 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -1026,6 +1100,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -1127,6 +1207,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports'
@@ -1161,6 +1247,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     description: Provides operations to count the resources in the collection.
@@ -1176,6 +1268,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -1237,6 +1335,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -1261,6 +1365,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Friends:
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -1363,6 +1473,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Friends/{UserName}/$ref':
     description: Provides operations to manage the collection of Person entities.
@@ -1394,8 +1510,15 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -1458,6 +1581,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -1566,6 +1695,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers
@@ -1607,6 +1742,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
@@ -1630,6 +1771,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -1698,6 +1845,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -1730,8 +1883,15 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -1794,6 +1954,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -1902,6 +2068,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports
@@ -1943,6 +2115,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
@@ -1966,6 +2144,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -2034,6 +2218,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -2066,6 +2256,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Friends/$count:
     description: Provides operations to count the resources in the collection.
@@ -2081,6 +2277,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Friends/$ref:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -2142,6 +2344,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -2166,8 +2374,15 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -2223,6 +2438,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -2237,7 +2458,14 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -2293,6 +2521,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -2307,7 +2541,14 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -2363,6 +2604,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers:
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -2464,6 +2711,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers
@@ -2498,6 +2751,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     description: Provides operations to count the resources in the collection.
@@ -2513,6 +2772,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -2574,6 +2839,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -2598,6 +2869,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline():
     description: Provides operations to call the GetFavoriteAirline method.
@@ -2617,6 +2894,12 @@ paths:
                 nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName=''{userName}'')':
     description: Provides operations to call the GetFriendsTrips method.
@@ -2649,6 +2932,12 @@ paths:
                       nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip:
     description: Provides operations to call the GetPeersForTrip method.
@@ -2689,8 +2978,15 @@ paths:
                       nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -2746,6 +3042,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -2847,6 +3149,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports
@@ -2881,6 +3189,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     description: Provides operations to count the resources in the collection.
@@ -2896,6 +3210,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -2957,6 +3277,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -2981,6 +3307,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire:
     description: Provides operations to call the Hire method.
@@ -3007,6 +3339,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip:
     description: Provides operations to call the ShareTrip method.
@@ -3036,6 +3374,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName=''{lastName}'')':
     description: Provides operations to call the UpdatePersonLastName method.
@@ -3064,6 +3408,12 @@ paths:
                     default: false
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
   /Me/Trips:
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -3154,6 +3504,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -3177,6 +3533,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Trips/{TripId}':
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -3239,6 +3601,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -3269,6 +3637,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -3297,6 +3671,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
     description: Provides operations to call the GetInvolvedPeople method.
@@ -3333,6 +3713,12 @@ paths:
                       nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
   '/Me/Trips/{TripId}/PlanItems':
     description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
@@ -3421,6 +3807,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
     description: Provides operations to manage the collection of Person entities.
@@ -3465,6 +3857,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   '/Me/Trips/{TripId}/PlanItems/$count':
     description: Provides operations to count the resources in the collection.
@@ -3491,6 +3889,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Trips/{TripId}/PlanItems/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -3550,6 +3954,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -3585,6 +3995,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
   /Me/Trips/$count:
     description: Provides operations to count the resources in the collection.
@@ -3600,6 +4016,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /NewComePeople:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -3903,6 +4325,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/BestFriend/$ref':
     description: Provides operations to manage the collection of Person entities.
@@ -3929,6 +4357,12 @@ paths:
                 type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     put:
       tags:
@@ -3958,6 +4392,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -3983,8 +4423,15 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -4047,6 +4494,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -4155,6 +4608,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers'
@@ -4195,6 +4654,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
@@ -4218,6 +4683,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -4286,6 +4757,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -4318,8 +4795,15 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -4382,6 +4866,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -4490,6 +4980,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports'
@@ -4530,6 +5026,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
@@ -4553,6 +5055,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -4621,6 +5129,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -4653,6 +5167,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -4802,6 +5322,7 @@ paths:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -5179,6 +5700,7 @@ paths:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -5679,6 +6201,7 @@ paths:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -5764,6 +6287,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -5913,6 +6437,12 @@ paths:
                       nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/trips
+        description: The GetFriendsTrips API is deprecated and will stop returning data on March 2023. Please use the new trips API on friends.
       x-ms-docs-operation-type: function
   '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
     description: Provides operations to call the GetPeersForTrip method.
@@ -6804,6 +7334,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
       tags:
         - People.Person
@@ -6825,6 +7361,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}':
     description: Provides operations to manage the collection of Person entities.
@@ -6890,6 +7432,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -6916,6 +7464,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -6940,6 +7494,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/BestFriend':
     description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -7006,6 +7566,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/BestFriend/$ref':
     description: Provides operations to manage the collection of Person entities.
@@ -7032,6 +7598,12 @@ paths:
                 type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     put:
       tags:
@@ -7061,6 +7633,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -7086,8 +7664,15 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -7150,6 +7735,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -7258,6 +7849,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers'
@@ -7299,6 +7896,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
@@ -7322,6 +7925,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -7390,6 +7999,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -7422,8 +8037,15 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -7486,6 +8108,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -7594,6 +8222,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports'
@@ -7635,6 +8269,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
@@ -7658,6 +8298,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -7726,6 +8372,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -7758,6 +8410,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -7867,6 +8525,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends/{UserName1}/$ref':
     description: Provides operations to manage the collection of Person entities.
@@ -7905,8 +8569,15 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -7976,6 +8647,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -8091,6 +8768,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers'
@@ -8139,6 +8822,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
@@ -8169,6 +8858,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -8244,6 +8939,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -8283,8 +8984,15 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -8354,6 +9062,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -8469,6 +9183,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports'
@@ -8517,6 +9237,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
@@ -8547,6 +9273,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -8622,6 +9354,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -8661,6 +9399,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends/$count':
     description: Provides operations to count the resources in the collection.
@@ -8684,6 +9428,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -8752,6 +9502,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -8784,8 +9540,15 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -8848,6 +9611,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -8870,7 +9639,14 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -8933,6 +9709,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -8955,7 +9737,14 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -9018,6 +9807,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -9126,6 +9921,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers'
@@ -9167,6 +9968,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
@@ -9190,6 +9997,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -9258,6 +10071,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -9290,6 +10109,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
     description: Provides operations to call the GetFavoriteAirline method.
@@ -9317,6 +10142,12 @@ paths:
                 nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips(userName=''{userName}'')':
     description: Provides operations to call the GetFriendsTrips method.
@@ -9356,6 +10187,12 @@ paths:
                       nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPeersForTrip':
     description: Provides operations to call the GetPeersForTrip method.
@@ -9404,8 +10241,15 @@ paths:
                       nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -9468,6 +10312,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -9576,6 +10426,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-ms-docs-grouped-path:
       - '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports'
@@ -9617,6 +10473,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
@@ -9640,6 +10502,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -9708,6 +10576,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -9740,6 +10614,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire':
     description: Provides operations to call the Hire method.
@@ -9774,6 +10654,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
     description: Provides operations to call the ShareTrip method.
@@ -9811,6 +10697,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.UpdatePersonLastName(lastName=''{lastName}'')':
     description: Provides operations to call the UpdatePersonLastName method.
@@ -9846,6 +10738,12 @@ paths:
                     default: false
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
   '/People/{UserName}/Trips':
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -9943,6 +10841,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -9974,6 +10878,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Trips/{TripId}':
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
@@ -10043,6 +10953,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     patch:
       tags:
@@ -10080,6 +10996,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     delete:
       tags:
@@ -10115,6 +11037,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
     description: Provides operations to call the GetInvolvedPeople method.
@@ -10158,6 +11086,12 @@ paths:
                       nullable: true
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
   '/People/{UserName}/Trips/{TripId}/PlanItems':
     description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
@@ -10253,6 +11187,12 @@ paths:
                       $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
     description: Provides operations to manage the collection of Person entities.
@@ -10304,6 +11244,12 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Trips/{TripId}/PlanItems/$count':
     description: Provides operations to count the resources in the collection.
@@ -10337,6 +11283,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Trips/{TripId}/PlanItems/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -10403,6 +11355,12 @@ paths:
                       type: string
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     post:
       tags:
@@ -10445,6 +11403,12 @@ paths:
                 type: object
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
   '/People/{UserName}/Trips/$count':
     description: Provides operations to count the resources in the collection.
@@ -10468,6 +11432,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   /People/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -10482,7 +11452,14 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    description: Casts the previous resource to Employee.
     get:
       tags:
         - Person.Employee
@@ -10538,6 +11515,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -10552,7 +11535,14 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    description: Casts the previous resource to Manager.
     get:
       tags:
         - Person.Manager
@@ -10608,6 +11598,12 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   /People/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -10622,6 +11618,12 @@ paths:
                 $ref: '#/components/schemas/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   /ResetDataSource:
     description: Provides operations to call the ResetDataSource method.
     post:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Vocabulary/Capabilities/DeprecatedRevisionTypeTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Vocabulary/Capabilities/DeprecatedRevisionTypeTests.cs
@@ -1,0 +1,81 @@
+using System;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Reader.Vocabulary.Capabilities.Tests;
+
+public class DeprecatedRevisionTypeTests
+{
+    [Fact]
+    public void DefaultPropertyAsNull()
+    {
+        // Arrange & Act
+        DeprecatedRevisionsType revision = new();
+
+        // Assert
+        Assert.Null(revision.Date);
+        Assert.Null(revision.RemovalDate);
+        Assert.Null(revision.Description);
+        Assert.Null(revision.Version);
+        Assert.Null(revision.Kind);
+    }
+    [Fact]
+    public void InitializeWithNullRecordThrows()
+    {
+        // Arrange & Act
+        DeprecatedRevisionsType revision = new();
+
+        // Assert
+        Assert.Throws<ArgumentNullException>("record", () => revision.Initialize(record: null));
+    }
+    private readonly static EdmEnumType enumType = new("Org.OData.Core.V1", "RevisionKind");
+    private readonly static EdmEnumMember deprecatedValue = new (enumType, "Deprecated", new EdmEnumMemberValue(2));
+    private readonly static EdmEnumMember addedValue = new (enumType, "Added", new EdmEnumMemberValue(0));
+    [Fact]
+    public void InitializeWithDeprecatedRevisionsTypeRecordSuccess()
+    {
+        // Arrange
+        IEdmRecordExpression record = new EdmRecordExpression(
+            new EdmPropertyConstructor("Date", new EdmDateConstant(new Date(2021, 8, 24))),
+            new EdmPropertyConstructor("RemovalDate", new EdmDateConstant(new Date(2021, 10, 24))),
+            new EdmPropertyConstructor("Kind", new EdmEnumMemberExpression(deprecatedValue)), 
+            new EdmPropertyConstructor("Description", new EdmStringConstant("The identityProvider API is deprecated and will stop returning data on March 2023. Please use the new identityProviderBase API.")),
+            new EdmPropertyConstructor("Version", new EdmStringConstant("2021-05/test")));
+
+        // Act
+        DeprecatedRevisionsType revision = new();
+        revision.Initialize(record);
+
+        // Assert
+        Assert.NotNull(revision.Version);
+        Assert.Equal("2021-05/test", revision.Version);
+
+        Assert.NotNull(revision.Description);
+        Assert.Equal("The identityProvider API is deprecated and will stop returning data on March 2023. Please use the new identityProviderBase API.", revision.Description);
+
+        Assert.NotNull(revision.Date);
+        Assert.Equal(new DateTime(2021, 8, 24), revision.Date);
+
+        Assert.NotNull(revision.RemovalDate);
+        Assert.Equal(new DateTime(2021, 10, 24), revision.RemovalDate);
+    }
+    [Fact]
+    public void ThrowsOnWrongKind()
+    {
+        // Arrange
+        IEdmRecordExpression record = new EdmRecordExpression(
+            new EdmPropertyConstructor("Date", new EdmDateConstant(new Date(2021, 8, 24))),
+            new EdmPropertyConstructor("RemovalDate", new EdmDateConstant(new Date(2021, 10, 24))),
+            new EdmPropertyConstructor("Kind", new EdmEnumMemberExpression(addedValue)), 
+            new EdmPropertyConstructor("Description", new EdmStringConstant("The identityProvider API is deprecated and will stop returning data on March 2023. Please use the new identityProviderBase API.")),
+            new EdmPropertyConstructor("Version", new EdmStringConstant("2021-05/test")));
+
+        // Act
+        DeprecatedRevisionsType revision = new();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(() => revision.Initialize(record));
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Vocabulary/Capabilities/DeprecatedRevisionTypeTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Vocabulary/Capabilities/DeprecatedRevisionTypeTests.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;


### PR DESCRIPTION
fixes #113

This PR sets `deprecated` to `true` on operations that depend on annotables with an annotation of term `Org.OData.Core.V1.Revisions` and of kind `Org.OData.Core.V1.RevisionKind/Deprecated` (see the linked issue for more details).

It will also add and extension to the operation to convey the additional information from the annotation like

```yaml
/People/$count:
    get:
      summary: Get the number of the resource
      operationId: Get.Count.People
      responses:
        '200':
          description: The count of the resource
          content:
            text/plain:
              schema:
                $ref: '#/components/schemas/ODataCountResponse'
        default:
          $ref: '#/components/responses/error'
      deprecated: true
      x-ms-deprecation:
        removalDate: '2023-03-15T00:00:00.0000000'
        date: '2021-08-24T00:00:00.0000000'
        version: 2021-05/people
        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
```

The flag + extension will be added to any operation if any path segment in the path is annotated including:
- parent entity sets
- parent singleton
- parent navigation properties
- the type or base type of the nav prop/singleton/entity set

> Note: depending on merge order, #149 will need to be updated to return the target type in the annotables for the segment