### PR TITLE
adds support for properties of complex type and navigation properties on complex types

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -89,5 +89,10 @@ namespace Microsoft.OpenApi.OData.Common
         /// Suffix used for collection response schemas.
         /// </summary>
         public static string CollectionSchemaSuffix = "CollectionResponse";
+
+        /// <summary>
+        /// Name used for reference update.
+        /// </summary>
+        public static string ReferenceUpdateSchemaName = "ReferenceUpdateSchema";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
@@ -16,37 +17,38 @@ namespace Microsoft.OpenApi.OData.Common
         /// Adds the derived types references together with their base type reference in the OneOf property of an OpenAPI schema.
         /// </summary>
         /// <returns>The OpenAPI schema with the list of derived types references and their base type references set in the OneOf property.</returns>
-        internal static OpenApiSchema GetDerivedTypesReferenceSchema(IEdmEntityType entityType, IEdmModel edmModel)
+        internal static OpenApiSchema GetDerivedTypesReferenceSchema(IEdmStructuredType structuredType, IEdmModel edmModel)
         {
-            Utils.CheckArgumentNull(entityType, nameof(entityType));
+            Utils.CheckArgumentNull(structuredType, nameof(structuredType));
             Utils.CheckArgumentNull(edmModel, nameof(edmModel));
+            if(structuredType is not IEdmSchemaElement schemaElement) throw new ArgumentException("The type is not a schema element.", nameof(structuredType));
 
-            IEnumerable<IEdmEntityType> derivedTypes = edmModel.FindDirectlyDerivedTypes(entityType).OfType<IEdmEntityType>();
+            IEnumerable<IEdmSchemaElement> derivedTypes = edmModel.FindDirectlyDerivedTypes(structuredType).OfType<IEdmSchemaElement>();
 
             if (!derivedTypes.Any())
             {
                 return null;
             }
 
-            OpenApiSchema schema = new OpenApiSchema
-            {
+            OpenApiSchema schema = new()
+			{
                 OneOf = new List<OpenApiSchema>()
             };
 
-            OpenApiSchema baseTypeSchema = new OpenApiSchema
-            {
+            OpenApiSchema baseTypeSchema = new()
+			{
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
-                    Id = entityType.FullName()
+                    Id = schemaElement.FullName()
                 }
             };
             schema.OneOf.Add(baseTypeSchema);
 
-            foreach (IEdmEntityType derivedType in derivedTypes)
+            foreach (IEdmSchemaElement derivedType in derivedTypes)
             {
-                OpenApiSchema derivedTypeSchema = new OpenApiSchema
-                {
+                OpenApiSchema derivedTypeSchema = new()
+				{
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
@@ -126,6 +126,26 @@ namespace Microsoft.OpenApi.OData.Edm
         }
 
         /// <summary>
+        /// Find all base types for a given <see cref="IEdmComplexType"/>
+        /// </summary>
+        /// <param name="complexType">The given complex type.</param>
+        /// <returns>All base types or null.</returns>
+        public static IEnumerable<IEdmComplexType> FindAllBaseTypes(this IEdmComplexType complexType)
+        {
+            if (complexType == null)
+            {
+                yield return null;
+            }
+
+            IEdmComplexType current = complexType.BaseComplexType();
+            while (current != null)
+            {
+                yield return current;
+                current = current.BaseComplexType();
+            }
+        }
+
+        /// <summary>
         /// Checks if the <paramref name="baseType"/> is assignable to <paramref name="subtype"/>.
         /// In other words, if <paramref name="subtype"/> is a subtype of <paramref name="baseType"/> or not.
         /// </summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
@@ -20,7 +20,8 @@ public class ODataComplexPropertySegment : ODataSegment
 
 	public IEdmStructuralProperty Property { get; }
 
-	public IEdmComplexType ComplexType => Property.Type.AsComplex().Definition as IEdmComplexType;
+	public IEdmComplexType ComplexType => 
+		(Property.Type.IsCollection() ? Property.Type.Definition.AsElementType() : Property.Type.AsComplex().Definition) as IEdmComplexType;
 
 	public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 	{

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
@@ -6,27 +6,46 @@ using Microsoft.OpenApi.OData.Common;
 
 namespace Microsoft.OpenApi.OData.Edm;
 
+/// <summary>
+/// Represents a property of complex type segment.
+/// </summary>
 public class ODataComplexPropertySegment : ODataSegment
 {
-	public ODataComplexPropertySegment(IEdmStructuralProperty property)
-	{
-		Property = property ?? throw Error.ArgumentNull(nameof(property));
-	}
-	/// <inheritdoc />
-	public override IEdmEntityType EntityType => null;
-	public override ODataSegmentKind Kind => ODataSegmentKind.ComplexProperty;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ODataComplexPropertySegment"/> class.
+    /// </summary>
+    /// <param name="property">The complex type property.</param>
+    public ODataComplexPropertySegment(IEdmStructuralProperty property)
+    {
+        Property = property ?? throw Error.ArgumentNull(nameof(property));
+    }
 
-	public override string Identifier => Property.Name;
+    /// <inheritdoc />
 
-	public IEdmStructuralProperty Property { get; }
+    public override IEdmEntityType EntityType => null;
+    /// <inheritdoc />
+    public override ODataSegmentKind Kind => ODataSegmentKind.ComplexProperty;
 
-	public IEdmComplexType ComplexType => 
-		(Property.Type.IsCollection() ? Property.Type.Definition.AsElementType() : Property.Type.AsComplex().Definition) as IEdmComplexType;
+    /// <inheritdoc />
+    public override string Identifier => Property.Name;
 
-	public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
-	{
-		return new IEdmVocabularyAnnotatable[] { Property, ComplexType }.Union(ComplexType.FindAllBaseTypes());
-	}
+    /// <summary>
+    /// Gets the complex type property this segment was inserted for.
+    /// </summary>
+    public IEdmStructuralProperty Property { get; }
 
-	public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => Property.Name;
+    /// <summary>
+    /// Gets the type definition of the property this segment was inserted for.
+    /// </summary>
+    public IEdmComplexType ComplexType => 
+        (Property.Type.IsCollection() ? Property.Type.Definition.AsElementType() : Property.Type.AsComplex().Definition) as IEdmComplexType;
+
+    /// <inheritdoc />
+    public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+    {
+        return new IEdmVocabularyAnnotatable[] { Property, ComplexType }.Union(ComplexType.FindAllBaseTypes());
+    }
+
+    /// <inheritdoc />
+    public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => Property.Name;
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
@@ -21,9 +21,6 @@ public class ODataComplexPropertySegment : ODataSegment
     }
 
     /// <inheritdoc />
-
-    public override IEdmEntityType EntityType => null;
-    /// <inheritdoc />
     public override ODataSegmentKind Kind => ODataSegmentKind.ComplexProperty;
 
     /// <inheritdoc />

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
@@ -21,6 +21,9 @@ public class ODataComplexPropertySegment : ODataSegment
     }
 
     /// <inheritdoc />
+    public override IEdmEntityType EntityType => null;
+
+    /// <inheritdoc />
     public override ODataSegmentKind Kind => ODataSegmentKind.ComplexProperty;
 
     /// <inheritdoc />

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataComplexPropertySegment.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OpenApi.OData.Common;
+
+namespace Microsoft.OpenApi.OData.Edm;
+
+public class ODataComplexPropertySegment : ODataSegment
+{
+	public ODataComplexPropertySegment(IEdmStructuralProperty property)
+	{
+		Property = property ?? throw Error.ArgumentNull(nameof(property));
+	}
+	/// <inheritdoc />
+	public override IEdmEntityType EntityType => null;
+	public override ODataSegmentKind Kind => ODataSegmentKind.ComplexProperty;
+
+	public override string Identifier => Property.Name;
+
+	public IEdmStructuralProperty Property { get; }
+
+	public IEdmComplexType ComplexType => Property.Type.AsComplex().Definition as IEdmComplexType;
+
+	public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+	{
+		return new IEdmVocabularyAnnotatable[] { Property, ComplexType }.Union(ComplexType.FindAllBaseTypes());
+	}
+
+	public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => Property.Name;
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
@@ -165,7 +165,7 @@ namespace Microsoft.OpenApi.OData.Edm
             {
                 if ((path.Kind == ODataPathKind.Operation && !Settings.EnableOperationPath) ||
                     (path.Kind == ODataPathKind.OperationImport && !Settings.EnableOperationImportPath) ||
-                    (path.Kind == ODataPathKind.NavigationProperty && !Settings.EnableNavigationPropertyPath))
+                    ((path.Kind == ODataPathKind.NavigationProperty || path.Kind == ODataPathKind.ComplexProperty) && !Settings.EnableNavigationPropertyPath))
                 {
                     continue;
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataDollarCountSegment.cs
@@ -5,33 +5,35 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 
-namespace Microsoft.OpenApi.OData.Edm
+namespace Microsoft.OpenApi.OData.Edm;
+/// <summary>
+/// The $count segment.
+/// </summary>
+public class ODataDollarCountSegment : ODataSegment
 {
     /// <summary>
-    /// The $count segment.
+    /// Get the static instance of $count segment.
     /// </summary>
-    public class ODataDollarCountSegment : ODataSegment
+    internal static ODataDollarCountSegment Instance = new();
+
+    /// <inheritdoc />
+    public override IEdmEntityType EntityType => null;
+
+    /// <inheritdoc />
+    public override ODataSegmentKind Kind => ODataSegmentKind.DollarCount;
+
+    /// <inheritdoc />
+    public override string Identifier => "$count";
+
+    /// <inheritdoc />
+    public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
     {
-        /// <summary>
-        /// Get the static instance of $count segment.
-        /// </summary>
-        internal static ODataDollarCountSegment Instance = new();
-
-        /// <inheritdoc />
-        public override ODataSegmentKind Kind => ODataSegmentKind.DollarCount;
-
-        /// <inheritdoc />
-        public override string Identifier => "$count";
-
-        /// <inheritdoc />
-		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
-		{
-			return Enumerable.Empty<IEdmVocabularyAnnotatable>();
-		}
-
-		/// <inheritdoc />
-		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$count";
+        return Enumerable.Empty<IEdmVocabularyAnnotatable>();
     }
+
+    /// <inheritdoc />
+    public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$count";
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataMetadataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataMetadataSegment.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -14,6 +15,8 @@ namespace Microsoft.OpenApi.OData.Edm
     /// </summary>
     public class ODataMetadataSegment : ODataSegment
     {
+        /// <inheritdoc />
+        public override IEdmEntityType EntityType => null;
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.Metadata;
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationImportSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationImportSegment.cs
@@ -49,6 +49,9 @@ namespace Microsoft.OpenApi.OData.Edm
         public IEdmOperationImport OperationImport { get; }
 
         /// <inheritdoc />
+        public override IEdmEntityType EntityType => null;
+
+        /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.OperationImport;
 
         /// <inheritdoc />

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -71,6 +71,9 @@ namespace Microsoft.OpenApi.OData.Edm
         public override string Identifier { get => Operation.Name; }
 
         /// <inheritdoc />
+        public override IEdmEntityType EntityType => null;
+
+        /// <inheritdoc />
         public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters)
         {
             Utils.CheckArgumentNull(settings, nameof(settings));

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
@@ -297,6 +297,10 @@ namespace Microsoft.OpenApi.OData.Edm
             {
                 return ODataPathKind.TypeCast;
             }
+            else if (Segments.Last().Kind == ODataSegmentKind.ComplexProperty)
+            {
+                return ODataPathKind.ComplexProperty;
+            }
             else if (Segments.Any(c => c.Kind == ODataSegmentKind.StreamProperty || c.Kind == ODataSegmentKind.StreamContent))
             {
                 return ODataPathKind.MediaEntity;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathKind.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathKind.cs
@@ -66,6 +66,11 @@ namespace Microsoft.OpenApi.OData.Edm
         TypeCast,
 
         /// <summary>
+        /// Represents a path item for a property of type complex.
+        /// </summary>
+        ComplexProperty,
+
+        /// <summary>
         /// Represents an un-supported/unknown path.
         /// </summary>
         Unknown,

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -571,7 +571,8 @@ namespace Microsoft.OpenApi.OData.Edm
         private static readonly HashSet<ODataPathKind> _oDataPathKindsToSkipForOperationsWhenSingle = new() {
             ODataPathKind.EntitySet,
             ODataPathKind.MediaEntity,
-            ODataPathKind.DollarCount
+            ODataPathKind.DollarCount,
+            ODataPathKind.ComplexProperty,
         };
         private bool AppendBoundOperationOnNavigationSourcePath(IEdmOperation edmOperation, bool isCollection, IEdmEntityType bindingEntityType)
         {

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -253,7 +253,9 @@ namespace Microsoft.OpenApi.OData.Edm
                 if (sp.Type.IsCollection())
                 {
                     CreateTypeCastPaths(currentPath, convertSettings, sp.Type.Definition.AsElementType() as IEdmComplexType, sp, true);
-                    CreateCountPath(currentPath, convertSettings);
+                    var count = _model.GetRecord<CountRestrictionsType>(sp, CapabilitiesConstants.CountRestrictions);
+                    if(count?.IsCountable ?? true)
+                        CreateCountPath(currentPath, convertSettings);
                 }
                 else
                 {
@@ -269,7 +271,8 @@ namespace Microsoft.OpenApi.OData.Edm
                                                         .Distinct()
                                                         .Where(CanFilter))
                     {
-                        RetrieveNavigationPropertyPaths(np, null, currentPath, convertSettings);//TODO get count restriction
+                        var count = _model.GetRecord<CountRestrictionsType>(np, CapabilitiesConstants.CountRestrictions);
+                        RetrieveNavigationPropertyPaths(np, count, currentPath, convertSettings);
                     }
                 }
                 currentPath.Pop();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -135,14 +135,15 @@ namespace Microsoft.OpenApi.OData.Edm
                 case ODataPathKind.EntitySet:
                 case ODataPathKind.Singleton:
                 case ODataPathKind.MediaEntity:
-                    ODataNavigationSourceSegment navigationSourceSegment = (ODataNavigationSourceSegment)path.FirstSegment;
-                    if (!_allNavigationSourcePaths.TryGetValue(navigationSourceSegment.EntityType, out IList<ODataPath> nsList))
+                    if (path.FirstSegment is ODataNavigationSourceSegment navigationSourceSegment)
                     {
-                        nsList = new List<ODataPath>();
-                        _allNavigationSourcePaths[navigationSourceSegment.EntityType] = nsList;
+                        if(!_allNavigationSourcePaths.TryGetValue(navigationSourceSegment.EntityType, out IList<ODataPath> nsList))
+                        {
+                            nsList = new List<ODataPath>();
+                            _allNavigationSourcePaths[navigationSourceSegment.EntityType] = nsList;
+                        }
+                        nsList.Add(path);
                     }
-
-                    nsList.Add(path);
                     break;
 
                 case ODataPathKind.NavigationProperty:
@@ -440,7 +441,8 @@ namespace Microsoft.OpenApi.OData.Edm
             IEdmEntityType navEntityType = navigationProperty.ToEntityType();
             foreach (ODataSegment segment in currentPath)
             {
-                if (navEntityType.IsAssignableFrom(segment.EntityType))
+                if (segment.EntityType != null && 
+                    navEntityType.IsAssignableFrom(segment.EntityType))
                 {
                     return false;
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataRefSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataRefSegment.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -25,6 +26,9 @@ namespace Microsoft.OpenApi.OData.Edm
         private ODataRefSegment()
         {
         }
+
+        /// <inheritdoc />
+        public override IEdmEntityType EntityType => null;
 
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.Ref;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
@@ -72,6 +72,11 @@ namespace Microsoft.OpenApi.OData.Edm
         /// $count
         /// </summary>
         DollarCount,
+
+        /// <summary>
+        /// Path Segment for a property of type complex
+        /// </summary>
+        ComplexProperty,
     }
 
     /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OpenApi.OData.Edm
@@ -14,6 +15,8 @@ namespace Microsoft.OpenApi.OData.Edm
     /// </summary>
     public class ODataStreamContentSegment : ODataSegment
     {
+        /// <inheritdoc />
+        public override IEdmEntityType EntityType => null;
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.StreamContent;
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
@@ -23,6 +24,9 @@ namespace Microsoft.OpenApi.OData.Edm
         {
             _streamPropertyName = streamPropertyName ?? throw Error.ArgumentNull(nameof(streamPropertyName));
         }
+
+        /// <inheritdoc />
+        public override IEdmEntityType EntityType => null;
 
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.StreamProperty;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
@@ -18,28 +18,29 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <summary>
         /// Initializes a new instance of <see cref="ODataTypeCastSegment"/> class.
         /// </summary>
-        /// <param name="entityType">The type cast type.</param>
-        public ODataTypeCastSegment(IEdmEntityType entityType)
+        /// <param name="structuredType">The target type cast type.</param>
+        public ODataTypeCastSegment(IEdmStructuredType structuredType)
         {
-            EntityType = entityType ?? throw Error.ArgumentNull(nameof(entityType));
+            StructuredType = structuredType ?? throw Error.ArgumentNull(nameof(structuredType));
         }
-
-        /// <inheritdoc />
-        public override IEdmEntityType EntityType { get; }
-
         /// <inheritdoc />
         public override ODataSegmentKind Kind => ODataSegmentKind.TypeCast;
 
         /// <inheritdoc />
-        public override string Identifier { get => EntityType.FullTypeName(); }
+        public override string Identifier { get => StructuredType.FullTypeName(); }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets the target type cast type.
+        /// </summary>
+		public IEdmStructuredType StructuredType { get; private set; }
+
+		/// <inheritdoc />
 		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
 		{
-			return new IEdmVocabularyAnnotatable[] { EntityType };
+			return new IEdmVocabularyAnnotatable[] { StructuredType as IEdmVocabularyAnnotatable };
 		}
 
 		/// <inheritdoc />
-		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => EntityType.FullTypeName();
+		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => StructuredType.FullTypeName();
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
@@ -8,39 +8,41 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
-namespace Microsoft.OpenApi.OData.Edm
+namespace Microsoft.OpenApi.OData.Edm;
+/// <summary>
+/// Type cast segment.
+/// </summary>
+public class ODataTypeCastSegment : ODataSegment
 {
     /// <summary>
-    /// Type cast segment.
+    /// Initializes a new instance of <see cref="ODataTypeCastSegment"/> class.
     /// </summary>
-    public class ODataTypeCastSegment : ODataSegment
+    /// <param name="structuredType">The target type cast type.</param>
+    public ODataTypeCastSegment(IEdmStructuredType structuredType)
     {
-        /// <summary>
-        /// Initializes a new instance of <see cref="ODataTypeCastSegment"/> class.
-        /// </summary>
-        /// <param name="structuredType">The target type cast type.</param>
-        public ODataTypeCastSegment(IEdmStructuredType structuredType)
-        {
-            StructuredType = structuredType ?? throw Error.ArgumentNull(nameof(structuredType));
-        }
-        /// <inheritdoc />
-        public override ODataSegmentKind Kind => ODataSegmentKind.TypeCast;
-
-        /// <inheritdoc />
-        public override string Identifier { get => StructuredType.FullTypeName(); }
-
-        /// <summary>
-        /// Gets the target type cast type.
-        /// </summary>
-		public IEdmStructuredType StructuredType { get; private set; }
-
-		/// <inheritdoc />
-		public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
-		{
-			return new IEdmVocabularyAnnotatable[] { StructuredType as IEdmVocabularyAnnotatable };
-		}
-
-		/// <inheritdoc />
-		public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => StructuredType.FullTypeName();
+        StructuredType = structuredType ?? throw Error.ArgumentNull(nameof(structuredType));
     }
+
+    /// <inheritdoc />
+    public override IEdmEntityType EntityType => null;
+
+    /// <inheritdoc />
+    public override ODataSegmentKind Kind => ODataSegmentKind.TypeCast;
+
+    /// <inheritdoc />
+    public override string Identifier { get => StructuredType.FullTypeName(); }
+
+    /// <summary>
+    /// Gets the target type cast type.
+    /// </summary>
+    public IEdmStructuredType StructuredType { get; private set; }
+
+    /// <inheritdoc />
+    public override IEnumerable<IEdmVocabularyAnnotatable> GetAnnotables()
+    {
+        return new IEdmVocabularyAnnotatable[] { StructuredType as IEdmVocabularyAnnotatable };
+    }
+
+    /// <inheritdoc />
+    public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => StructuredType.FullTypeName();
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -363,10 +363,14 @@ namespace Microsoft.OpenApi.OData.Generator
         /// <param name="entityType">The Edm Entity type.</param>
         /// <returns>The created <see cref="OpenApiParameter"/> or null.</returns>
         public static OpenApiParameter CreateOrderBy(this ODataContext context, IEdmVocabularyAnnotatable target, IEdmEntityType entityType)
+        {// patchwork to avoid breaking changes
+            return context.CreateOrderBy(target, entityType as IEdmStructuredType);
+        }
+        public static OpenApiParameter CreateOrderBy(this ODataContext context, IEdmVocabularyAnnotatable target, IEdmStructuredType structuredType)
         {
             Utils.CheckArgumentNull(context, nameof(context));
             Utils.CheckArgumentNull(target, nameof(target));
-            Utils.CheckArgumentNull(entityType, nameof(entityType));
+            Utils.CheckArgumentNull(structuredType, nameof(structuredType));
 
             SortRestrictionsType sort = context.Model.GetRecord<SortRestrictionsType>(target, CapabilitiesConstants.SortRestrictions);
             if (sort != null && !sort.IsSortable)
@@ -375,15 +379,15 @@ namespace Microsoft.OpenApi.OData.Generator
             }
 
             IList<IOpenApiAny> orderByItems = new List<IOpenApiAny>();
-            foreach (var property in entityType.StructuralProperties())
+            foreach (var property in structuredType.StructuralProperties())
             {
                 if (sort != null && sort.IsNonSortableProperty(property.Name))
                 {
                     continue;
                 }
 
-                bool isAscOnly = sort != null ? sort.IsAscendingOnlyProperty(property.Name) : false ;
-                bool isDescOnly = sort != null ? sort.IsDescendingOnlyProperty(property.Name) : false;
+                bool isAscOnly = sort != null && sort.IsAscendingOnlyProperty(property.Name);
+                bool isDescOnly = sort != null && sort.IsDescendingOnlyProperty(property.Name);
                 if (isAscOnly || isDescOnly)
                 {
                     if (isAscOnly)
@@ -454,10 +458,14 @@ namespace Microsoft.OpenApi.OData.Generator
         /// <param name="entityType">The Edm entity type.</param>
         /// <returns>The created <see cref="OpenApiParameter"/> or null.</returns>
         public static OpenApiParameter CreateSelect(this ODataContext context, IEdmVocabularyAnnotatable target, IEdmEntityType entityType)
+        { // patchwork to avoid breaking changes
+            return context.CreateSelect(target, entityType as IEdmStructuredType);
+        }
+        public static OpenApiParameter CreateSelect(this ODataContext context, IEdmVocabularyAnnotatable target, IEdmStructuredType structuredType)
         {
             Utils.CheckArgumentNull(context, nameof(context));
             Utils.CheckArgumentNull(target, nameof(target));
-            Utils.CheckArgumentNull(entityType, nameof(entityType));
+            Utils.CheckArgumentNull(structuredType, nameof(structuredType));
 
             NavigationRestrictionsType navigation = context.Model.GetRecord<NavigationRestrictionsType>(target, CapabilitiesConstants.NavigationRestrictions);
             if (navigation != null && !navigation.IsNavigable)
@@ -467,12 +475,12 @@ namespace Microsoft.OpenApi.OData.Generator
 
             IList<IOpenApiAny> selectItems = new List<IOpenApiAny>();
 
-            foreach (var property in entityType.StructuralProperties())
+            foreach (var property in structuredType.StructuralProperties())
             {
                 selectItems.Add(new OpenApiString(property.Name));
             }
 
-            foreach (var property in entityType.NavigationProperties())
+            foreach (var property in structuredType.NavigationProperties())
             {
                 if (navigation != null && navigation.IsRestrictedProperty(property.Name))
                 {
@@ -501,7 +509,6 @@ namespace Microsoft.OpenApi.OData.Generator
                 Explode = false
             };
         }
-
         public static OpenApiParameter CreateExpand(this ODataContext context, IEdmEntitySet entitySet)
         {
             Utils.CheckArgumentNull(context, nameof(context));
@@ -534,10 +541,14 @@ namespace Microsoft.OpenApi.OData.Generator
         /// <param name="entityType">The edm entity path.</param>
         /// <returns>The created <see cref="OpenApiParameter"/> or null.</returns>
         public static OpenApiParameter CreateExpand(this ODataContext context, IEdmVocabularyAnnotatable target, IEdmEntityType entityType)
+        { // patchwork to avoid breaking changes
+            return context.CreateExpand(target, entityType as IEdmStructuredType);
+        }
+        public static OpenApiParameter CreateExpand(this ODataContext context, IEdmVocabularyAnnotatable target, IEdmStructuredType structuredType)
         {
             Utils.CheckArgumentNull(context, nameof(context));
             Utils.CheckArgumentNull(target, nameof(target));
-            Utils.CheckArgumentNull(entityType, nameof(entityType));
+            Utils.CheckArgumentNull(structuredType, nameof(structuredType));
 
             ExpandRestrictionsType expand = context.Model.GetRecord<ExpandRestrictionsType>(target, CapabilitiesConstants.ExpandRestrictions);
             if (expand != null && !expand.IsExpandable)
@@ -550,7 +561,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 new OpenApiString("*")
             };
 
-            foreach (var property in entityType.NavigationProperties())
+            foreach (var property in structuredType.NavigationProperties())
             {
                 if (expand != null && expand.IsNonExpandableProperty(property.Name))
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -77,6 +77,11 @@ namespace Microsoft.OpenApi.OData.Generator
                                                             $"{(x is IEdmEntityType eType ? eType.FullName() : x.FullTypeName())}{Constants.CollectionSchemaSuffix}",
                                                             CreateCollectionResponse(x)))
                                         .Where(x => !responses.ContainsKey(x.Key)))
+                                .Concat(context.GetAllCollectionComplexTypes()
+                                        .Select(x => new KeyValuePair<string, OpenApiResponse>(
+                                                            $"{x.FullTypeName()}{Constants.CollectionSchemaSuffix}",
+                                                            CreateCollectionResponse(x)))
+                                        .Where(x => !responses.ContainsKey(x.Key)))
                             .ToDictionary(x => x.Key, x => x.Value);
 
             if(context.HasAnyNonContainedCollections())                                        

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -81,7 +81,18 @@ namespace Microsoft.OpenApi.OData.Generator
                             .ToDictionary(x => x.Key, x => x.Value);
             
             if(context.HasAnyNonContainedCollections())                                        
+            {
                 schemas[$"String{Constants.CollectionSchemaSuffix}"] = CreateCollectionSchema(context, new OpenApiSchema { Type = "string" }, "string");
+                schemas[Constants.ReferenceUpdateSchemaName] = new()
+                {
+                    Type = "object",
+                    Properties = new Dictionary<string, OpenApiSchema>
+                    {
+                        {"@odata.id", new OpenApiSchema { Type = "string", Nullable = false }},
+                        {"@odata.type", new OpenApiSchema { Type = "string", Nullable = true }},
+                    }
+                };
+            }
 
             return schemas;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
@@ -1,0 +1,14 @@
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+
+namespace Microsoft.OpenApi.OData.Operation;
+
+internal abstract class ComplexPropertyBaseOperationHandler : OperationHandler
+{
+	/// <inheritdoc/>
+    protected override void Initialize(ODataContext context, ODataPath path)
+    {
+        ComplexPropertySegment = path.LastSegment as ODataComplexPropertySegment ?? throw Error.ArgumentNull(nameof(path));
+    }
+    protected ODataComplexPropertySegment ComplexPropertySegment;
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
@@ -1,6 +1,10 @@
+using System.Linq;
+using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
@@ -8,6 +12,23 @@ internal class ComplexPropertyDeleteOperationHandler : ComplexPropertyBaseOperat
 {
     /// <inheritdoc />
     public override OperationType OperationType => OperationType.Delete;
+
+    /// <inheritdoc/>
+    protected override void SetBasicInfo(OpenApiOperation operation)
+    {
+        // Summary
+        operation.Summary = $"Delete {ComplexPropertySegment.Property.Name} property value";
+
+        // Description
+        operation.Description = Context.Model.GetDescriptionAnnotation(ComplexPropertySegment.Property);
+
+        // OperationId
+        if (Context.Settings.EnableOperationId)
+        {
+            string typeName = ComplexPropertySegment.ComplexType.Name;
+            operation.OperationId = ComplexPropertySegment.Property.Name + "." + typeName + ".Delete" + Utils.UpperFirstChar(typeName);
+        }
+    }
 
     /// <inheritdoc/>
     protected override void SetParameters(OpenApiOperation operation)
@@ -36,5 +57,34 @@ internal class ComplexPropertyDeleteOperationHandler : ComplexPropertyBaseOperat
         };
 
         base.SetResponses(operation);
+    }
+    protected override void SetSecurity(OpenApiOperation operation)
+    {
+        DeleteRestrictionsType delete = Context.Model.GetRecord<DeleteRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.DeleteRestrictions);
+        if (delete == null || delete.Permissions == null)
+        {
+            return;
+        }
+
+        operation.Security = Context.CreateSecurityRequirements(delete.Permissions).ToList();
+    }
+
+    protected override void AppendCustomParameters(OpenApiOperation operation)
+    {
+        DeleteRestrictionsType delete = Context.Model.GetRecord<DeleteRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.DeleteRestrictions);
+        if (delete == null)
+        {
+            return;
+        }
+
+        if (delete.CustomHeaders != null)
+        {
+            AppendCustomParameters(operation, delete.CustomHeaders, ParameterLocation.Header);
+        }
+
+        if (delete.CustomQueryOptions != null)
+        {
+            AppendCustomParameters(operation, delete.CustomQueryOptions, ParameterLocation.Query);
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
@@ -1,0 +1,40 @@
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Generator;
+
+namespace Microsoft.OpenApi.OData.Operation;
+
+internal class ComplexPropertyDeleteOperationHandler : ComplexPropertyBaseOperationHandler
+{
+    /// <inheritdoc />
+    public override OperationType OperationType => OperationType.Delete;
+
+    /// <inheritdoc/>
+    protected override void SetParameters(OpenApiOperation operation)
+    {
+        base.SetParameters(operation);
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "If-Match",
+            In = ParameterLocation.Header,
+            Description = "ETag",
+            Schema = new OpenApiSchema
+            {
+                Type = "string"
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    protected override void SetResponses(OpenApiOperation operation)
+    {
+        operation.Responses = new OpenApiResponses
+        {
+            { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
+            { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
+        };
+
+        base.SetResponses(operation);
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -1,8 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
@@ -10,6 +14,111 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
 {
     /// <inheritdoc />
     public override OperationType OperationType => OperationType.Get;
+    /// <inheritdoc/>
+    protected override void SetBasicInfo(OpenApiOperation operation)
+    {
+        // Summary
+        operation.Summary = $"Get {ComplexPropertySegment.Property.Name} property value";
+
+        // OperationId
+        if (Context.Settings.EnableOperationId)
+        {
+            string typeName = ComplexPropertySegment.ComplexType.Name;
+            string listOrGet = ComplexPropertySegment.Property.Type.IsCollection() ? ".List" : ".Get";
+            operation.OperationId = ComplexPropertySegment.Property.Name + "." + typeName + listOrGet + Utils.UpperFirstChar(typeName);
+        }
+
+        base.SetBasicInfo(operation);
+    }
+    /// <inheritdoc/>
+    protected override void SetParameters(OpenApiOperation operation)
+    {
+        base.SetParameters(operation);
+
+        OpenApiParameter parameter;
+        if(ComplexPropertySegment.Property.Type.IsCollection())
+        {
+
+            // The parameters array contains Parameter Objects for all system query options allowed for this collection,
+            // and it does not list system query options not allowed for this collection, see terms
+            // Capabilities.TopSupported, Capabilities.SkipSupported, Capabilities.SearchRestrictions,
+            // Capabilities.FilterRestrictions, and Capabilities.CountRestrictions
+            // $top
+            parameter = Context.CreateTop(ComplexPropertySegment.Property);
+            if (parameter != null)
+            {
+                operation.Parameters.Add(parameter);
+            }
+
+            // $skip
+            parameter = Context.CreateSkip(ComplexPropertySegment.Property);
+            if (parameter != null)
+            {
+                operation.Parameters.Add(parameter);
+            }
+
+            // $search
+            parameter = Context.CreateSearch(ComplexPropertySegment.Property);
+            if (parameter != null)
+            {
+                operation.Parameters.Add(parameter);
+            }
+
+            // $filter
+            parameter = Context.CreateFilter(ComplexPropertySegment.Property);
+            if (parameter != null)
+            {
+                operation.Parameters.Add(parameter);
+            }
+
+            // $count
+            parameter = Context.CreateCount(ComplexPropertySegment.Property);
+            if (parameter != null)
+            {
+                operation.Parameters.Add(parameter);
+            }
+
+            // the syntax of the system query options $expand, $select, and $orderby is too flexible
+            // to be formally described with OpenAPI Specification means, yet the typical use cases
+            // of just providing a comma-separated list of properties can be expressed via an array-valued
+            // parameter with an enum constraint
+            // $order
+            parameter = Context.CreateOrderBy(ComplexPropertySegment.Property, ComplexPropertySegment.ComplexType);
+            if (parameter != null)
+            {
+                operation.Parameters.Add(parameter);
+            }
+        }
+
+        // $select
+        parameter = Context.CreateSelect(ComplexPropertySegment.Property, ComplexPropertySegment.ComplexType);
+        if (parameter != null)
+        {
+            operation.Parameters.Add(parameter);
+        }
+
+        // $expand
+        parameter = Context.CreateExpand(ComplexPropertySegment.Property, ComplexPropertySegment.ComplexType);
+        if (parameter != null)
+        {
+            operation.Parameters.Add(parameter);
+        }
+    }
+
+    protected override void SetExtensions(OpenApiOperation operation)
+    {
+        if (Context.Settings.EnablePagination && ComplexPropertySegment.Property.Type.IsCollection())
+        {
+            OpenApiObject extension = new()
+			{
+                { "nextLinkName", new OpenApiString("@odata.nextLink")},
+                { "operationName", new OpenApiString(Context.Settings.PageableOperationName)}
+            };
+            operation.Extensions.Add(Constants.xMsPageable, extension);
+
+            base.SetExtensions(operation);
+        }
+    }
     /// <inheritdoc/>
     protected override void SetResponses(OpenApiOperation operation)
     {
@@ -73,5 +182,34 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
                 }
             }
         };
+    }
+    protected override void SetSecurity(OpenApiOperation operation)
+    {
+        ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.ReadRestrictions);
+        if (read == null || read.Permissions == null)
+        {
+            return;
+        }
+
+        operation.Security = Context.CreateSecurityRequirements(read.Permissions).ToList();
+    }
+
+    protected override void AppendCustomParameters(OpenApiOperation operation)
+    {
+        ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.ReadRestrictions);
+        if (read == null)
+        {
+            return;
+        }
+
+        if (read.CustomHeaders != null)
+        {
+            AppendCustomParameters(operation, read.CustomHeaders, ParameterLocation.Header);
+        }
+
+        if (read.CustomQueryOptions != null)
+        {
+            AppendCustomParameters(operation, read.CustomQueryOptions, ParameterLocation.Query);
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -2,65 +2,56 @@ using System.Collections.Generic;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
-using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
-internal class ComplexPropertyGetOperationHandler : OperationHandler
+internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperationHandler
 {
     /// <inheritdoc />
     public override OperationType OperationType => OperationType.Get;
-
     /// <inheritdoc/>
-    protected override void Initialize(ODataContext context, ODataPath path)
-	{
-		complexPropertySegment = path.LastSegment as ODataComplexPropertySegment ?? throw Error.ArgumentNull(nameof(path));
-	}
-	private ODataComplexPropertySegment complexPropertySegment;
+    protected override void SetResponses(OpenApiOperation operation)
+    {
+        SetSingleResponse(operation);
+        operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
 
-	/// <inheritdoc/>
-	protected override void SetResponses(OpenApiOperation operation)
-	{
-		SetSingleResponse(operation);
-		operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+        base.SetResponses(operation);
+    }
+    private void SetSingleResponse(OpenApiOperation operation)
+    {
+        OpenApiSchema schema = null;
 
-		base.SetResponses(operation);
-	}
-	private void SetSingleResponse(OpenApiOperation operation)
-	{
-		OpenApiSchema schema = null;
-
-		if (schema == null)
-		{
-			schema = new OpenApiSchema
-			{
-				Reference = new OpenApiReference
-				{
-					Type = ReferenceType.Schema,
-					Id = complexPropertySegment.ComplexType.FullName()
-				}
-			};
-		}
-		operation.Responses = new OpenApiResponses
-		{
-			{
-				Constants.StatusCode200,
-				new OpenApiResponse
-				{
-					Description = "Result entities",
-					Content = new Dictionary<string, OpenApiMediaType>
-					{
-						{
-							Constants.ApplicationJsonMediaType,
-							new OpenApiMediaType
-							{
-								Schema = schema
-							}
-						}
-					},
-				}
-			}
-		};
-	}
+        if (schema == null)
+        {
+            schema = new OpenApiSchema
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = ComplexPropertySegment.ComplexType.FullName()
+                }
+            };
+        }
+        operation.Responses = new OpenApiResponses
+        {
+            {
+                Constants.StatusCode200,
+                new OpenApiResponse
+                {
+                    Description = "Result entities",
+                    Content = new Dictionary<string, OpenApiMediaType>
+                    {
+                        {
+                            Constants.ApplicationJsonMediaType,
+                            new OpenApiMediaType
+                            {
+                                Schema = schema
+                            }
+                        }
+                    },
+                }
+            }
+        };
+    }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+
+namespace Microsoft.OpenApi.OData.Operation;
+
+internal class ComplexPropertyGetOperationHandler : OperationHandler
+{
+    /// <inheritdoc />
+    public override OperationType OperationType => OperationType.Get;
+
+    /// <inheritdoc/>
+    protected override void Initialize(ODataContext context, ODataPath path)
+	{
+		complexPropertySegment = path.LastSegment as ODataComplexPropertySegment ?? throw Error.ArgumentNull(nameof(path));
+	}
+	private ODataComplexPropertySegment complexPropertySegment;
+
+	/// <inheritdoc/>
+	protected override void SetResponses(OpenApiOperation operation)
+	{
+		SetSingleResponse(operation);
+		operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+
+		base.SetResponses(operation);
+	}
+	private void SetSingleResponse(OpenApiOperation operation)
+	{
+		OpenApiSchema schema = null;
+
+		if (schema == null)
+		{
+			schema = new OpenApiSchema
+			{
+				Reference = new OpenApiReference
+				{
+					Type = ReferenceType.Schema,
+					Id = complexPropertySegment.ComplexType.FullName()
+				}
+			};
+		}
+		operation.Responses = new OpenApiResponses
+		{
+			{
+				Constants.StatusCode200,
+				new OpenApiResponse
+				{
+					Description = "Result entities",
+					Content = new Dictionary<string, OpenApiMediaType>
+					{
+						{
+							Constants.ApplicationJsonMediaType,
+							new OpenApiMediaType
+							{
+								Schema = schema
+							}
+						}
+					},
+				}
+			}
+		};
+	}
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -13,10 +13,30 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
     /// <inheritdoc/>
     protected override void SetResponses(OpenApiOperation operation)
     {
-        SetSingleResponse(operation);
+        if(ComplexPropertySegment.Property.Type.IsCollection())
+            SetCollectionResponse(operation);
+        else
+            SetSingleResponse(operation);
         operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
 
         base.SetResponses(operation);
+    }
+    private void SetCollectionResponse(OpenApiOperation operation)
+    {
+        operation.Responses = new OpenApiResponses
+        {
+            {
+                Constants.StatusCode200,
+                new OpenApiResponse
+                {
+                    Reference = new OpenApiReference()
+                    {
+                        Type = ReferenceType.Response,
+                        Id = $"{ComplexPropertySegment.ComplexType.FullName()}{Constants.CollectionSchemaSuffix}"
+                    },
+                }
+            }
+        };
     }
     private void SetSingleResponse(OpenApiOperation operation)
     {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Generator;
+
+namespace Microsoft.OpenApi.OData.Operation;
+
+internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperationHandler
+{
+    /// <inheritdoc />
+    public override OperationType OperationType => OperationType.Patch;
+
+    /// <inheritdoc/>
+    protected override void SetRequestBody(OpenApiOperation operation)
+    {
+        OpenApiSchema schema = null;
+
+        if (schema == null)
+        {
+            schema = new OpenApiSchema
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = ComplexPropertySegment.ComplexType.FullName()
+                }
+            };
+        }
+
+        operation.RequestBody = new OpenApiRequestBody
+        {
+            Required = true,
+            Description = "New property values",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                {
+                    Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                    {
+                        Schema = schema
+                    }
+                }
+            }
+        };
+
+        base.SetRequestBody(operation);
+    }
+
+    /// <inheritdoc/>
+    protected override void SetResponses(OpenApiOperation operation)
+    {
+        operation.Responses = new OpenApiResponses
+        {
+            { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
+            { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
+        };
+
+        base.SetResponses(operation);
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
@@ -10,6 +13,23 @@ internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperati
 {
     /// <inheritdoc />
     public override OperationType OperationType => OperationType.Patch;
+
+    /// <inheritdoc/>
+    protected override void SetBasicInfo(OpenApiOperation operation)
+    {
+        // Summary
+        operation.Summary = $"Update property {ComplexPropertySegment.Property.Name} value.";
+
+        // Description
+        operation.Description = Context.Model.GetDescriptionAnnotation(ComplexPropertySegment.Property);
+
+        // OperationId
+        if (Context.Settings.EnableOperationId)
+        {
+            string typeName = ComplexPropertySegment.ComplexType.Name;
+            operation.OperationId = ComplexPropertySegment.Property.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
+        }
+    }
 
     /// <inheritdoc/>
     protected override void SetRequestBody(OpenApiOperation operation)
@@ -65,5 +85,34 @@ internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperati
         };
 
         base.SetResponses(operation);
+    }
+    protected override void SetSecurity(OpenApiOperation operation)
+    {
+        UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.UpdateRestrictions);
+        if (update == null || update.Permissions == null)
+        {
+            return;
+        }
+
+        operation.Security = Context.CreateSecurityRequirements(update.Permissions).ToList();
+    }
+
+    protected override void AppendCustomParameters(OpenApiOperation operation)
+    {
+        UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.UpdateRestrictions);
+        if (update == null)
+        {
+            return;
+        }
+
+        if (update.CustomHeaders != null)
+        {
+            AppendCustomParameters(operation, update.CustomHeaders, ParameterLocation.Header);
+        }
+
+        if (update.CustomQueryOptions != null)
+        {
+            AppendCustomParameters(operation, update.CustomQueryOptions, ParameterLocation.Query);
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
@@ -14,11 +14,21 @@ internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperati
     /// <inheritdoc/>
     protected override void SetRequestBody(OpenApiOperation operation)
     {
-        OpenApiSchema schema = null;
-
-        if (schema == null)
-        {
-            schema = new OpenApiSchema
+        OpenApiSchema schema =  ComplexPropertySegment.Property.Type.IsCollection() ?
+			new OpenApiSchema
+			{
+				Type = "array",
+				Items = new OpenApiSchema
+				{
+					Reference = new OpenApiReference
+					{
+						Type = ReferenceType.Schema,
+						Id = ComplexPropertySegment.ComplexType.FullName()
+					}
+				}
+			}
+		:
+            new OpenApiSchema
             {
                 Reference = new OpenApiReference
                 {
@@ -26,7 +36,6 @@ internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperati
                     Id = ComplexPropertySegment.ComplexType.FullName()
                 }
             };
-        }
 
         operation.RequestBody = new OpenApiRequestBody
         {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
@@ -6,37 +6,42 @@ using Microsoft.OpenApi.OData.Generator;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
-internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperationHandler
+internal class ComplexPropertyPostOperationHandler : ComplexPropertyBaseOperationHandler
 {
     /// <inheritdoc />
-    public override OperationType OperationType => OperationType.Patch;
+    public override OperationType OperationType => OperationType.Post;
 
+    /// <inheritdoc/>
+    protected override void SetParameters(OpenApiOperation operation)
+    {
+        base.SetParameters(operation);
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "If-Match",
+            In = ParameterLocation.Header,
+            Description = "ETag",
+            Schema = new OpenApiSchema
+            {
+                Type = "string"
+            }
+        });
+    }
     /// <inheritdoc/>
     protected override void SetRequestBody(OpenApiOperation operation)
     {
-        OpenApiSchema schema =  ComplexPropertySegment.Property.Type.IsCollection() ?
-            new OpenApiSchema
-            {
-                Type = "array",
-                Items = new OpenApiSchema
-                {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = ComplexPropertySegment.ComplexType.FullName()
-                    }
-                }
-            }
-        :
-            new OpenApiSchema
+        OpenApiSchema schema = new()
+        {
+            Type = "array",
+            Items = new OpenApiSchema
             {
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
                     Id = ComplexPropertySegment.ComplexType.FullName()
                 }
-            };
-
+            }
+        };
         operation.RequestBody = new OpenApiRequestBody
         {
             Required = true,
@@ -54,7 +59,6 @@ internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperati
 
         base.SetRequestBody(operation);
     }
-
     /// <inheritdoc/>
     protected override void SetResponses(OpenApiOperation operation)
     {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
@@ -11,8 +12,33 @@ namespace Microsoft.OpenApi.OData.Operation;
 
 internal class ComplexPropertyPostOperationHandler : ComplexPropertyBaseOperationHandler
 {
+    /// <inheritdoc/>
+    protected override void Initialize(ODataContext context, ODataPath path)
+    {
+        base.Initialize(context, path);
+        if(!ComplexPropertySegment.Property.Type.IsCollection())
+        {
+            throw new InvalidOperationException("OData conventions do not support POSTing to a complex property that is not a collection.");
+        }
+    }
     /// <inheritdoc />
     public override OperationType OperationType => OperationType.Post;
+
+    /// <inheritdoc/>
+    protected override void SetBasicInfo(OpenApiOperation operation)
+    {
+        // Summary
+        operation.Summary = $"Sets a new value for the collection of {ComplexPropertySegment.ComplexType.Name}.";
+
+        // OperationId
+        if (Context.Settings.EnableOperationId)
+        {
+            string typeName = ComplexPropertySegment.ComplexType.Name;
+            operation.OperationId = ComplexPropertySegment.Property.Name + "." + typeName + ".Set" + Utils.UpperFirstChar(typeName);
+        }
+
+        base.SetBasicInfo(operation);
+    }
 
     /// <inheritdoc/>
     protected override void SetParameters(OpenApiOperation operation)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
@@ -69,5 +72,35 @@ internal class ComplexPropertyPostOperationHandler : ComplexPropertyBaseOperatio
         };
 
         base.SetResponses(operation);
+    }
+
+    protected override void SetSecurity(OpenApiOperation operation)
+    {
+        InsertRestrictionsType insert = Context.Model.GetRecord<InsertRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.InsertRestrictions);
+        if (insert == null || insert.Permissions == null)
+        {
+            return;
+        }
+
+        operation.Security = Context.CreateSecurityRequirements(insert.Permissions).ToList();
+    }
+
+    protected override void AppendCustomParameters(OpenApiOperation operation)
+    {
+        InsertRestrictionsType insert = Context.Model.GetRecord<InsertRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.InsertRestrictions);
+        if (insert == null)
+        {
+            return;
+        }
+
+        if (insert.CustomQueryOptions != null)
+        {
+            AppendCustomParameters(operation, insert.CustomQueryOptions, ParameterLocation.Query);
+        }
+
+        if (insert.CustomHeaders != null)
+        {
+            AppendCustomParameters(operation, insert.CustomHeaders, ParameterLocation.Header);
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -95,6 +95,15 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 {OperationType.Get, new ODataTypeCastGetOperationHandler() },
             }},
+
+            // .../entity/propertyOfComplexType
+            {ODataPathKind.ComplexProperty, new Dictionary<OperationType, IOperationHandler>
+            {
+                {OperationType.Get, new ComplexPropertyGetOperationHandler() },
+                //TODO patch handler
+                //TODO post handler
+                //TODO delete handler
+            }},
         };
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 {OperationType.Get, new ComplexPropertyGetOperationHandler() },
                 {OperationType.Patch, new ComplexPropertyPatchOperationHandler() },
-                //TODO delete handler
+                {OperationType.Delete, new ComplexPropertyDeleteOperationHandler() },
             }},
         };
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -101,6 +101,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 {OperationType.Get, new ComplexPropertyGetOperationHandler() },
                 {OperationType.Patch, new ComplexPropertyPatchOperationHandler() },
+                {OperationType.Post, new ComplexPropertyPostOperationHandler() },
                 {OperationType.Delete, new ComplexPropertyDeleteOperationHandler() },
             }},
         };

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -100,8 +100,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {ODataPathKind.ComplexProperty, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new ComplexPropertyGetOperationHandler() },
-                //TODO patch handler
-                //TODO post handler
+                {OperationType.Patch, new ComplexPropertyPatchOperationHandler() },
                 //TODO delete handler
             }},
         };

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
@@ -38,12 +38,6 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetRequestBody(OpenApiOperation operation)
         {
-            OpenApiSchema schema = new OpenApiSchema
-            {
-                Type = "object",
-                AdditionalProperties = new OpenApiSchema { Type = "object" }
-           };
-
             operation.RequestBody = new OpenApiRequestBody
             {
                 Required = true,
@@ -53,7 +47,13 @@ namespace Microsoft.OpenApi.OData.Operation
                     {
                         Constants.ApplicationJsonMediaType, new OpenApiMediaType
                         {
-                            Schema = schema
+                            Schema = new()
+                            {
+                                Reference = new OpenApiReference {
+                                    Id = Constants.ReferenceUpdateSchemaName,
+                                    Type = ReferenceType.Schema
+                                },
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
 
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -12,7 +12,11 @@ internal class ComplexPropertyItemHandler : PathItemHandler
     /// <inheritdoc/>
 	protected override void SetOperations(OpenApiPathItem item)
 	{
-		AddOperation(item, OperationType.Get); //TODO post delete
+		AddOperation(item, OperationType.Get); //TODO post
 		AddOperation(item, OperationType.Patch);
+		if(Path.LastSegment is ODataComplexPropertySegment segment && segment.Property.Type.IsNullable)
+		{
+			AddOperation(item, OperationType.Delete);
+		}
 	}
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -1,4 +1,5 @@
 
+using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 
@@ -12,11 +13,14 @@ internal class ComplexPropertyItemHandler : PathItemHandler
     /// <inheritdoc/>
 	protected override void SetOperations(OpenApiPathItem item)
 	{
-		AddOperation(item, OperationType.Get); //TODO post
+		AddOperation(item, OperationType.Get);
 		AddOperation(item, OperationType.Patch);
-		if(Path.LastSegment is ODataComplexPropertySegment segment && segment.Property.Type.IsNullable)
+		if(Path.LastSegment is ODataComplexPropertySegment segment)
 		{
-			AddOperation(item, OperationType.Delete);
+			if(segment.Property.Type.IsNullable)
+				AddOperation(item, OperationType.Delete);
+			if(segment.Property.Type.IsCollection())
+				AddOperation(item, OperationType.Post);
 		}
 	}
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -1,0 +1,17 @@
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Edm;
+
+namespace Microsoft.OpenApi.OData.PathItem;
+
+internal class ComplexPropertyItemHandler : PathItemHandler
+{
+    /// <inheritdoc/>
+	protected override ODataPathKind HandleKind => ODataPathKind.ComplexProperty;
+
+    /// <inheritdoc/>
+	protected override void SetOperations(OpenApiPathItem item)
+	{
+		AddOperation(item, OperationType.Get); //TODO post patch delete
+	}
+}

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -12,6 +12,7 @@ internal class ComplexPropertyItemHandler : PathItemHandler
     /// <inheritdoc/>
 	protected override void SetOperations(OpenApiPathItem item)
 	{
-		AddOperation(item, OperationType.Get); //TODO post patch delete
+		AddOperation(item, OperationType.Get); //TODO post delete
+		AddOperation(item, OperationType.Patch);
 	}
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
@@ -28,14 +28,14 @@ internal class ODataTypeCastPathItemHandler : PathItemHandler
         base.Initialize(context, path);
         if(path.LastSegment is ODataTypeCastSegment castSegment)
         {
-            EntityType = castSegment.EntityType;
+            StructuredType = castSegment.StructuredType;
         }
     }
-    private IEdmEntityType EntityType { get; set; }
+    private IEdmStructuredType StructuredType { get; set; }
     /// <inheritdoc/>
     protected override void SetBasicInfo(OpenApiPathItem pathItem)
     {
         base.SetBasicInfo(pathItem);
-        pathItem.Description = $"Casts the previous resource to {EntityType.Name}.";
+        pathItem.Description = $"Casts the previous resource to {(StructuredType as IEdmNamedElement).Name}.";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandlerProvider.cs
@@ -48,6 +48,9 @@ namespace Microsoft.OpenApi.OData.PathItem
             // ~/groups/{id}/members/microsoft.graph.user
             { ODataPathKind.TypeCast, new ODataTypeCastPathItemHandler() },
 
+            // ~/users/{id}/mailboxSettings
+            { ODataPathKind.ComplexProperty, new ComplexPropertyItemHandler() },
+
             // Unknown
             { ODataPathKind.Unknown, null },
         };

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -95,7 +95,6 @@ Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.ODataTypeCastSegment(Microsoft.
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.ODataComplexPropertySegment(Microsoft.OData.Edm.IEdmStructuralProperty property) -> void
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Property.get -> Microsoft.OData.Edm.IEdmStructuralProperty
-override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Identifier.get -> string
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.ComplexType.get -> Microsoft.OData.Edm.IEdmComplexType

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -95,6 +95,7 @@ Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.ODataTypeCastSegment(Microsoft.
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.ODataComplexPropertySegment(Microsoft.OData.Edm.IEdmStructuralProperty property) -> void
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Property.get -> Microsoft.OData.Edm.IEdmStructuralProperty
+override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Identifier.get -> string
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.ComplexType.get -> Microsoft.OData.Edm.IEdmComplexType
@@ -180,6 +181,7 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDeprecationInformation.get 
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDeprecationInformation.set -> void
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataKeySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
@@ -189,6 +191,7 @@ override Microsoft.OpenApi.OData.Edm.ODataKeySegment.Kind.get -> Microsoft.OpenA
 override Microsoft.OpenApi.OData.Edm.ODataKeySegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataMetadataSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataNavigationPropertySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
@@ -203,28 +206,34 @@ override Microsoft.OpenApi.OData.Edm.ODataNavigationSourceSegment.Kind.get -> Mi
 override Microsoft.OpenApi.OData.Edm.ODataNavigationSourceSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataOperationImportSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataOperationSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataPath.ToString() -> string
 override Microsoft.OpenApi.OData.Edm.ODataRefSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataRefSegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataRefSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataRefSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataRefSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.StructuredType.get -> Microsoft.OData.Edm.IEdmStructuredType
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.Identifier.get -> string
+override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 static Microsoft.OpenApi.OData.Common.Utils.GetTermQualifiedName<T>() -> string

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -64,13 +64,14 @@ Microsoft.OpenApi.OData.Edm.ODataPathKind.OperationImport = 4 -> Microsoft.OpenA
 Microsoft.OpenApi.OData.Edm.ODataPathKind.Ref = 6 -> Microsoft.OpenApi.OData.Edm.ODataPathKind
 Microsoft.OpenApi.OData.Edm.ODataPathKind.Singleton = 2 -> Microsoft.OpenApi.OData.Edm.ODataPathKind
 Microsoft.OpenApi.OData.Edm.ODataPathKind.TypeCast = 10 -> Microsoft.OpenApi.OData.Edm.ODataPathKind
-Microsoft.OpenApi.OData.Edm.ODataPathKind.Unknown = 11 -> Microsoft.OpenApi.OData.Edm.ODataPathKind
+Microsoft.OpenApi.OData.Edm.ODataPathKind.ComplexProperty = 11 -> Microsoft.OpenApi.OData.Edm.ODataPathKind
+Microsoft.OpenApi.OData.Edm.ODataPathKind.Unknown = 12 -> Microsoft.OpenApi.OData.Edm.ODataPathKind
 Microsoft.OpenApi.OData.Edm.ODataPathProvider
 Microsoft.OpenApi.OData.Edm.ODataPathProvider.ODataPathProvider() -> void
 Microsoft.OpenApi.OData.Edm.ODataRefSegment
 Microsoft.OpenApi.OData.Edm.ODataSegment
 Microsoft.OpenApi.OData.Edm.ODataSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> string
-Microsoft.OpenApi.OData.Edm.ODataSegment.GetPathHash(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, Microsoft.OpenApi.OData.Edm.ODataPath path) -> string
+Microsoft.OpenApi.OData.Edm.ODataSegment.GetPathHash(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, Microsoft.OpenApi.OData.Edm.ODataPath path = null) -> string
 Microsoft.OpenApi.OData.Edm.ODataSegment.ODataSegment() -> void
 Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 Microsoft.OpenApi.OData.Edm.ODataSegmentKind.DollarCount = 10 -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
@@ -84,12 +85,22 @@ Microsoft.OpenApi.OData.Edm.ODataSegmentKind.Ref = 7 -> Microsoft.OpenApi.OData.
 Microsoft.OpenApi.OData.Edm.ODataSegmentKind.StreamContent = 8 -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 Microsoft.OpenApi.OData.Edm.ODataSegmentKind.StreamProperty = 9 -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 Microsoft.OpenApi.OData.Edm.ODataSegmentKind.TypeCast = 6 -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+Microsoft.OpenApi.OData.Edm.ODataSegmentKind.ComplexProperty = 11 -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment
 Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.ODataStreamContentSegment() -> void
 Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment
 Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.ODataStreamPropertySegment(string streamPropertyName) -> void
 Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment
-Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.ODataTypeCastSegment(Microsoft.OData.Edm.IEdmEntityType entityType) -> void
+Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.ODataTypeCastSegment(Microsoft.OData.Edm.IEdmStructuredType structuredType) -> void
+Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment
+Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.ODataComplexPropertySegment(Microsoft.OData.Edm.IEdmStructuralProperty property) -> void
+Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Property.get -> Microsoft.OData.Edm.IEdmStructuralProperty
+override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
+override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
+override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Identifier.get -> string
+Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.ComplexType.get -> Microsoft.OData.Edm.IEdmComplexType
+override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
+override Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 Microsoft.OpenApi.OData.EdmModelOpenApiExtensions
 Microsoft.OpenApi.OData.Extensions.IODataRoutePathPrefixProvider
 Microsoft.OpenApi.OData.Extensions.IODataRoutePathPrefixProvider.Parameters.get -> System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.OpenApiParameter>
@@ -212,7 +223,7 @@ override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.GetPathItemName(
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 override Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
-override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
+Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.StructuredType.get -> Microsoft.OData.Edm.IEdmStructuredType
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
@@ -221,6 +232,7 @@ static Microsoft.OpenApi.OData.Common.Utils.GetTermQualifiedName<T>() -> string
 static Microsoft.OpenApi.OData.Common.Utils.GetUniqueName(string input, System.Collections.Generic.HashSet<string> set) -> string
 static Microsoft.OpenApi.OData.Common.Utils.UpperFirstChar(string input) -> string
 static Microsoft.OpenApi.OData.Edm.EdmModelExtensions.FindAllBaseTypes(this Microsoft.OData.Edm.IEdmEntityType entityType) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmEntityType>
+static Microsoft.OpenApi.OData.Edm.EdmModelExtensions.FindAllBaseTypes(this Microsoft.OData.Edm.IEdmComplexType complexType) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmComplexType>
 static Microsoft.OpenApi.OData.Edm.EdmModelExtensions.GetAllElements(this Microsoft.OData.Edm.IEdmModel model) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmSchemaElement>
 static Microsoft.OpenApi.OData.Edm.EdmModelExtensions.IsAssignableFrom(this Microsoft.OData.Edm.IEdmEntityType baseType, Microsoft.OData.Edm.IEdmEntityType subtype) -> bool
 static Microsoft.OpenApi.OData.Edm.EdmModelExtensions.IsOperationImportOverload(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmOperationImport operationImport) -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataComplexPropertySegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataComplexPropertySegmentTests.cs
@@ -1,0 +1,62 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Edm.Tests;
+public class ODataComplexPropertySegmentTests
+{
+    private readonly EdmEntityType _person;
+    private readonly EdmStructuralProperty _addressProperty;
+    private readonly EdmComplexType _addressComplexType;
+
+    public ODataComplexPropertySegmentTests()
+    {
+        _person = new EdmEntityType("NS", "Person");
+        _addressComplexType = new EdmComplexType("NS", "Address");
+        _addressComplexType.AddStructuralProperty("Street", EdmCoreModel.Instance.GetString(false));
+        _person.AddKeys(_person.AddStructuralProperty("Id", EdmCoreModel.Instance.GetString(false)));
+        _addressProperty = _person.AddStructuralProperty("HomeAddress", new EdmComplexTypeReference(_addressComplexType, false));
+    }
+
+    [Fact]
+    public void TypeCastSegmentConstructorThrowsArgumentNull()
+    {
+        Assert.Throws<ArgumentNullException>("property", () => new ODataComplexPropertySegment(null));
+    }
+
+    [Fact]
+    public void ComplexTypeReturnsPropertyComplexType()
+    {
+        // Arrange & Act
+        var segment = new ODataComplexPropertySegment(_addressProperty);
+
+        // Assert
+        Assert.Throws<NotImplementedException>(() => segment.EntityType);
+        Assert.Same(_addressComplexType, segment.ComplexType);
+    }
+
+    [Fact]
+    public void KindPropertyReturnsComplexPropertyEnumMember()
+    {
+        // Arrange & Act
+        var segment = new ODataComplexPropertySegment(_addressProperty);
+
+        // Assert
+        Assert.Equal(ODataSegmentKind.ComplexProperty, segment.Kind);
+    }
+
+    [Fact]
+    public void GetPathItemNameReturnsCorrectPropertyName()
+    {
+        // Arrange & Act
+        var segment = new ODataComplexPropertySegment(_addressProperty);
+
+        // Assert
+        Assert.Equal("HomeAddress", segment.GetPathItemName(new OpenApiConvertSettings()));
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataComplexPropertySegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataComplexPropertySegmentTests.cs
@@ -36,7 +36,7 @@ public class ODataComplexPropertySegmentTests
         var segment = new ODataComplexPropertySegment(_addressProperty);
 
         // Assert
-        Assert.Throws<NotImplementedException>(() => segment.EntityType);
+        Assert.Null(segment.EntityType);
         Assert.Same(_addressComplexType, segment.ComplexType);
     }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationImportSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationImportSegmentTests.cs
@@ -44,13 +44,13 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         }
 
         [Fact]
-        public void GetEntityTypeThrowsNotImplementedException()
+        public void GetEntityTypeReturnsNull()
         {
             // Arrange & Act
             var segment = new ODataOperationImportSegment(_actionImport);
 
             // Assert
-            Assert.Throws<NotImplementedException>(() => segment.EntityType);
+            Assert.Null(segment.EntityType);
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
@@ -31,14 +31,14 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         }
 
         [Fact]
-        public void GetEntityTypeThrowsNotImplementedException()
+        public void GetEntityTypeReturnsNull()
         {
             // Arrange & Act
             IEdmOperation operation = new EdmAction("NS", "MyAction", null);
             var segment = new ODataOperationSegment(operation);
 
             // Assert
-            Assert.Throws<NotImplementedException>(() => segment.EntityType);
+            Assert.Null(segment.EntityType);
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17178, paths.Count());
+            Assert.Equal(50085, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17163, paths.Count());
+            Assert.Equal(50070, paths.Count());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
@@ -11,13 +11,12 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 {
     public class ODataTypeCastSegmentTests
     {
-        private IEdmEntityType _person { get; }
+        private readonly EdmEntityType _person;
 
         public ODataTypeCastSegmentTests()
         {
-            var person = new EdmEntityType("NS", "Person");
-            person.AddKeys(person.AddStructuralProperty("Id", EdmCoreModel.Instance.GetString(false)));
-            _person = person;
+            _person = new EdmEntityType("NS", "Person");
+            _person.AddKeys(_person.AddStructuralProperty("Id", EdmCoreModel.Instance.GetString(false)));
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         [Fact]
         public void TypeCastSegmentConstructorThrowsArgumentNull()
         {
-            Assert.Throws<ArgumentNullException>("entityType", () => new ODataTypeCastSegment(null));
+            Assert.Throws<ArgumentNullException>("structuredType", () => new ODataTypeCastSegment(null));
         }
 
         [Fact]
@@ -33,7 +33,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var segment = new ODataTypeCastSegment(_person);
 
             // Assert
-            Assert.Same(_person, segment.EntityType);
+            Assert.Throws<NotImplementedException>(() => segment.EntityType);
+            Assert.Same(_person, segment.StructuredType);
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var segment = new ODataTypeCastSegment(_person);
 
             // Assert
-            Assert.Throws<NotImplementedException>(() => segment.EntityType);
+            Assert.Null(segment.EntityType);
             Assert.Same(_person, segment.StructuredType);
         }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
@@ -57,11 +57,16 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(pathItems);
-            Assert.Equal(10, pathItems.Count);
+            Assert.Equal(26, pathItems.Count);
 
             Assert.Contains("/People", pathItems.Keys);
             Assert.Contains("/People/$count", pathItems.Keys);
             Assert.Contains("/People/{UserName}", pathItems.Keys);
+            Assert.Contains("/People/{UserName}/Addresses", pathItems.Keys);
+            Assert.Contains("/People/{UserName}/Addresses/$count", pathItems.Keys);
+            Assert.Contains("/People/{UserName}/HomeAddress", pathItems.Keys);
+            Assert.Contains("/People/{UserName}/HomeAddress/City", pathItems.Keys);
+            Assert.Contains("/People/{UserName}/HomeAddress/City/$ref", pathItems.Keys);
             Assert.Contains("/City", pathItems.Keys);
             Assert.Contains("/City/$count", pathItems.Keys);
             Assert.Contains("/City/{Name}", pathItems.Keys);
@@ -69,6 +74,14 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.Contains("/CountryOrRegion/$count", pathItems.Keys);
             Assert.Contains("/CountryOrRegion/{Name}", pathItems.Keys);
             Assert.Contains("/Me", pathItems.Keys);
+            Assert.Contains("/Me/Addresses", pathItems.Keys);
+            Assert.Contains("/Me/Addresses/$count", pathItems.Keys);
+            Assert.Contains("/Me/HomeAddress", pathItems.Keys);
+            Assert.Contains("/Me/HomeAddress/City", pathItems.Keys);
+            Assert.Contains("/Me/HomeAddress/City/$ref", pathItems.Keys);
+            Assert.Contains("/Me/WorkAddress", pathItems.Keys);
+            Assert.Contains("/Me/WorkAddress/City", pathItems.Keys);
+            Assert.Contains("/Me/WorkAddress/City/$ref", pathItems.Keys);
         }
 
         [Theory]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
@@ -56,11 +56,16 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(10, paths.Count);
+            Assert.Equal(26, paths.Count);
 
             Assert.Contains("/People", paths.Keys);
             Assert.Contains("/People/$count", paths.Keys);
             Assert.Contains("/People/{UserName}", paths.Keys);
+            Assert.Contains("/People/{UserName}/Addresses", paths.Keys);
+            Assert.Contains("/People/{UserName}/Addresses/$count", paths.Keys);
+            Assert.Contains("/People/{UserName}/HomeAddress", paths.Keys);
+            Assert.Contains("/People/{UserName}/HomeAddress/City", paths.Keys);
+            Assert.Contains("/People/{UserName}/HomeAddress/City/$ref", paths.Keys);
             Assert.Contains("/City", paths.Keys);
             Assert.Contains("/City/$count", paths.Keys);
             Assert.Contains("/City/{Name}", paths.Keys);
@@ -68,6 +73,14 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.Contains("/CountryOrRegion/$count", paths.Keys);
             Assert.Contains("/CountryOrRegion/{Name}", paths.Keys);
             Assert.Contains("/Me", paths.Keys);
+            Assert.Contains("/Me/Addresses", paths.Keys);
+            Assert.Contains("/Me/Addresses/$count", paths.Keys);
+            Assert.Contains("/Me/HomeAddress", paths.Keys);
+            Assert.Contains("/Me/HomeAddress/City", paths.Keys);
+            Assert.Contains("/Me/HomeAddress/City/$ref", paths.Keys);
+            Assert.Contains("/Me/WorkAddress", paths.Keys);
+            Assert.Contains("/Me/WorkAddress/City", paths.Keys);
+            Assert.Contains("/Me/WorkAddress/City/$ref", paths.Keys);
         }
 
         [Fact]
@@ -87,11 +100,16 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(10, paths.Count);
+            Assert.Equal(26, paths.Count);
 
             Assert.Contains("/some/prefix/People", paths.Keys);
             Assert.Contains("/some/prefix/People/$count", paths.Keys);
             Assert.Contains("/some/prefix/People/{UserName}", paths.Keys);
+            Assert.Contains("/some/prefix/People/{UserName}/Addresses", paths.Keys);
+            Assert.Contains("/some/prefix/People/{UserName}/Addresses/$count", paths.Keys);
+            Assert.Contains("/some/prefix/People/{UserName}/HomeAddress", paths.Keys);
+            Assert.Contains("/some/prefix/People/{UserName}/HomeAddress/City", paths.Keys);
+            Assert.Contains("/some/prefix/People/{UserName}/HomeAddress/City/$ref", paths.Keys);
             Assert.Contains("/some/prefix/City", paths.Keys);
             Assert.Contains("/some/prefix/City/$count", paths.Keys);
             Assert.Contains("/some/prefix/City/{Name}", paths.Keys);
@@ -99,6 +117,14 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.Contains("/some/prefix/CountryOrRegion/$count", paths.Keys);
             Assert.Contains("/some/prefix/CountryOrRegion/{Name}", paths.Keys);
             Assert.Contains("/some/prefix/Me", paths.Keys);
+            Assert.Contains("/some/prefix/Me/Addresses", paths.Keys);
+            Assert.Contains("/some/prefix/Me/Addresses/$count", paths.Keys);
+            Assert.Contains("/some/prefix/Me/HomeAddress", paths.Keys);
+            Assert.Contains("/some/prefix/Me/HomeAddress/City", paths.Keys);
+            Assert.Contains("/some/prefix/Me/HomeAddress/City/$ref", paths.Keys);
+            Assert.Contains("/some/prefix/Me/WorkAddress", paths.Keys);
+            Assert.Contains("/some/prefix/Me/WorkAddress/City", paths.Keys);
+            Assert.Contains("/some/prefix/Me/WorkAddress/City/$ref", paths.Keys);
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyDeleteOperationHandlerTests.cs
@@ -1,0 +1,93 @@
+
+using System;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests;
+
+public class ComplexPropertyDeleteOperationHandlerTests
+{
+	private readonly ComplexPropertyDeleteOperationHandler _operationHandler = new();
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyDeleteOperationReturnsCorrectOperationForSingle(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("BillingAddress");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var delete = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(delete);
+		Assert.Equal("Delete BillingAddress property value", delete.Summary);
+
+		Assert.NotNull(delete.Parameters);
+		Assert.Equal(2, delete.Parameters.Count); //id, etag
+
+		Assert.NotNull(delete.Responses);
+		Assert.Equal(2, delete.Responses.Count);
+		Assert.Equal(new[] { "204", "default" }, delete.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("BillingAddress.Address.DeleteAddress", delete.OperationId);
+		}
+		else
+		{
+			Assert.Null(delete.OperationId);
+		}
+	}
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyPostOperationReturnsCorrectOperationForCollection(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("AlternativeAddresses");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var delete = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(delete);
+		Assert.Equal("Delete AlternativeAddresses property value", delete.Summary);
+
+		Assert.NotNull(delete.Parameters);
+		Assert.Equal(2, delete.Parameters.Count); //id, etag
+
+		Assert.NotNull(delete.Responses);
+		Assert.Equal(2, delete.Responses.Count);
+		Assert.Equal(new[] { "204", "default" }, delete.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("AlternativeAddresses.Address.DeleteAddress", delete.OperationId);
+		}
+		else
+		{
+			Assert.Null(delete.OperationId);
+		}
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyDeleteOperationHandlerTests.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
 
 using System;
 using System.Linq;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyGetOperationHandlerTests.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.OData.Edm;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyGetOperationHandlerTests.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests;
+
+public class ComplexPropertyGetOperationHandlerTests
+{
+	private readonly ComplexPropertyGetOperationHandler _operationHandler = new();
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyGetOperationReturnsCorrectOperationForSingle(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("BillingAddress");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var get = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(get);
+		Assert.Equal("Get BillingAddress property value", get.Summary);
+
+		Assert.NotNull(get.Parameters);
+		Assert.Equal(3, get.Parameters.Count); //id, select, expand
+
+		Assert.NotNull(get.Responses);
+		Assert.Equal(2, get.Responses.Count);
+		Assert.Equal(new[] { "200", "default" }, get.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("BillingAddress.Address.GetAddress", get.OperationId);
+		}
+		else
+		{
+			Assert.Null(get.OperationId);
+		}
+	}
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyGetOperationReturnsCorrectOperationForCollection(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("AlternativeAddresses");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var get = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(get);
+		Assert.Equal("Get AlternativeAddresses property value", get.Summary);
+
+		Assert.NotNull(get.Parameters);
+		Assert.Equal(9, get.Parameters.Count); //id, select, expand, order, top, skip, count, search, filter
+
+		Assert.NotNull(get.Responses);
+		Assert.Equal(2, get.Responses.Count);
+		Assert.Equal(new[] { "200", "default" }, get.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("AlternativeAddresses.Address.ListAddress", get.OperationId);
+		}
+		else
+		{
+			Assert.Null(get.OperationId);
+		}
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPatchOperationHandlerTests.cs
@@ -1,0 +1,93 @@
+
+using System;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests;
+
+public class ComplexPropertyPatchOperationHandlerTests
+{
+	private readonly ComplexPropertyPatchOperationHandler _operationHandler = new();
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyDeleteOperationReturnsCorrectOperationForSingle(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("BillingAddress");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var patch = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(patch);
+		Assert.Equal("Update property BillingAddress value.", patch.Summary);
+
+		Assert.NotNull(patch.Parameters);
+		Assert.Equal(1, patch.Parameters.Count); //id
+
+		Assert.NotNull(patch.Responses);
+		Assert.Equal(2, patch.Responses.Count);
+		Assert.Equal(new[] { "204", "default" }, patch.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("BillingAddress.Address.UpdateAddress", patch.OperationId);
+		}
+		else
+		{
+			Assert.Null(patch.OperationId);
+		}
+	}
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyPostOperationReturnsCorrectOperationForCollection(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("AlternativeAddresses");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var patch = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(patch);
+		Assert.Equal("Update property AlternativeAddresses value.", patch.Summary);
+
+		Assert.NotNull(patch.Parameters);
+		Assert.Equal(1, patch.Parameters.Count); //id
+
+		Assert.NotNull(patch.Responses);
+		Assert.Equal(2, patch.Responses.Count);
+		Assert.Equal(new[] { "204", "default" }, patch.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("AlternativeAddresses.Address.UpdateAddress", patch.OperationId);
+		}
+		else
+		{
+			Assert.Null(patch.OperationId);
+		}
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPatchOperationHandlerTests.cs
@@ -1,3 +1,7 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
 
 using System;
 using System.Linq;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPostOperationHandlerTests.cs
@@ -13,7 +13,7 @@ public class ComplexPropertyPostOperationHandlerTests
 	public void CreateComplexPropertyPostOperationThrowsForSingle()
 	{
 		// Arrange
-		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var model = EntitySetPostOperationHandlerTests.GetEdmModel("");
 		var entitySet = model.EntityContainer.FindEntitySet("Customers");
 		var entity = entitySet.EntityType();
 		var property = entity.FindProperty("BillingAddress");
@@ -30,7 +30,7 @@ public class ComplexPropertyPostOperationHandlerTests
 	public void CreateComplexPropertyPostOperationReturnsCorrectOperationForCollection(bool enableOperationId)
 	{
 		// Arrange
-		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var model = EntitySetPostOperationHandlerTests.GetEdmModel("");
 		var entitySet = model.EntityContainer.FindEntitySet("Customers");
 		var entity = entitySet.EntityType();
 		var property = entity.FindProperty("AlternativeAddresses");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPostOperationHandlerTests.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System;
 using System.Linq;
 using Microsoft.OData.Edm;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPostOperationHandlerTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests;
+
+public class ComplexPropertyPostOperationHandlerTests
+{
+	private readonly ComplexPropertyPostOperationHandler _operationHandler = new();
+	[Fact]
+	public void CreateComplexPropertyPostOperationThrowsForSingle()
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("BillingAddress");
+		var settings = new OpenApiConvertSettings();
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		Assert.Throws<InvalidOperationException>(() => _operationHandler.CreateOperation(context, path));
+	}
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyPostOperationReturnsCorrectOperationForCollection(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("AlternativeAddresses");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var post = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(post);
+		Assert.Equal("Sets a new value for the collection of Address.", post.Summary);
+
+		Assert.NotNull(post.Parameters);
+		Assert.Equal(2, post.Parameters.Count); //id, etag
+
+		Assert.NotNull(post.Responses);
+		Assert.Equal(2, post.Responses.Count);
+		Assert.Equal(new[] { "204", "default" }, post.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("AlternativeAddresses.Address.SetAddress", post.OperationId);
+		}
+		else
+		{
+			Assert.Null(post.OperationId);
+		}
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetGetOperationHandlerTests.cs
@@ -331,12 +331,18 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <ComplexType Name=""Address"">
+        <Property Name=""City"" Type=""Edm.String"" />
+      </ComplexType>
       <EntityType Name=""Customer"">
         <Annotation Term=""Org.OData.Core.V1.Description"" String=""A business customer."" />
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""BillingAddress"" Type=""NS.Address"" />
+        <Property Name=""MailingAddress"" Type=""NS.Address"" Nullable=""false"" />
+        <Property Name=""AlternativeAddresses"" Type=""Collection(NS.Address)"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
         <EntitySet Name=""Customers"" EntityType=""NS.Customer"">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -229,16 +229,22 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             }
         }
 
-        private static IEdmModel GetEdmModel(string annotation, bool hasStream = false)
+        internal static IEdmModel GetEdmModel(string annotation, bool hasStream = false)
         {
             const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <ComplexType Name=""Address"">
+        <Property Name=""City"" Type=""Edm.String"" />
+      </ComplexType>
       <EntityType Name=""Customer"" HasStream=""{0}"">
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""BillingAddress"" Type=""NS.Address"" />
+        <Property Name=""MailingAddress"" Type=""NS.Address"" Nullable=""false"" />
+        <Property Name=""AlternativeAddresses"" Type=""Collection(NS.Address)"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
         <EntitySet Name=""Customers"" EntityType=""NS.Customer"">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.PathItem.Tests;
+
+
+public class ComplexPropertyPathItemHandlerTests
+{
+	private readonly ComplexPropertyItemHandler _pathItemHandler = new();
+	[Fact]
+	public void CreatePathItemThrowsForNullContext()
+	{
+		Assert.Throws<ArgumentNullException>("context",
+			() => _pathItemHandler.CreatePathItem(context: null, path: new ODataPath()));
+	}
+	[Fact]
+	public void SetsDefaultOperations()
+	{
+		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: "");
+		var context = new ODataContext(model);
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		Assert.NotNull(entitySet); // guard
+		var entityType = entitySet.EntityType();
+		var property = entityType.FindProperty("BillingAddress");
+		Assert.NotNull(property); // guard
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entityType), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+		Assert.Equal(ODataPathKind.ComplexProperty, path.Kind); // guard
+		var pathItem = _pathItemHandler.CreatePathItem(context, path);
+		Assert.NotNull(pathItem);
+		Assert.Equal(3, pathItem.Operations.Count);
+		Assert.True(pathItem.Operations.ContainsKey(OperationType.Get));
+		Assert.True(pathItem.Operations.ContainsKey(OperationType.Patch));
+		Assert.True(pathItem.Operations.ContainsKey(OperationType.Delete));
+	}
+	[Fact]
+	public void DoesntSetDeleteOnNonNullableProperties()
+	{
+		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: "");
+		var context = new ODataContext(model);
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		Assert.NotNull(entitySet); // guard
+		var entityType = entitySet.EntityType();
+		var property = entityType.FindProperty("MailingAddress");
+		Assert.NotNull(property); // guard
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entityType), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+		Assert.Equal(ODataPathKind.ComplexProperty, path.Kind); // guard
+		var pathItem = _pathItemHandler.CreatePathItem(context, path);
+		Assert.NotNull(pathItem);
+		Assert.Equal(2, pathItem.Operations.Count);
+		Assert.False(pathItem.Operations.ContainsKey(OperationType.Delete));
+	}
+	[Fact]
+	public void SetsPostOnCollectionProperties()
+	{
+		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: "");
+		var context = new ODataContext(model);
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		Assert.NotNull(entitySet); // guard
+		var entityType = entitySet.EntityType();
+		var property = entityType.FindProperty("AlternativeAddresses");
+		Assert.NotNull(property); // guard
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entityType), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+		Assert.Equal(ODataPathKind.ComplexProperty, path.Kind); // guard
+		var pathItem = _pathItemHandler.CreatePathItem(context, path);
+		Assert.NotNull(pathItem);
+		Assert.Equal(3, pathItem.Operations.Count);
+		Assert.True(pathItem.Operations.ContainsKey(OperationType.Post));
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
 using System;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
@@ -158,11 +158,17 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <ComplexType Name=""Address"">
+        <Property Name=""City"" Type=""Edm.String"" />
+      </ComplexType>
       <EntityType Name=""Customer"">
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""BillingAddress"" Type=""NS.Address"" />
+        <Property Name=""MailingAddress"" Type=""NS.Address"" Nullable=""false"" />
+        <Property Name=""AlternativeAddresses"" Type=""Collection(NS.Address)"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
          <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -598,6 +598,567 @@
       },
       "x-description": "Provides operations to manage the Person singleton."
     },
+    "/Me/Addresses": {
+      "get": {
+        "summary": "Get Addresses property value",
+        "operationId": "Addresses.Address.ListAddress",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "City"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/DefaultNs.AddressCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Addresses value.",
+        "operationId": "Addresses.Address.UpdateAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DefaultNs.Address"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DefaultNs.Address"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Addresses/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Addresses-3180",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Address.GetAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "City"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Address.UpdateAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/HomeAddress/City": {
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get City from Me",
+        "operationId": "Me.GetCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/WorkAddress/City"
+      ]
+    },
+    "/Me/HomeAddress/City/$ref": {
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get ref of City from Me",
+        "operationId": "Me.GetRefCity",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Update the ref of navigation property City in Me",
+        "operationId": "Me.UpdateRefCity",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property ref values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReferenceUpdateSchema"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Delete ref of navigation property City for Me",
+        "operationId": "Me.DeleteRefCity",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/WorkAddress": {
+      "get": {
+        "summary": "Get WorkAddress property value",
+        "operationId": "WorkAddress.Address.GetAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "City"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property WorkAddress value.",
+        "operationId": "WorkAddress.Address.UpdateAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/WorkAddress/City": {
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get City from Me",
+        "operationId": "Me.GetCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/HomeAddress/City"
+      ]
+    },
+    "/Me/WorkAddress/City/$ref": {
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get ref of City from Me",
+        "operationId": "Me.GetRefCity",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Update the ref of navigation property City in Me",
+        "operationId": "Me.UpdateRefCity",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property ref values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReferenceUpdateSchema"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Delete ref of navigation property City for Me",
+        "operationId": "Me.DeleteRefCity",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
     "/People": {
       "get": {
         "tags": [
@@ -821,6 +1382,701 @@
         ],
         "summary": "Delete entity from People",
         "operationId": "People.Person.DeletePerson",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People({UserName})/Addresses": {
+      "get": {
+        "summary": "Get Addresses property value",
+        "operationId": "Addresses.Address.ListAddress",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "Id desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "City"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/DefaultNs.AddressCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Addresses value.",
+        "operationId": "Addresses.Address.UpdateAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DefaultNs.Address"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DefaultNs.Address"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People({UserName})/Addresses/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Addresses-5a5d",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People({UserName})/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Address.GetAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "City"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Address.UpdateAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People({UserName})/HomeAddress/City": {
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get City from People",
+        "operationId": "People.GetCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "x-ms-docs-grouped-path": [
+        "/People({UserName})/WorkAddress/City"
+      ]
+    },
+    "/People({UserName})/HomeAddress/City/$ref": {
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get ref of City from People",
+        "operationId": "People.GetRefCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Update the ref of navigation property City in People",
+        "operationId": "People.UpdateRefCity",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property ref values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReferenceUpdateSchema"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Delete ref of navigation property City for People",
+        "operationId": "People.DeleteRefCity",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People({UserName})/WorkAddress": {
+      "get": {
+        "summary": "Get WorkAddress property value",
+        "operationId": "WorkAddress.Address.GetAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Id",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "City"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property WorkAddress value.",
+        "operationId": "WorkAddress.Address.UpdateAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.Address"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People({UserName})/WorkAddress/City": {
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get City from People",
+        "operationId": "People.GetCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/DefaultNs.City"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "x-ms-docs-grouped-path": [
+        "/People({UserName})/HomeAddress/City"
+      ]
+    },
+    "/People({UserName})/WorkAddress/City/$ref": {
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get ref of City from People",
+        "operationId": "People.GetRefCity",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Update the ref of navigation property City in People",
+        "operationId": "People.UpdateRefCity",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property ref values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReferenceUpdateSchema"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Delete ref of navigation property City for People",
+        "operationId": "People.DeleteRefCity",
         "parameters": [
           {
             "in": "path",
@@ -1076,6 +2332,18 @@
           }
         }
       }
+    },
+    "DefaultNs.AddressCollectionResponse": {
+      "title": "Collection of DefaultNs.Address",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DefaultNs.Address"
+          }
+        }
+      }
     }
   },
   "parameters": {
@@ -1142,6 +2410,12 @@
       "schema": {
         "$ref": "#/definitions/DefaultNs.CountryOrRegionCollectionResponse"
       }
+    },
+    "DefaultNs.AddressCollectionResponse": {
+      "description": "Retrieved collection",
+      "schema": {
+        "$ref": "#/definitions/DefaultNs.AddressCollectionResponse"
+      }
     }
   },
   "tags": [
@@ -1158,7 +2432,15 @@
       "x-ms-docs-toc-type": "page"
     },
     {
+      "name": "Me.City",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
       "name": "People.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "People.City",
       "x-ms-docs-toc-type": "page"
     }
   ]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -697,6 +697,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Address.",
+        "operationId": "Addresses.Address.SetAddress",
         "consumes": [
           "application/json"
         ],
@@ -1525,6 +1527,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Address.",
+        "operationId": "Addresses.Address.SetAddress",
         "consumes": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -456,6 +456,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of Address.
+      operationId: Addresses.Address.SetAddress
       consumes:
         - application/json
       parameters:
@@ -1005,6 +1007,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of Address.
+      operationId: Addresses.Address.SetAddress
       consumes:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -394,6 +394,374 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Person singleton.
+  /Me/Addresses:
+    get:
+      summary: Get Addresses property value
+      operationId: Addresses.Address.ListAddress
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - City
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/DefaultNs.AddressCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property Addresses value.
+      operationId: Addresses.Address.UpdateAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  /Me/Addresses/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Addresses-3180
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  /Me/HomeAddress:
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Address.GetAddress
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - City
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Address.UpdateAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  /Me/HomeAddress/City:
+    get:
+      tags:
+        - Me.City
+      summary: Get City from Me
+      operationId: Me.GetCity
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    x-ms-docs-grouped-path:
+      - /Me/WorkAddress/City
+  /Me/HomeAddress/City/$ref:
+    get:
+      tags:
+        - Me.City
+      summary: Get ref of City from Me
+      operationId: Me.GetRefCity
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.City
+      summary: Update the ref of navigation property City in Me
+      operationId: Me.UpdateRefCity
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New navigation property ref values
+          required: true
+          schema:
+            $ref: '#/definitions/ReferenceUpdateSchema'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.City
+      summary: Delete ref of navigation property City for Me
+      operationId: Me.DeleteRefCity
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  /Me/WorkAddress:
+    get:
+      summary: Get WorkAddress property value
+      operationId: WorkAddress.Address.GetAddress
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - City
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property WorkAddress value.
+      operationId: WorkAddress.Address.UpdateAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  /Me/WorkAddress/City:
+    get:
+      tags:
+        - Me.City
+      summary: Get City from Me
+      operationId: Me.GetCity
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    x-ms-docs-grouped-path:
+      - /Me/HomeAddress/City
+  /Me/WorkAddress/City/$ref:
+    get:
+      tags:
+        - Me.City
+      summary: Get ref of City from Me
+      operationId: Me.GetRefCity
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.City
+      summary: Update the ref of navigation property City in Me
+      operationId: Me.UpdateRefCity
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New navigation property ref values
+          required: true
+          schema:
+            $ref: '#/definitions/ReferenceUpdateSchema'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.City
+      summary: Delete ref of navigation property City for Me
+      operationId: Me.DeleteRefCity
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
   /People:
     get:
       tags:
@@ -563,6 +931,473 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People({UserName})/Addresses':
+    get:
+      summary: Get Addresses property value
+      operationId: Addresses.Address.ListAddress
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Id
+              - Id desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - City
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/DefaultNs.AddressCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property Addresses value.
+      operationId: Addresses.Address.UpdateAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/People({UserName})/Addresses/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Addresses-5a5d
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/People({UserName})/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Address.GetAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - City
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Address.UpdateAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/People({UserName})/HomeAddress/City':
+    get:
+      tags:
+        - People.City
+      summary: Get City from People
+      operationId: People.GetCity
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    x-ms-docs-grouped-path:
+      - '/People({UserName})/WorkAddress/City'
+  '/People({UserName})/HomeAddress/City/$ref':
+    get:
+      tags:
+        - People.City
+      summary: Get ref of City from People
+      operationId: People.GetRefCity
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.City
+      summary: Update the ref of navigation property City in People
+      operationId: People.UpdateRefCity
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property ref values
+          required: true
+          schema:
+            $ref: '#/definitions/ReferenceUpdateSchema'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.City
+      summary: Delete ref of navigation property City for People
+      operationId: People.DeleteRefCity
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People({UserName})/WorkAddress':
+    get:
+      summary: Get WorkAddress property value
+      operationId: WorkAddress.Address.GetAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Id
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - City
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property WorkAddress value.
+      operationId: WorkAddress.Address.UpdateAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/DefaultNs.Address'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/People({UserName})/WorkAddress/City':
+    get:
+      tags:
+        - People.City
+      summary: Get City from People
+      operationId: People.GetCity
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/DefaultNs.City'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    x-ms-docs-grouped-path:
+      - '/People({UserName})/HomeAddress/City'
+  '/People({UserName})/WorkAddress/City/$ref':
+    get:
+      tags:
+        - People.City
+      summary: Get ref of City from People
+      operationId: People.GetRefCity
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.City
+      summary: Update the ref of navigation property City in People
+      operationId: People.UpdateRefCity
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property ref values
+          required: true
+          schema:
+            $ref: '#/definitions/ReferenceUpdateSchema'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.City
+      summary: Delete ref of navigation property City for People
+      operationId: People.DeleteRefCity
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
   /People/$count:
     get:
       summary: Get the number of the resource
@@ -713,6 +1548,14 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/DefaultNs.CountryOrRegion'
+  DefaultNs.AddressCollectionResponse:
+    title: Collection of DefaultNs.Address
+    type: object
+    properties:
+      value:
+        type: array
+        items:
+          $ref: '#/definitions/DefaultNs.Address'
 parameters:
   top:
     in: query
@@ -762,6 +1605,10 @@ responses:
     description: Retrieved collection
     schema:
       $ref: '#/definitions/DefaultNs.CountryOrRegionCollectionResponse'
+  DefaultNs.AddressCollectionResponse:
+    description: Retrieved collection
+    schema:
+      $ref: '#/definitions/DefaultNs.AddressCollectionResponse'
 tags:
   - name: City.City
     x-ms-docs-toc-type: page
@@ -769,5 +1616,9 @@ tags:
     x-ms-docs-toc-type: page
   - name: Me.Person
     x-ms-docs-toc-type: page
+  - name: Me.City
+    x-ms-docs-toc-type: page
   - name: People.Person
+    x-ms-docs-toc-type: page
+  - name: People.City
     x-ms-docs-toc-type: page

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -669,6 +669,618 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/Addresses": {
+      "get": {
+        "summary": "Get Addresses property value",
+        "operationId": "Addresses.Address.ListAddress",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "Id desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DefaultNs.AddressCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Addresses value.",
+        "operationId": "Addresses.Address.UpdateAddress",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Addresses/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Addresses-3180",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Address.GetAddress",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Address.UpdateAddress",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefaultNs.Address"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/HomeAddress/City": {
+      "description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get City from Me",
+        "operationId": "Me.GetCity",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.City"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/WorkAddress/City"
+      ]
+    },
+    "/Me/HomeAddress/City/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get ref of City from Me",
+        "operationId": "Me.GetRefCity",
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Update the ref of navigation property City in Me",
+        "operationId": "Me.UpdateRefCity",
+        "requestBody": {
+          "description": "New navigation property ref values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Delete ref of navigation property City for Me",
+        "operationId": "Me.DeleteRefCity",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/WorkAddress": {
+      "get": {
+        "summary": "Get WorkAddress property value",
+        "operationId": "WorkAddress.Address.GetAddress",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property WorkAddress value.",
+        "operationId": "WorkAddress.Address.UpdateAddress",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefaultNs.Address"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/WorkAddress/City": {
+      "description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get City from Me",
+        "operationId": "Me.GetCity",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.City"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/HomeAddress/City"
+      ]
+    },
+    "/Me/WorkAddress/City/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Get ref of City from Me",
+        "operationId": "Me.GetRefCity",
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Update the ref of navigation property City in Me",
+        "operationId": "Me.UpdateRefCity",
+        "requestBody": {
+          "description": "New navigation property ref values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.City"
+        ],
+        "summary": "Delete ref of navigation property City for Me",
+        "operationId": "Me.DeleteRefCity",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
     "/People": {
       "description": "Provides operations to manage the collection of Person entities.",
       "get": {
@@ -951,6 +1563,794 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People({UserName})/Addresses": {
+      "get": {
+        "summary": "Get Addresses property value",
+        "operationId": "Addresses.Address.ListAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "Id desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DefaultNs.AddressCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Addresses value.",
+        "operationId": "Addresses.Address.UpdateAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People({UserName})/Addresses/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Addresses-5a5d",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People({UserName})/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Address.GetAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Address.UpdateAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefaultNs.Address"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People({UserName})/HomeAddress/City": {
+      "description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get City from People",
+        "operationId": "People.GetCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.City"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People({UserName})/WorkAddress/City"
+      ]
+    },
+    "/People({UserName})/HomeAddress/City/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get ref of City from People",
+        "operationId": "People.GetRefCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Update the ref of navigation property City in People",
+        "operationId": "People.UpdateRefCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property ref values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Delete ref of navigation property City for People",
+        "operationId": "People.DeleteRefCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People({UserName})/WorkAddress": {
+      "get": {
+        "summary": "Get WorkAddress property value",
+        "operationId": "WorkAddress.Address.GetAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Id",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.Address"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property WorkAddress value.",
+        "operationId": "WorkAddress.Address.UpdateAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefaultNs.Address"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People({UserName})/WorkAddress/City": {
+      "description": "Provides operations to manage the City property of the DefaultNs.Address entity.",
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get City from People",
+        "operationId": "People.GetCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefaultNs.City"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People({UserName})/HomeAddress/City"
+      ]
+    },
+    "/People({UserName})/WorkAddress/City/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Get ref of City from People",
+        "operationId": "People.GetRefCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Update the ref of navigation property City in People",
+        "operationId": "People.UpdateRefCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property ref values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.City"
+        ],
+        "summary": "Delete ref of navigation property City for People",
+        "operationId": "People.DeleteRefCity",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
     "/People/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -1179,6 +2579,18 @@
             }
           }
         }
+      },
+      "DefaultNs.AddressCollectionResponse": {
+        "title": "Collection of DefaultNs.Address",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DefaultNs.Address"
+            }
+          }
+        }
       }
     },
     "responses": {
@@ -1228,6 +2640,16 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/DefaultNs.CountryOrRegionCollectionResponse"
+            }
+          }
+        }
+      },
+      "DefaultNs.AddressCollectionResponse": {
+        "description": "Retrieved collection",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DefaultNs.AddressCollectionResponse"
             }
           }
         }
