### PR TITLE
Updates navigation property expansion logic

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
@@ -124,43 +124,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 current = current.BaseEntityType();
             }
         }
-
-        /// <summary>
-        /// Checks if the <paramref name="baseType"/> is assignable to <paramref name="subtype"/>.
-        /// In other words, if <paramref name="subtype"/> is a subtype of <paramref name="baseType"/> or not.
-        /// </summary>
-        /// <param name="baseType">Type of the base type.</param>
-        /// <param name="subtype">Type of the sub type.</param>
-        /// <returns>true, if the <paramref name="baseType"/> is assignable to <paramref name="subtype"/>. Otherwise returns false.</returns>
-        public static bool IsAssignableFrom(this IEdmEntityType baseType, IEdmEntityType subtype)
-        {
-            Utils.CheckArgumentNull(baseType, nameof(baseType));
-            Utils.CheckArgumentNull(subtype, nameof(subtype));
-
-            if (baseType.TypeKind != subtype.TypeKind)
-            {
-                return false;
-            }
-
-            if (subtype.IsEquivalentTo(baseType))
-            {
-                return true;
-            }
-
-            IEdmStructuredType structuredSubType = subtype;
-            while (structuredSubType != null)
-            {
-                if (structuredSubType.IsEquivalentTo(baseType))
-                {
-                    return true;
-                }
-
-                structuredSubType = structuredSubType.BaseType;
-            }
-
-            return false;
-        }
-
+                
         /// <summary>
         /// Check whether the operation is overload in the model.
         /// </summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
@@ -124,7 +124,44 @@ namespace Microsoft.OpenApi.OData.Edm
                 current = current.BaseEntityType();
             }
         }
-                
+
+        /// <summary>
+        /// Checks if the <paramref name="baseType"/> is assignable to <paramref name="subtype"/>.
+        /// In other words, if <paramref name="subtype"/> is a subtype of <paramref name="baseType"/> or not.
+        /// </summary>
+        /// <param name="baseType">Type of the base type.</param>
+        /// <param name="subtype">Type of the sub type.</param>
+        /// <returns>true, if the <paramref name="baseType"/> is assignable to <paramref name="subtype"/>. Otherwise returns false.</returns>
+        [Obsolete]
+        public static bool IsAssignableFrom(this IEdmEntityType baseType, IEdmEntityType subtype)
+        {
+            Utils.CheckArgumentNull(baseType, nameof(baseType));
+            Utils.CheckArgumentNull(subtype, nameof(subtype));
+
+            if (baseType.TypeKind != subtype.TypeKind)
+            {
+                return false;
+            }
+
+            if (subtype.IsEquivalentTo(baseType))
+            {
+                return true;
+            }
+
+            IEdmStructuredType structuredSubType = subtype;
+            while (structuredSubType != null)
+            {
+                if (structuredSubType.IsEquivalentTo(baseType))
+                {
+                    return true;
+                }
+
+                structuredSubType = structuredSubType.BaseType;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Check whether the operation is overload in the model.
         /// </summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -337,7 +337,7 @@ namespace Microsoft.OpenApi.OData.Edm
 
             if (visitedNavigationProperties == null)
             {
-                visitedNavigationProperties = new Stack<string>();
+                visitedNavigationProperties = new ();
             }
                         
             var navPropFullyQualifiedName = $"{navigationProperty.DeclaringType.FullTypeName()}/{navigationProperty.Name}";

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -273,6 +273,15 @@ namespace Microsoft.OpenApi.OData.Edm
             Debug.Assert(navigationProperty != null);
             Debug.Assert(currentPath != null);
 
+            // Check whether the navigation property has already been navigated in the path
+            foreach (ODataSegment segment in currentPath)
+            {
+                if (navigationProperty.Name.Equals(segment.Identifier))
+                {
+                    return;
+                }
+            }
+
             // Check whether the navigation property should be part of the path
             NavigationRestrictionsType navigation = _model.GetRecord<NavigationRestrictionsType>(navigationProperty, CapabilitiesConstants.NavigationRestrictions);
             if (navigation != null && !navigation.IsNavigable)
@@ -281,7 +290,7 @@ namespace Microsoft.OpenApi.OData.Edm
             }
 
             // test the expandable for the navigation property.
-            bool shouldExpand = ShouldExpandNavigationProperty(navigationProperty, currentPath);
+            bool shouldExpand = navigationProperty.ContainsTarget;
 
             // append a navigation property.
             currentPath.Push(new ODataNavigationPropertySegment(navigationProperty));
@@ -362,31 +371,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 }
             }
             currentPath.Pop();
-        }
-
-        private bool ShouldExpandNavigationProperty(IEdmNavigationProperty navigationProperty, ODataPath currentPath)
-        {
-            Debug.Assert(navigationProperty != null);
-            Debug.Assert(currentPath != null);
-
-            // not expand for the non-containment.
-            if (!navigationProperty.ContainsTarget)
-            {
-                return false;
-            }
-
-            // check the type is visited before, if visited, not expand it.
-            IEdmEntityType navEntityType = navigationProperty.ToEntityType();
-            foreach (ODataSegment segment in currentPath)
-            {
-                if (navEntityType.IsAssignableFrom(segment.EntityType))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+        }              
 
         /// <summary>
         /// Create $ref paths.

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -289,7 +289,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 return;
             }
 
-            // test the expandable for the navigation property.
+            // Whether to expand the navigation property
             bool shouldExpand = navigationProperty.ContainsTarget;
 
             // append a navigation property.

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(50085, paths.Count());
+            Assert.Equal(1413958, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(50070, paths.Count());
+            Assert.Equal(1413937, paths.Count());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17178, paths.Count());
+            Assert.Equal(57490, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17163, paths.Count());
+            Assert.Equal(57469, paths.Count());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(28227, paths.Count());
+            Assert.Equal(26436, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(28193, paths.Count());
+            Assert.Equal(26394, paths.Count());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/123

This PR proposes:
- Updating the expansion logic for containment navigation properties to evaluate based on whether the navigation property  has been visited before and not the navigation property type.

NB: This approach expands on all containment navigation properties. This ends up exploding the number of paths significantly.