@@ -1336,7 +2758,15 @@
       "x-ms-docs-toc-type": "page"
     },
     {
+      "name": "Me.City",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
       "name": "People.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "People.City",
       "x-ms-docs-toc-type": "page"
     }
   ]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -780,6 +780,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Address.",
+        "operationId": "Addresses.Address.SetAddress",
         "parameters": [
           {
             "name": "If-Match",
@@ -1696,6 +1698,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Address.",
+        "operationId": "Addresses.Address.SetAddress",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -441,6 +441,410 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /Me/Addresses:
+    get:
+      summary: Get Addresses property value
+      operationId: Addresses.Address.ListAddress
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - Id desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - City
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/DefaultNs.AddressCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property Addresses value.
+      operationId: Addresses.Address.UpdateAddress
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  /Me/Addresses/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Addresses-3180
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /Me/HomeAddress:
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Address.GetAddress
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - City
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Address.UpdateAddress
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  /Me/HomeAddress/City:
+    description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    get:
+      tags:
+        - Me.City
+      summary: Get City from Me
+      operationId: Me.GetCity
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.City'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/WorkAddress/City
+  /Me/HomeAddress/City/$ref:
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.City
+      summary: Get ref of City from Me
+      operationId: Me.GetRefCity
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.City
+      summary: Update the ref of navigation property City in Me
+      operationId: Me.UpdateRefCity
+      requestBody:
+        description: New navigation property ref values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.City
+      summary: Delete ref of navigation property City for Me
+      operationId: Me.DeleteRefCity
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /Me/WorkAddress:
+    get:
+      summary: Get WorkAddress property value
+      operationId: WorkAddress.Address.GetAddress
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - City
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property WorkAddress value.
+      operationId: WorkAddress.Address.UpdateAddress
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  /Me/WorkAddress/City:
+    description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    get:
+      tags:
+        - Me.City
+      summary: Get City from Me
+      operationId: Me.GetCity
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.City'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/HomeAddress/City
+  /Me/WorkAddress/City/$ref:
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.City
+      summary: Get ref of City from Me
+      operationId: Me.GetRefCity
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.City
+      summary: Update the ref of navigation property City in Me
+      operationId: Me.UpdateRefCity
+      requestBody:
+        description: New navigation property ref values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.City
+      summary: Delete ref of navigation property City for Me
+      operationId: Me.DeleteRefCity
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   /People:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -631,6 +1035,530 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/People({UserName})/Addresses':
+    get:
+      summary: Get Addresses property value
+      operationId: Addresses.Address.ListAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - Id desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - City
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/DefaultNs.AddressCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property Addresses value.
+      operationId: Addresses.Address.UpdateAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/People({UserName})/Addresses/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Addresses-5a5d
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/People({UserName})/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Address.GetAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - City
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Address.UpdateAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/People({UserName})/HomeAddress/City':
+    description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    get:
+      tags:
+        - People.City
+      summary: Get City from People
+      operationId: People.GetCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.City'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People({UserName})/WorkAddress/City'
+  '/People({UserName})/HomeAddress/City/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.City
+      summary: Get ref of City from People
+      operationId: People.GetRefCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.City
+      summary: Update the ref of navigation property City in People
+      operationId: People.UpdateRefCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property ref values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.City
+      summary: Delete ref of navigation property City for People
+      operationId: People.DeleteRefCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/People({UserName})/WorkAddress':
+    get:
+      summary: Get WorkAddress property value
+      operationId: WorkAddress.Address.GetAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Id
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - City
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.Address'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property WorkAddress value.
+      operationId: WorkAddress.Address.UpdateAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DefaultNs.Address'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/People({UserName})/WorkAddress/City':
+    description: Provides operations to manage the City property of the DefaultNs.Address entity.
+    get:
+      tags:
+        - People.City
+      summary: Get City from People
+      operationId: People.GetCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultNs.City'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People({UserName})/HomeAddress/City'
+  '/People({UserName})/WorkAddress/City/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.City
+      summary: Get ref of City from People
+      operationId: People.GetRefCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.City
+      summary: Update the ref of navigation property City in People
+      operationId: People.UpdateRefCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property ref values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.City
+      summary: Delete ref of navigation property City for People
+      operationId: People.DeleteRefCity
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   /People/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -782,6 +1710,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DefaultNs.CountryOrRegion'
+    DefaultNs.AddressCollectionResponse:
+      title: Collection of DefaultNs.Address
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/DefaultNs.Address'
   responses:
     error:
       description: error
@@ -813,6 +1749,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/DefaultNs.CountryOrRegionCollectionResponse'
+    DefaultNs.AddressCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DefaultNs.AddressCollectionResponse'
   parameters:
     top:
       name: $top
@@ -879,5 +1821,9 @@ tags:
     x-ms-docs-toc-type: page
   - name: Me.Person
     x-ms-docs-toc-type: page
+  - name: Me.City
+    x-ms-docs-toc-type: page
   - name: People.Person
+    x-ms-docs-toc-type: page
+  - name: People.City
     x-ms-docs-toc-type: page

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -513,6 +513,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of Address.
+      operationId: Addresses.Address.SetAddress
       parameters:
         - name: If-Match
           in: header
@@ -1122,6 +1124,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of Address.
+      operationId: Addresses.Address.SetAddress
       parameters:
         - name: UserName
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -974,6 +974,228 @@
       },
       "x-description": "Provides operations to manage the collection of DocumentDto entities."
     },
+    "/Documents({Id})/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.ListDocumentTagRelDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "Name desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRelDto.UpdateDocumentTagRelDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.DeleteDocumentTagRelDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Documents({Id})/Tags/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-ed53",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/Documents/$count": {
       "get": {
         "summary": "Get the number of the resource",
@@ -1462,6 +1684,283 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of LibraryDto entities."
+    },
+    "/Libraries({Id})/Documents({Id1})/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.ListDocumentTagRelDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "path",
+            "name": "Id1",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "Name desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRelDto.UpdateDocumentTagRelDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "path",
+            "name": "Id1",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.DeleteDocumentTagRelDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "path",
+            "name": "Id1",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "path",
+            "name": "Id1",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Libraries({Id})/Documents({Id1})/Tags/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-2853",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "path",
+            "name": "Id1",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
     },
     "/Libraries({Id})/Documents/$count": {
       "get": {
@@ -2128,10 +2627,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "$ref": "#/definitions/ReferenceUpdateSchema"
             }
           }
         ],
@@ -2181,6 +2677,495 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of RevisionDto entities."
+    },
+    "/Revisions({Id})/Document/DocumentClasses": {
+      "get": {
+        "summary": "Get DocumentClasses property value",
+        "operationId": "DocumentClasses.DocumentClass.ListDocumentClass",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "ClassInstance",
+                "ClassInstance desc",
+                "ClassId",
+                "ClassId desc",
+                "DocumentId",
+                "DocumentId desc",
+                "CreatedBy",
+                "CreatedBy desc",
+                "CreationDate",
+                "CreationDate desc",
+                "ModifiedBy",
+                "ModifiedBy desc",
+                "ModificationDate",
+                "ModificationDate desc",
+                "IsPrimary",
+                "IsPrimary desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "ClassInstance",
+                "ClassId",
+                "DocumentId",
+                "CreatedBy",
+                "CreationDate",
+                "ModifiedBy",
+                "ModificationDate",
+                "IsPrimary",
+                "Document"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property DocumentClasses value.",
+        "operationId": "DocumentClasses.DocumentClass.UpdateDocumentClass",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete DocumentClasses property value",
+        "operationId": "DocumentClasses.DocumentClass.DeleteDocumentClass",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Revisions({Id})/Document/DocumentClasses/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.DocumentClasses-6342",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Revisions({Id})/Document/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRel.ListDocumentTagRel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "DocumentId",
+                "DocumentId desc",
+                "TagId",
+                "TagId desc",
+                "DomainId",
+                "DomainId desc",
+                "CreatedBy",
+                "CreatedBy desc",
+                "ModifiedBy",
+                "ModifiedBy desc",
+                "CreationDate",
+                "CreationDate desc",
+                "ModificationDate",
+                "ModificationDate desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "DocumentId",
+                "TagId",
+                "DomainId",
+                "CreatedBy",
+                "ModifiedBy",
+                "CreationDate",
+                "ModificationDate",
+                "Document",
+                "Tag"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Document",
+                "Tag"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRel.UpdateDocumentTagRel",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRel.DeleteDocumentTagRel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Revisions({Id})/Document/Tags/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-161f",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "RevisionDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
     },
     "/Revisions/$count": {
       "get": {
@@ -2879,6 +3864,228 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of DocumentDto entities."
+    },
+    "/Tasks({Id})/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.ListDocumentTagRelDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name",
+                "Name desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Name"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRelDto.UpdateDocumentTagRelDto",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.DeleteDocumentTagRelDto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Tasks({Id})/Tags/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-3a1b",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
     },
     "/Tasks/$count": {
       "get": {
@@ -4755,6 +5962,42 @@
         }
       }
     },
+    "Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse": {
+      "title": "Collection of Siterra.Documents.App.DTO.DocumentTagRelDto",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto"
+          }
+        }
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse": {
+      "title": "Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+          }
+        }
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse": {
+      "title": "Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+          }
+        }
+      }
+    },
     "StringCollectionResponse": {
       "title": "Collection of string",
       "type": "object",
@@ -4764,6 +6007,17 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "ReferenceUpdateSchema": {
+      "type": "object",
+      "properties": {
+        "@odata.id": {
+          "type": "string"
+        },
+        "@odata.type": {
+          "type": "string"
         }
       }
     }
@@ -4861,6 +6115,24 @@
       "description": "Retrieved collection",
       "schema": {
         "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryTypeCollectionResponse"
+      }
+    },
+    "Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse": {
+      "description": "Retrieved collection",
+      "schema": {
+        "$ref": "#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse": {
+      "description": "Retrieved collection",
+      "schema": {
+        "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse"
+      }
+    },
+    "Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse": {
+      "description": "Retrieved collection",
+      "schema": {
+        "$ref": "#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse"
       }
     },
     "StringCollectionResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -1124,6 +1124,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRelDto.",
+        "operationId": "Tags.DocumentTagRelDto.SetDocumentTagRelDto",
         "consumes": [
           "application/json"
         ],
@@ -1868,6 +1870,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRelDto.",
+        "operationId": "Tags.DocumentTagRelDto.SetDocumentTagRelDto",
         "consumes": [
           "application/json"
         ],
@@ -2851,6 +2855,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentClass.",
+        "operationId": "DocumentClasses.DocumentClass.SetDocumentClass",
         "consumes": [
           "application/json"
         ],
@@ -3095,6 +3101,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRel.",
+        "operationId": "Tags.DocumentTagRel.SetDocumentTagRel",
         "consumes": [
           "application/json"
         ],
@@ -4015,6 +4023,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRelDto.",
+        "operationId": "Tags.DocumentTagRelDto.SetDocumentTagRelDto",
         "consumes": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -799,6 +799,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRelDto.
+      operationId: Tags.DocumentTagRelDto.SetDocumentTagRelDto
       consumes:
         - application/json
       parameters:
@@ -1331,6 +1333,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRelDto.
+      operationId: Tags.DocumentTagRelDto.SetDocumentTagRelDto
       consumes:
         - application/json
       parameters:
@@ -2052,6 +2056,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentClass.
+      operationId: DocumentClasses.DocumentClass.SetDocumentClass
       consumes:
         - application/json
       parameters:
@@ -2223,6 +2229,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRel.
+      operationId: Tags.DocumentTagRel.SetDocumentTagRel
       consumes:
         - application/json
       parameters:
@@ -2880,6 +2888,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRelDto.
+      operationId: Tags.DocumentTagRelDto.SetDocumentTagRelDto
       consumes:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -699,6 +699,155 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of DocumentDto entities.
+  '/Documents({Id})/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRelDto.ListDocumentTagRelDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Name
+              - Name desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRelDto.UpdateDocumentTagRelDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRelDto.DeleteDocumentTagRelDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Documents({Id})/Tags/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-ed53
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
   /Documents/$count:
     get:
       summary: Get the number of the resource
@@ -1055,6 +1204,200 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of LibraryDto entities.
+  '/Libraries({Id})/Documents({Id1})/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRelDto.ListDocumentTagRelDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of LibraryDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: path
+          name: Id1
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Name
+              - Name desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRelDto.UpdateDocumentTagRelDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of LibraryDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: path
+          name: Id1
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRelDto.DeleteDocumentTagRelDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of LibraryDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: path
+          name: Id1
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of LibraryDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: path
+          name: Id1
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Libraries({Id})/Documents({Id1})/Tags/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-2853
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of LibraryDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: path
+          name: Id1
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
   '/Libraries({Id})/Documents/$count':
     get:
       summary: Get the number of the resource
@@ -1553,9 +1896,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: object
-            additionalProperties:
-              type: object
+            $ref: '#/definitions/ReferenceUpdateSchema'
       responses:
         '204':
           description: Success
@@ -1588,6 +1929,349 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of RevisionDto entities.
+  '/Revisions({Id})/Document/DocumentClasses':
+    get:
+      summary: Get DocumentClasses property value
+      operationId: DocumentClasses.DocumentClass.ListDocumentClass
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - ClassInstance
+              - ClassInstance desc
+              - ClassId
+              - ClassId desc
+              - DocumentId
+              - DocumentId desc
+              - CreatedBy
+              - CreatedBy desc
+              - CreationDate
+              - CreationDate desc
+              - ModifiedBy
+              - ModifiedBy desc
+              - ModificationDate
+              - ModificationDate desc
+              - IsPrimary
+              - IsPrimary desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - ClassInstance
+              - ClassId
+              - DocumentId
+              - CreatedBy
+              - CreationDate
+              - ModifiedBy
+              - ModificationDate
+              - IsPrimary
+              - Document
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property DocumentClasses value.
+      operationId: DocumentClasses.DocumentClass.UpdateDocumentClass
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete DocumentClasses property value
+      operationId: DocumentClasses.DocumentClass.DeleteDocumentClass
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Revisions({Id})/Document/DocumentClasses/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.DocumentClasses-6342
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/Revisions({Id})/Document/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRel.ListDocumentTagRel
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - DocumentId
+              - DocumentId desc
+              - TagId
+              - TagId desc
+              - DomainId
+              - DomainId desc
+              - CreatedBy
+              - CreatedBy desc
+              - ModifiedBy
+              - ModifiedBy desc
+              - CreationDate
+              - CreationDate desc
+              - ModificationDate
+              - ModificationDate desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - DocumentId
+              - TagId
+              - DomainId
+              - CreatedBy
+              - ModifiedBy
+              - CreationDate
+              - ModificationDate
+              - Document
+              - Tag
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Document
+              - Tag
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRel.UpdateDocumentTagRel
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRel.DeleteDocumentTagRel
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Revisions({Id})/Document/Tags/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-161f
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of RevisionDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: RevisionDto
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
   /Revisions/$count:
     get:
       summary: Get the number of the resource
@@ -2096,6 +2780,155 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of DocumentDto entities.
+  '/Tasks({Id})/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRelDto.ListDocumentTagRelDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Name
+              - Name desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Name
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRelDto.UpdateDocumentTagRelDto
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRelDto.DeleteDocumentTagRelDto
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Tasks({Id})/Tags/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-3a1b
+      parameters:
+        - in: path
+          name: Id
+          description: 'key: Id of DocumentDto'
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
   /Tasks/$count:
     get:
       summary: Get the number of the resource
@@ -3529,6 +4362,30 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType'
+  Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse:
+    title: Collection of Siterra.Documents.App.DTO.DocumentTagRelDto
+    type: object
+    properties:
+      value:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDto'
+  Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse:
+    title: Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass
+    type: object
+    properties:
+      value:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
+  Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse:
+    title: Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel
+    type: object
+    properties:
+      value:
+        type: array
+        items:
+          $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
   StringCollectionResponse:
     title: Collection of string
     type: object
@@ -3537,6 +4394,13 @@ definitions:
         type: array
         items:
           type: string
+  ReferenceUpdateSchema:
+    type: object
+    properties:
+      '@odata.id':
+        type: string
+      '@odata.type':
+        type: string
 parameters:
   top:
     in: query
@@ -3606,6 +4470,18 @@ responses:
     description: Retrieved collection
     schema:
       $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Library.LibraryTypeCollectionResponse'
+  Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse:
+    description: Retrieved collection
+    schema:
+      $ref: '#/definitions/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+  Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse:
+    description: Retrieved collection
+    schema:
+      $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse'
+  Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse:
+    description: Retrieved collection
+    schema:
+      $ref: '#/definitions/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse'
   StringCollectionResponse:
     description: Retrieved collection
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -1084,6 +1084,255 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Documents({Id})/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.ListDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name",
+                  "Name desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRelDto.UpdateDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.DeleteDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Documents({Id})/Tags/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-ed53",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Documents/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -1635,6 +1884,320 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Libraries({Id})/Documents({Id1})/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.ListDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "name": "Id1",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name",
+                  "Name desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRelDto.UpdateDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "name": "Id1",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.DeleteDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "name": "Id1",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "name": "Id1",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Libraries({Id})/Documents({Id1})/Tags/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-2853",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of LibraryDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "name": "Id1",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Libraries({Id})/Documents/$count": {
@@ -2432,10 +2995,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object"
-                }
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
               }
             }
           },
@@ -2489,6 +3049,549 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Revisions({Id})/Document/DocumentClasses": {
+      "get": {
+        "summary": "Get DocumentClasses property value",
+        "operationId": "DocumentClasses.DocumentClass.ListDocumentClass",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "ClassInstance",
+                  "ClassInstance desc",
+                  "ClassId",
+                  "ClassId desc",
+                  "DocumentId",
+                  "DocumentId desc",
+                  "CreatedBy",
+                  "CreatedBy desc",
+                  "CreationDate",
+                  "CreationDate desc",
+                  "ModifiedBy",
+                  "ModifiedBy desc",
+                  "ModificationDate",
+                  "ModificationDate desc",
+                  "IsPrimary",
+                  "IsPrimary desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "ClassInstance",
+                  "ClassId",
+                  "DocumentId",
+                  "CreatedBy",
+                  "CreationDate",
+                  "ModifiedBy",
+                  "ModificationDate",
+                  "IsPrimary",
+                  "Document"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Document"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property DocumentClasses value.",
+        "operationId": "DocumentClasses.DocumentClass.UpdateDocumentClass",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete DocumentClasses property value",
+        "operationId": "DocumentClasses.DocumentClass.DeleteDocumentClass",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Revisions({Id})/Document/DocumentClasses/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.DocumentClasses-6342",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Revisions({Id})/Document/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRel.ListDocumentTagRel",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "DocumentId",
+                  "DocumentId desc",
+                  "TagId",
+                  "TagId desc",
+                  "DomainId",
+                  "DomainId desc",
+                  "CreatedBy",
+                  "CreatedBy desc",
+                  "ModifiedBy",
+                  "ModifiedBy desc",
+                  "CreationDate",
+                  "CreationDate desc",
+                  "ModificationDate",
+                  "ModificationDate desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "DocumentId",
+                  "TagId",
+                  "DomainId",
+                  "CreatedBy",
+                  "ModifiedBy",
+                  "CreationDate",
+                  "ModificationDate",
+                  "Document",
+                  "Tag"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Document",
+                  "Tag"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRel.UpdateDocumentTagRel",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRel.DeleteDocumentTagRel",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Revisions({Id})/Document/Tags/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-161f",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of RevisionDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "RevisionDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Revisions/$count": {
@@ -3265,6 +4368,255 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Tasks({Id})/Tags": {
+      "get": {
+        "summary": "Get Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.ListDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name",
+                  "Name desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Name"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Tags value.",
+        "operationId": "Tags.DocumentTagRelDto.UpdateDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Tags property value",
+        "operationId": "Tags.DocumentTagRelDto.DeleteDocumentTagRelDto",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Tasks({Id})/Tags/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Tags-3a1b",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Tasks/$count": {
@@ -5339,6 +6691,42 @@
           }
         }
       },
+      "Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse": {
+        "title": "Collection of Siterra.Documents.App.DTO.DocumentTagRelDto",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
+            }
+          }
+        }
+      },
+      "Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse": {
+        "title": "Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
+            }
+          }
+        }
+      },
+      "Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse": {
+        "title": "Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
+            }
+          }
+        }
+      },
       "StringCollectionResponse": {
         "title": "Collection of string",
         "type": "object",
@@ -5348,6 +6736,18 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "ReferenceUpdateSchema": {
+        "type": "object",
+        "properties": {
+          "@odata.id": {
+            "type": "string"
+          },
+          "@odata.type": {
+            "type": "string",
+            "nullable": true
           }
         }
       }
@@ -5449,6 +6849,36 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Library.LibraryTypeCollectionResponse"
+            }
+          }
+        }
+      },
+      "Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse": {
+        "description": "Retrieved collection",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse"
+            }
+          }
+        }
+      },
+      "Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse": {
+        "description": "Retrieved collection",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse"
+            }
+          }
+        }
+      },
+      "Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse": {
+        "description": "Retrieved collection",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -1256,6 +1256,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRelDto.",
+        "operationId": "Tags.DocumentTagRelDto.SetDocumentTagRelDto",
         "parameters": [
           {
             "name": "Id",
@@ -2097,6 +2099,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRelDto.",
+        "operationId": "Tags.DocumentTagRelDto.SetDocumentTagRelDto",
         "parameters": [
           {
             "name": "Id",
@@ -3246,6 +3250,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentClass.",
+        "operationId": "DocumentClasses.DocumentClass.SetDocumentClass",
         "parameters": [
           {
             "name": "Id",
@@ -3517,6 +3523,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRel.",
+        "operationId": "Tags.DocumentTagRel.SetDocumentTagRel",
         "parameters": [
           {
             "name": "Id",
@@ -4542,6 +4550,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of DocumentTagRelDto.",
+        "operationId": "Tags.DocumentTagRelDto.SetDocumentTagRelDto",
         "parameters": [
           {
             "name": "Id",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -884,6 +884,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRelDto.
+      operationId: Tags.DocumentTagRelDto.SetDocumentTagRelDto
       parameters:
         - name: Id
           in: path
@@ -1479,6 +1481,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRelDto.
+      operationId: Tags.DocumentTagRelDto.SetDocumentTagRelDto
       parameters:
         - name: Id
           in: path
@@ -2305,6 +2309,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentClass.
+      operationId: DocumentClasses.DocumentClass.SetDocumentClass
       parameters:
         - name: Id
           in: path
@@ -2493,6 +2499,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRel.
+      operationId: Tags.DocumentTagRel.SetDocumentTagRel
       parameters:
         - name: Id
           in: path
@@ -3217,6 +3225,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of DocumentTagRelDto.
+      operationId: Tags.DocumentTagRelDto.SetDocumentTagRelDto
       parameters:
         - name: Id
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -769,6 +769,172 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Documents({Id})/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRelDto.ListDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+                - Name desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRelDto.UpdateDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRelDto.DeleteDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Documents({Id})/Tags/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-ed53
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Documents/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -1168,6 +1334,222 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Libraries({Id})/Documents({Id1})/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRelDto.ListDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of LibraryDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: LibraryDto
+        - name: Id1
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+                - Name desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRelDto.UpdateDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of LibraryDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: LibraryDto
+        - name: Id1
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRelDto.DeleteDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of LibraryDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: LibraryDto
+        - name: Id1
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of LibraryDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: LibraryDto
+        - name: Id1
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Libraries({Id})/Documents({Id1})/Tags/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-2853
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of LibraryDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: LibraryDto
+        - name: Id1
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/Libraries({Id})/Documents/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -1750,9 +2132,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties:
-                type: object
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
         required: true
       responses:
         '204':
@@ -1787,6 +2167,383 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Revisions({Id})/Document/DocumentClasses':
+    get:
+      summary: Get DocumentClasses property value
+      operationId: DocumentClasses.DocumentClass.ListDocumentClass
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - ClassInstance
+                - ClassInstance desc
+                - ClassId
+                - ClassId desc
+                - DocumentId
+                - DocumentId desc
+                - CreatedBy
+                - CreatedBy desc
+                - CreationDate
+                - CreationDate desc
+                - ModifiedBy
+                - ModifiedBy desc
+                - ModificationDate
+                - ModificationDate desc
+                - IsPrimary
+                - IsPrimary desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - ClassInstance
+                - ClassId
+                - DocumentId
+                - CreatedBy
+                - CreationDate
+                - ModifiedBy
+                - ModificationDate
+                - IsPrimary
+                - Document
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Document
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property DocumentClasses value.
+      operationId: DocumentClasses.DocumentClass.UpdateDocumentClass
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete DocumentClasses property value
+      operationId: DocumentClasses.DocumentClass.DeleteDocumentClass
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Revisions({Id})/Document/DocumentClasses/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.DocumentClasses-6342
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/Revisions({Id})/Document/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRel.ListDocumentTagRel
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - DocumentId
+                - DocumentId desc
+                - TagId
+                - TagId desc
+                - DomainId
+                - DomainId desc
+                - CreatedBy
+                - CreatedBy desc
+                - ModifiedBy
+                - ModifiedBy desc
+                - CreationDate
+                - CreationDate desc
+                - ModificationDate
+                - ModificationDate desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - DocumentId
+                - TagId
+                - DomainId
+                - CreatedBy
+                - ModifiedBy
+                - CreationDate
+                - ModificationDate
+                - Document
+                - Tag
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Document
+                - Tag
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRel.UpdateDocumentTagRel
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRel.DeleteDocumentTagRel
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Revisions({Id})/Document/Tags/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-161f
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of RevisionDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: RevisionDto
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Revisions/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -2345,6 +3102,172 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Tasks({Id})/Tags':
+    get:
+      summary: Get Tags property value
+      operationId: Tags.DocumentTagRelDto.ListDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+                - Name desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Name
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property Tags value.
+      operationId: Tags.DocumentTagRelDto.UpdateDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete Tags property value
+      operationId: Tags.DocumentTagRelDto.DeleteDocumentTagRelDto
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Tasks({Id})/Tags/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Tags-3a1b
+      parameters:
+        - name: Id
+          in: path
+          description: 'key: Id of DocumentDto'
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Tasks/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -3924,6 +4847,30 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Library.LibraryType'
+    Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse:
+      title: Collection of Siterra.Documents.App.DTO.DocumentTagRelDto
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
+    Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse:
+      title: Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
+    Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse:
+      title: Collection of Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
     StringCollectionResponse:
       title: Collection of string
       type: object
@@ -3932,6 +4879,14 @@ components:
           type: array
           items:
             type: string
+    ReferenceUpdateSchema:
+      type: object
+      properties:
+        '@odata.id':
+          type: string
+        '@odata.type':
+          type: string
+          nullable: true
   responses:
     error:
       description: error
@@ -3993,6 +4948,24 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Library.LibraryTypeCollectionResponse'
+    Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDtoCollectionResponse'
+    Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClassCollectionResponse'
+    Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRelCollectionResponse'
     StringCollectionResponse:
       description: Retrieved collection
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -13,8 +13,20 @@
         <Property Name="Gender" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender" Nullable="false" />
         <Property Name="Age" Type="Edm.Int64" />
         <Property Name="Emails" Type="Collection(Edm.String)" />
-        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location)" />
-        <Property Name="HomeAddress" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location" />
+        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location)">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+            <Collection>
+              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation</String>
+            </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="HomeAddress" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
+          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+            <Collection>
+              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation</String>
+            </Collection>
+          </Annotation>
+        </Property>
         <Property Name="FavoriteFeature" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature" Nullable="false" />
         <Property Name="Features" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature)" Nullable="false" />
         <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -78,6 +78,9 @@
       </ComplexType>
       <ComplexType Name="AirportLocation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
         <Property Name="Loc" Type="Edm.GeographyPoint" />
+        <NavigationProperty Name="EmergencyAuthority" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+          <Annotation Term="Org.OData.Core.V1.Description" String="The person to contact in case of a crisis at this location." />
+        </NavigationProperty>
       </ComplexType>
       <ComplexType Name="EventLocation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
         <Property Name="BuildingInfo" Type="Edm.String" />
@@ -229,7 +232,9 @@
             </Collection>
           </Annotation>
         </EntitySet>
-        <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
+        <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport">
+          <NavigationPropertyBinding Path="Location/EmergencyAuthority" Target="People" />
+        </EntitySet>
         <EntitySet Name="NewComePeople" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Singleton Name="Me" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
           <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -964,6 +964,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -1560,6 +1562,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -1988,6 +1992,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -2642,6 +2648,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -3512,6 +3520,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -4305,6 +4315,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -5079,6 +5091,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -6087,6 +6101,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -7604,6 +7620,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -8622,6 +8640,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -10391,6 +10411,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -10887,6 +10909,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -11660,6 +11684,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -12667,6 +12693,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -13555,6 +13583,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -14342,6 +14372,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -15366,6 +15398,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -18060,6 +18094,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -18584,6 +18620,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -19358,6 +19396,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -20366,6 +20406,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -21289,6 +21331,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -22175,6 +22219,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -23319,6 +23365,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -25068,6 +25116,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],
@@ -26250,6 +26300,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "consumes": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -14336,6 +14336,9 @@
           "properties": {
             "Loc": {
               "$ref": "#/definitions/Edm.GeographyPoint"
+            },
+            "EmergencyAuthority": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -516,6 +516,718 @@
       },
       "x-description": "Provides operations to manage the collection of Airport entities."
     },
+    "/Airports/{IcaoCode}/Location": {
+      "get": {
+        "summary": "Get Location property value",
+        "operationId": "Location.AirportLocation.GetAirportLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City",
+                "Loc",
+                "EmergencyAuthority"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "EmergencyAuthority"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Location value.",
+        "operationId": "Location.AirportLocation.UpdateAirportLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Location property value",
+        "operationId": "Location.AirportLocation.DeleteAirportLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority": {
+      "get": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Get EmergencyAuthority from Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.GetEmergencyAuthority",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the EmergencyAuthority property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation entity."
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/$ref": {
+      "get": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Get ref of EmergencyAuthority from Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.GetRefEmergencyAuthority",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Update the ref of navigation property EmergencyAuthority in Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.UpdateRefEmergencyAuthority",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property ref values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReferenceUpdateSchema"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Delete ref of navigation property EmergencyAuthority for Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.DeleteRefEmergencyAuthority",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Airport entities."
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-2ffe",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fbf9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e708",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0bb9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/Airports/$count": {
       "get": {
         "summary": "Get the number of the resource",
@@ -707,6 +1419,256 @@
       },
       "x-description": "Provides operations to manage the Person singleton."
     },
+    "/Me/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-38f2",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b1a4",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5575",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/Me/BestFriend": {
       "get": {
         "tags": [
@@ -830,10 +1792,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "$ref": "#/definitions/ReferenceUpdateSchema"
             }
           }
         ],
@@ -887,6 +1846,395 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/BestFriend/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-b695",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2154",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0105",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/BestFriend/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a28d",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
@@ -1128,6 +2476,491 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-fd8c",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fc60",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5b72",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1c35",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -1514,6 +3347,491 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-d54c",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9a3f",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5246",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-32bf",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
         "summary": "Get the number of the resource",
@@ -1822,6 +4140,491 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/Me/Friends/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-246e",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f440",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-42c7",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Friends/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-15cc",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
         "tags": [
@@ -2086,6 +4889,579 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-48a8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2502",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-af23",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0b8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -2521,6 +5897,579 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-431a",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c88",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c06",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1293",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
@@ -3110,6 +7059,145 @@
       },
       "x-description": "Provides operations to count the resources in the collection."
     },
+    "/Me/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba49",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
         "tags": [
@@ -3350,6 +7438,491 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-3e91",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1e59",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be1d",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dc11",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -3883,6 +8456,491 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-f650",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-660b",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a070",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5e6e",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
@@ -5189,6 +10247,269 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/NewComePeople/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-29d6",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d026",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-29d3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/NewComePeople/{UserName}/BestFriend": {
       "get": {
         "tags": [
@@ -5338,10 +10659,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "$ref": "#/definitions/ReferenceUpdateSchema"
             }
           }
         ],
@@ -5403,6 +10721,491 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-513c",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-73fa",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba36",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/BestFriend/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8ebe",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
@@ -5667,6 +11470,579 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-4a98",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e8e0",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9b7d",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c470",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -6102,6 +12478,579 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-d1f1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f240",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2b9e",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ebc0",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
         "summary": "Get the number of the resource",
@@ -6438,6 +13387,502 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-9334",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-eeb4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be92",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f4d9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
         "tags": [
@@ -6704,6 +14149,590 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-5dc7",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8c47",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c569",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-14b4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -7144,6 +15173,590 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-4981",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-7650",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3cb5",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fefc",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
@@ -7748,6 +16361,151 @@
         }
       },
       "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/NewComePeople/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3fd9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
       "get": {
@@ -9137,6 +17895,318 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/People/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-ed5a",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e5b8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-4abd",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/People/{UserName}/BestFriend": {
       "get": {
         "tags": [
@@ -9286,10 +18356,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "$ref": "#/definitions/ReferenceUpdateSchema"
             }
           }
         ],
@@ -9351,6 +18418,491 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/BestFriend/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-16df",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c332",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fe88",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/BestFriend/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-53c4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
@@ -9616,6 +19168,579 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-b3b3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2413",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cdcc",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b55f",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -10052,6 +20177,579 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-6b26",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d278",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-974b",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-51d6",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
         "summary": "Get the number of the resource",
@@ -10402,6 +21100,579 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-bdaf",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a5f6",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2795",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-da5e",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
         "tags": [
@@ -10690,6 +21961,667 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-4fcb",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-caeb",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dd01",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8049",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -11173,6 +23105,667 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-62f0",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f6bd",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-de2a",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3646",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName2",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
@@ -11848,6 +24441,179 @@
       },
       "x-description": "Provides operations to count the resources in the collection."
     },
+    "/People/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0cf",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "get": {
         "tags": [
@@ -12112,6 +24878,579 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-755d",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b918",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ef5e",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-311b",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -12721,6 +26060,579 @@
         "x-ms-docs-operation-type": "operation"
       },
       "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-f46e",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1252",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5d49",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cf8d",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
@@ -14934,6 +28846,18 @@
         }
       }
     },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse": {
+      "title": "Collection of Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+          }
+        }
+      }
+    },
     "StringCollectionResponse": {
       "title": "Collection of string",
       "type": "object",
@@ -14943,6 +28867,17 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "ReferenceUpdateSchema": {
+      "type": "object",
+      "properties": {
+        "@odata.id": {
+          "type": "string"
+        },
+        "@odata.type": {
+          "type": "string"
         }
       }
     }
@@ -15054,6 +28989,12 @@
         "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.FlightCollectionResponse"
       }
     },
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse": {
+      "description": "Retrieved collection",
+      "schema": {
+        "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+      }
+    },
     "StringCollectionResponse": {
       "description": "Retrieved collection",
       "schema": {
@@ -15068,6 +29009,14 @@
     },
     {
       "name": "Airports.Airport",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Airports.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Location.EventLocation",
       "x-ms-docs-toc-type": "page"
     },
     {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -344,6 +344,491 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Airport entities.
+  '/Airports/{IcaoCode}/Location':
+    get:
+      summary: Get Location property value
+      operationId: Location.AirportLocation.GetAirportLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+              - Loc
+              - EmergencyAuthority
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - EmergencyAuthority
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property Location value.
+      operationId: Location.AirportLocation.UpdateAirportLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete Location property value
+      operationId: Location.AirportLocation.DeleteAirportLocation
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority':
+    get:
+      tags:
+        - Airports.Person
+      summary: Get EmergencyAuthority from Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.GetEmergencyAuthority
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the EmergencyAuthority property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation entity.
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/$ref':
+    get:
+      tags:
+        - Airports.Person
+      summary: Get ref of EmergencyAuthority from Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.GetRefEmergencyAuthority
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Airports.Person
+      summary: Update the ref of navigation property EmergencyAuthority in Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.UpdateRefEmergencyAuthority
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: body
+          name: body
+          description: New navigation property ref values
+          required: true
+          schema:
+            $ref: '#/definitions/ReferenceUpdateSchema'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Airports.Person
+      summary: Delete ref of navigation property EmergencyAuthority for Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.DeleteRefEmergencyAuthority
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Airport entities.
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-2ffe
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fbf9
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e708
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0bb9
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: 'key: IcaoCode of Airport'
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
   /Airports/$count:
     get:
       summary: Get the number of the resource
@@ -480,6 +965,176 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Person singleton.
+  /Me/AddressInfo:
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/AddressInfo/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-38f2
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b1a4
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  /Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5575
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
   /Me/BestFriend:
     get:
       tags:
@@ -574,9 +1229,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: object
-            additionalProperties:
-              type: object
+            $ref: '#/definitions/ReferenceUpdateSchema'
       responses:
         '204':
           description: Success
@@ -613,6 +1266,273 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  /Me/BestFriend/AddressInfo:
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/AddressInfo/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-b695
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2154
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  /Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0105
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/BestFriend/HomeAddress:
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a28d
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
     get:
       tags:
@@ -791,6 +1711,343 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-fd8c
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fc60
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5b72
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1c35
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     get:
       summary: Get the number of the resource
@@ -1071,6 +2328,343 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-d54c
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9a3f
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5246
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-32bf
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     get:
       summary: Get the number of the resource
@@ -1293,6 +2887,343 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Friends/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-246e
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f440
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-42c7
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Friends/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-15cc
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     get:
       tags:
@@ -1489,6 +3420,409 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-48a8
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2502
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-af23
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0b8
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     get:
       summary: Get the number of the resource
@@ -1806,6 +4140,409 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-431a
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c88
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c06
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1293
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     get:
       summary: Get the number of the resource
@@ -2231,6 +4968,103 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to count the resources in the collection.
+  /Me/HomeAddress:
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba49
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
     get:
       tags:
@@ -2409,6 +5243,343 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-3e91
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1e59
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be1d
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dc11
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     get:
       summary: Get the number of the resource
@@ -2793,6 +5964,343 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-f650
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-660b
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a070
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5e6e
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     get:
       summary: Get the number of the resource
@@ -3726,6 +7234,179 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/NewComePeople/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-29d6
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d026
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
+  '/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-29d3
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
   '/NewComePeople/{UserName}/BestFriend':
     get:
       tags:
@@ -3839,9 +7520,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: object
-            additionalProperties:
-              type: object
+            $ref: '#/definitions/ReferenceUpdateSchema'
       responses:
         '204':
           description: Success
@@ -3884,6 +7563,343 @@ paths:
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-513c
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-73fa
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to EventLocation.
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba36
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/BestFriend/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8ebe
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to EventLocation.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     get:
       tags:
@@ -4079,6 +8095,409 @@ paths:
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-4a98
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e8e0
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to EventLocation.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9b7d
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c470
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to EventLocation.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     get:
       summary: Get the number of the resource
@@ -4395,6 +8814,409 @@ paths:
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-d1f1
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f240
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to EventLocation.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2b9e
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ebc0
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Casts the previous resource to EventLocation.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     get:
       summary: Get the number of the resource
@@ -4636,6 +9458,343 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-9334
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-eeb4
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be92
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f4d9
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     get:
       tags:
@@ -4831,6 +9990,409 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-5dc7
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8c47
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c569
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-14b4
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     get:
       summary: Get the number of the resource
@@ -5147,6 +10709,409 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-4981
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-7650
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3cb5
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fefc
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     get:
       summary: Get the number of the resource
@@ -5575,6 +11540,104 @@ paths:
         default:
           $ref: '#/responses/error'
     x-description: Provides operations to count the resources in the collection.
+  '/NewComePeople/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+  '/NewComePeople/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3fd9
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+    x-description: Casts the previous resource to EventLocation.
   '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
     get:
       tags:
@@ -6558,6 +12621,221 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-ed5a
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e5b8
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-4abd
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/BestFriend':
     get:
       tags:
@@ -6671,9 +12949,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: object
-            additionalProperties:
-              type: object
+            $ref: '#/definitions/ReferenceUpdateSchema'
       responses:
         '204':
           description: Success
@@ -6716,6 +12992,343 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/BestFriend/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-16df
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c332
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fe88
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/BestFriend/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-53c4
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     get:
       tags:
@@ -6912,6 +13525,409 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-b3b3
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2413
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cdcc
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b55f
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     get:
       summary: Get the number of the resource
@@ -7229,6 +14245,409 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-6b26
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d278
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-974b
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-51d6
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     get:
       summary: Get the number of the resource
@@ -7482,6 +14901,409 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-bdaf
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a5f6
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2795
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Friends/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-da5e
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     get:
       tags:
@@ -7696,6 +15518,475 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-4fcb
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-caeb
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dd01
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8049
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     get:
       summary: Get the number of the resource
@@ -8049,6 +16340,475 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-62f0
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f6bd
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-de2a
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3646
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName2
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     get:
       summary: Get the number of the resource
@@ -8537,6 +17297,128 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0cf
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     get:
       tags:
@@ -8733,6 +17615,409 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-755d
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b918
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ef5e
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-311b
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     get:
       summary: Get the number of the resource
@@ -9173,6 +18458,409 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-f46e
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1252
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5d49
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cf8d
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     get:
       summary: Get the number of the resource
@@ -10719,6 +20407,14 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight'
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse:
+    title: Collection of Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+    type: object
+    properties:
+      value:
+        type: array
+        items:
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
   StringCollectionResponse:
     title: Collection of string
     type: object
@@ -10727,6 +20423,13 @@ definitions:
         type: array
         items:
           type: string
+  ReferenceUpdateSchema:
+    type: object
+    properties:
+      '@odata.id':
+        type: string
+      '@odata.type':
+        type: string
 parameters:
   top:
     in: query
@@ -10804,6 +20507,10 @@ responses:
     description: Retrieved collection
     schema:
       $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.FlightCollectionResponse'
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse:
+    description: Retrieved collection
+    schema:
+      $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
   StringCollectionResponse:
     description: Retrieved collection
     schema:
@@ -10812,6 +20519,10 @@ tags:
   - name: Airlines.Airline
     x-ms-docs-toc-type: page
   - name: Airports.Airport
+    x-ms-docs-toc-type: page
+  - name: Airports.Person
+    x-ms-docs-toc-type: page
+  - name: Location.EventLocation
     x-ms-docs-toc-type: page
   - name: Airports
     x-ms-docs-toc-type: container

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -652,6 +652,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -1059,6 +1061,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -1360,6 +1364,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -1823,6 +1829,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -2440,6 +2448,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -2999,6 +3009,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -3550,6 +3562,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -4270,6 +4284,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -5355,6 +5371,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -6076,6 +6094,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -7328,6 +7348,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -7675,6 +7697,8 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -8225,6 +8249,8 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -8944,6 +8970,8 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -9570,6 +9598,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -10120,6 +10150,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -10839,6 +10871,8 @@ paths:
         default:
           $ref: '#/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -12733,6 +12767,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -13104,6 +13140,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -13655,6 +13693,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -14375,6 +14415,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -15031,6 +15073,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -15666,6 +15710,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -16488,6 +16534,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -17745,6 +17793,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:
@@ -18588,6 +18638,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       consumes:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -10331,6 +10331,8 @@ definitions:
         properties:
           Loc:
             $ref: '#/definitions/Edm.GeographyPoint'
+          EmergencyAuthority:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
   Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
     allOf:
       - $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -16003,6 +16003,15 @@
             "properties": {
               "Loc": {
                 "$ref": "#/components/schemas/Edm.GeographyPoint"
+              },
+              "EmergencyAuthority": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                  }
+                ],
+                "description": "The person to contact in case of a crisis at this location.",
+                "nullable": true
               }
             }
           }
@@ -16953,6 +16962,9 @@
       },
       "Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation": {
         "value": {
+          "EmergencyAuthority": {
+            "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+          },
           "Loc": "GeographyPoint"
         }
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -578,6 +578,808 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Airports/{IcaoCode}/Location": {
+      "get": {
+        "summary": "Get Location property value",
+        "operationId": "Location.AirportLocation.GetAirportLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City",
+                  "Loc",
+                  "EmergencyAuthority"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "EmergencyAuthority"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property Location value.",
+        "operationId": "Location.AirportLocation.UpdateAirportLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Location property value",
+        "operationId": "Location.AirportLocation.DeleteAirportLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority": {
+      "description": "Provides operations to manage the EmergencyAuthority property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation entity.",
+      "get": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Get EmergencyAuthority from Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.GetEmergencyAuthority",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/$ref": {
+      "description": "Provides operations to manage the collection of Airport entities.",
+      "get": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Get ref of EmergencyAuthority from Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.GetRefEmergencyAuthority",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Update the ref of navigation property EmergencyAuthority in Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.UpdateRefEmergencyAuthority",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property ref values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Delete ref of navigation property EmergencyAuthority for Airports",
+        "description": "The person to contact in case of a crisis at this location.",
+        "operationId": "Airports.DeleteRefEmergencyAuthority",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-2ffe",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fbf9",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e708",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0bb9",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "key: IcaoCode of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Airports/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -823,6 +1625,271 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-38f2",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b1a4",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5575",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/BestFriend": {
       "description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -954,10 +2021,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object"
-                }
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
               }
             }
           },
@@ -1013,6 +2077,420 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/BestFriend/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-b695",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2154",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0105",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a28d",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
@@ -1286,6 +2764,542 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-fd8c",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fc60",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5b72",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1c35",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -1708,6 +3722,542 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-d54c",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9a3f",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5246",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-32bf",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -2040,6 +4590,542 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/Friends/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-246e",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f440",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-42c7",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-15cc",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "description": "Casts the previous resource to Employee.",
       "get": {
@@ -2341,6 +5427,652 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-48a8",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2502",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-af23",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0b8",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -2825,6 +6557,652 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-431a",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c88",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c06",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1293",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
@@ -3459,6 +7837,155 @@
         }
       }
     },
+    "/Me/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba49",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "description": "Casts the previous resource to Employee.",
       "get": {
@@ -3730,6 +8257,542 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-3e91",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1e59",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be1d",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dc11",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -4315,6 +9378,542 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-f650",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-660b",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a070",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5e6e",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
@@ -5733,6 +11332,300 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/NewComePeople/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-29d6",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d026",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-29d3",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/NewComePeople/{UserName}/BestFriend": {
       "description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -5898,10 +11791,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object"
-                }
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
               }
             }
           },
@@ -5967,6 +11857,542 @@
           "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-513c",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-73fa",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba36",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8ebe",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
       }
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
@@ -6269,6 +12695,652 @@
           "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-4a98",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e8e0",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9b7d",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c470",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
       }
     },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -6754,6 +13826,652 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-d1f1",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f240",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2b9e",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ebc0",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
     "/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -7126,6 +14844,575 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-9334",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-eeb4",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be92",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f4d9",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "description": "Casts the previous resource to Employee.",
       "get": {
@@ -7435,6 +15722,685 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-5dc7",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8c47",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c569",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-14b4",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -7936,6 +16902,685 @@
           }
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-4981",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-7650",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3cb5",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fefc",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
@@ -8601,6 +18246,171 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/NewComePeople/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3fd9",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -10165,6 +19975,349 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People/{UserName}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-ed5a",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e5b8",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-4abd",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/BestFriend": {
       "description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -10330,10 +20483,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object"
-                }
+                "$ref": "#/components/schemas/ReferenceUpdateSchema"
               }
             }
           },
@@ -10399,6 +20549,542 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/BestFriend/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-16df",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c332",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fe88",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-53c4",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
@@ -10702,6 +21388,652 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-b3b3",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2413",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cdcc",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b55f",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -11188,6 +22520,652 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-6b26",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d278",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-974b",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-51d6",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -11574,6 +23552,652 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-bdaf",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a5f6",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2795",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-da5e",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "description": "Casts the previous resource to Employee.",
       "get": {
@@ -11905,6 +24529,762 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-4fcb",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-caeb",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dd01",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8049",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -12449,6 +25829,762 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-62f0",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f6bd",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-de2a",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3646",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName2",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
@@ -13191,6 +27327,199 @@
         }
       }
     },
+    "/People/{UserName}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0cf",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
       "description": "Casts the previous resource to Employee.",
       "get": {
@@ -13492,6 +27821,652 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-755d",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b918",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ef5e",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-311b",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
@@ -14175,6 +29150,652 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo": {
+      "get": {
+        "summary": "Get AddressInfo property value",
+        "operationId": "AddressInfo.Location.ListLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property AddressInfo value.",
+        "operationId": "AddressInfo.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete AddressInfo property value",
+        "operationId": "AddressInfo.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.AddressInfo-f46e",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1252",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5d49",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress": {
+      "get": {
+        "summary": "Get HomeAddress property value",
+        "operationId": "HomeAddress.Location.GetLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "summary": "Update property HomeAddress value.",
+        "operationId": "HomeAddress.Location.UpdateLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "summary": "Delete HomeAddress property value",
+        "operationId": "HomeAddress.Location.DeleteLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Location.EventLocation"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cf8d",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
@@ -16694,6 +32315,18 @@
           }
         }
       },
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse": {
+        "title": "Collection of Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        }
+      },
       "StringCollectionResponse": {
         "title": "Collection of string",
         "type": "object",
@@ -16703,6 +32336,18 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "ReferenceUpdateSchema": {
+        "type": "object",
+        "properties": {
+          "@odata.id": {
+            "type": "string"
+          },
+          "@odata.type": {
+            "type": "string",
+            "nullable": true
           }
         }
       }
@@ -16824,6 +32469,16 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.FlightCollectionResponse"
+            }
+          }
+        }
+      },
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse": {
+        "description": "Retrieved collection",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
             }
           }
         }
@@ -17060,6 +32715,14 @@
     },
     {
       "name": "Airports.Airport",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Airports.Person",
+      "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Location.EventLocation",
       "x-ms-docs-toc-type": "page"
     },
     {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1087,6 +1087,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -1780,6 +1782,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "If-Match",
@@ -2234,6 +2238,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "If-Match",
@@ -2953,6 +2959,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -3909,6 +3917,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -4777,6 +4787,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -5646,6 +5658,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -6776,6 +6790,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -8446,6 +8462,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -9567,6 +9585,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -11498,6 +11518,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -12046,6 +12068,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -12914,6 +12938,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -14043,6 +14069,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -15040,6 +15068,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -15950,6 +15980,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -17130,6 +17162,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -20162,6 +20196,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -20738,6 +20774,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -21607,6 +21645,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -22737,6 +22777,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -23769,6 +23811,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -24778,6 +24822,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -26078,6 +26124,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -28040,6 +28088,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",
@@ -29369,6 +29419,8 @@
         }
       },
       "post": {
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "AddressInfo.Location.SetLocation",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -730,6 +730,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: IcaoCode
           in: path
@@ -1190,6 +1192,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: If-Match
           in: header
@@ -1509,6 +1513,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: If-Match
           in: header
@@ -2017,6 +2023,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -2690,6 +2698,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -3297,6 +3307,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -3908,6 +3920,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -4702,6 +4716,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -5888,6 +5904,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -6670,6 +6688,8 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -8022,6 +8042,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -8400,6 +8422,8 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -9010,6 +9034,8 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -9803,6 +9829,8 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -10494,6 +10522,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -11118,6 +11148,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -11928,6 +11960,8 @@ paths:
         default:
           $ref: '#/components/responses/error'
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -14018,6 +14052,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -14420,6 +14456,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -15031,6 +15069,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -15825,6 +15865,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -16546,6 +16588,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -17255,6 +17299,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -18168,6 +18214,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -19556,6 +19604,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path
@@ -20482,6 +20532,8 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     post:
+      summary: Sets a new value for the collection of Location.
+      operationId: AddressInfo.Location.SetLocation
       parameters:
         - name: UserName
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -11371,6 +11371,11 @@ components:
           properties:
             Loc:
               $ref: '#/components/schemas/Edm.GeographyPoint'
+            EmergencyAuthority:
+              anyOf:
+                - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+              description: The person to contact in case of a crisis at this location.
+              nullable: true
     Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
       allOf:
         - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
@@ -11966,6 +11971,8 @@ components:
         Region: String
     Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation:
       value:
+        EmergencyAuthority:
+          '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person
         Loc: GeographyPoint
     Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
       value:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -384,6 +384,545 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/Airports/{IcaoCode}/Location':
+    get:
+      summary: Get Location property value
+      operationId: Location.AirportLocation.GetAirportLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+                - Loc
+                - EmergencyAuthority
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - EmergencyAuthority
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property Location value.
+      operationId: Location.AirportLocation.UpdateAirportLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete Location property value
+      operationId: Location.AirportLocation.DeleteAirportLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority':
+    description: Provides operations to manage the EmergencyAuthority property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation entity.
+    get:
+      tags:
+        - Airports.Person
+      summary: Get EmergencyAuthority from Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.GetEmergencyAuthority
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/$ref':
+    description: Provides operations to manage the collection of Airport entities.
+    get:
+      tags:
+        - Airports.Person
+      summary: Get ref of EmergencyAuthority from Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.GetRefEmergencyAuthority
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Airports.Person
+      summary: Update the ref of navigation property EmergencyAuthority in Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.UpdateRefEmergencyAuthority
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      requestBody:
+        description: New navigation property ref values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Airports.Person
+      summary: Delete ref of navigation property EmergencyAuthority for Airports
+      description: The person to contact in case of a crisis at this location.
+      operationId: Airports.DeleteRefEmergencyAuthority
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-2ffe
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fbf9
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e708
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0bb9
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: 'key: IcaoCode of Airport'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
   /Airports/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -546,6 +1085,187 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  /Me/AddressInfo:
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/AddressInfo/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-38f2
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b1a4
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5575
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend:
     description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -646,9 +1366,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties:
-                type: object
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
         required: true
       responses:
         '204':
@@ -686,6 +1404,291 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  /Me/BestFriend/AddressInfo:
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/AddressInfo/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-b695
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2154
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-0105
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/HomeAddress:
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a28d
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
     description: Casts the previous resource to Employee.
     get:
@@ -887,6 +1890,374 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-fd8c
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fc60
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5b72
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1c35
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -1192,6 +2563,374 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-d54c
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9a3f
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5246
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-32bf
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -1431,6 +3170,374 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  '/Me/Friends/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-246e
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f440
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-42c7
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-15cc
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     description: Casts the previous resource to Employee.
     get:
@@ -1653,6 +3760,451 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-48a8
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2502
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-af23
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0b8
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -2002,6 +4554,451 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-431a
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c88
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3c06
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1293
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   '/Me/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -2459,6 +5456,110 @@ paths:
         date: '2021-08-24T00:00:00.0000000'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/HomeAddress:
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba49
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
     description: Casts the previous resource to Employee.
     get:
@@ -2660,6 +5761,374 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-3e91
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1e59
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be1d
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dc11
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -3074,6 +6543,374 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-f650
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-660b
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a070
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5e6e
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -4076,6 +7913,198 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-29d6
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d026
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-29d3
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/BestFriend':
     description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -4199,9 +8228,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties:
-                type: object
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
         required: true
       responses:
         '204':
@@ -4246,6 +8273,374 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-513c
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-73fa
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ba36
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8ebe
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     description: Casts the previous resource to Employee.
     get:
@@ -4467,6 +8862,451 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-4a98
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e8e0
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-9b7d
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c470
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -4815,6 +9655,451 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-d1f1
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f240
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2b9e
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ebc0
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -5079,6 +10364,385 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-9334
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-eeb4
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-be92
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f4d9
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     description: Casts the previous resource to Employee.
     get:
@@ -5303,6 +10967,462 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-5dc7
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8c47
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c569
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-14b4
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -5657,6 +11777,462 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-4981
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-7650
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3cb5
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fefc
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -6126,6 +12702,116 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3fd9
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
         default:
           $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
@@ -7205,6 +13891,240 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-ed5a
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-e5b8
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-4abd
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend':
     description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -7328,9 +14248,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties:
-                type: object
+              $ref: '#/components/schemas/ReferenceUpdateSchema'
         required: true
       responses:
         '204':
@@ -7375,6 +14293,374 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/BestFriend/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-16df
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-c332
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-fe88
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-53c4
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     description: Casts the previous resource to Employee.
     get:
@@ -7597,6 +14883,451 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-b3b3
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2413
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cdcc
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b55f
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -7946,6 +15677,451 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-6b26
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d278
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-974b
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-51d6
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -8222,6 +16398,451 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-bdaf
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-a5f6
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-2795
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-da5e
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     description: Casts the previous resource to Employee.
     get:
@@ -8465,6 +17086,528 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-4fcb
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-caeb
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-dd01
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-8049
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -8856,6 +17999,528 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-62f0
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-f6bd
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-de2a
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName2}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-3646
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName2
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -9387,6 +19052,140 @@ paths:
         date: '2021-08-24T00:00:00.0000000'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-d0cf
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
     description: Casts the previous resource to Employee.
     get:
@@ -9609,6 +19408,451 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-755d
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-b918
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-ef5e
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-311b
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -10090,6 +20334,451 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo':
+    get:
+      summary: Get AddressInfo property value
+      operationId: AddressInfo.Location.ListLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property AddressInfo value.
+      operationId: AddressInfo.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete AddressInfo property value
+      operationId: AddressInfo.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.AddressInfo-f46e
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-1252
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Get.Count.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-5d49
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress':
+    get:
+      summary: Get HomeAddress property value
+      operationId: HomeAddress.Location.GetLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      summary: Update property HomeAddress value.
+      operationId: HomeAddress.Location.UpdateLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      summary: Delete HomeAddress property value
+      operationId: HomeAddress.Location.DeleteLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Location.EventLocation
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation-cf8d
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -11801,6 +22490,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight'
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse:
+      title: Collection of Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
     StringCollectionResponse:
       title: Collection of string
       type: object
@@ -11809,6 +22506,14 @@ components:
           type: array
           items:
             type: string
+    ReferenceUpdateSchema:
+      type: object
+      properties:
+        '@odata.id':
+          type: string
+        '@odata.type':
+          type: string
+          nullable: true
   responses:
     error:
       description: error
@@ -11882,6 +22587,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.FlightCollectionResponse'
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
     StringCollectionResponse:
       description: Retrieved collection
       content:
@@ -12030,6 +22741,10 @@ tags:
   - name: Airlines.Airline
     x-ms-docs-toc-type: page
   - name: Airports.Airport
+    x-ms-docs-toc-type: page
+  - name: Airports.Person
+    x-ms-docs-toc-type: page
+  - name: Location.EventLocation
     x-ms-docs-toc-type: page
   - name: Airports
     x-ms-docs-toc-type: container


### PR DESCRIPTION
fixes #15

This pull request adds path items for complex properties on entities as well as path items for navigation properties in complex types. Subsequently, it adds raw count, type cast and $ref path segments under those when required.
For a detail of which paths we're adding, see #15