### PR TITLE
Add support for PUT operation on entity sets and navigation properties based on UpdateMethod annotation

### DIFF
--- a/docs/csdl/TripService.xml
+++ b/docs/csdl/TripService.xml
@@ -117,6 +117,10 @@
         <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
         <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
       </Function>
+      <Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person">
+        <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
+      </Function>
       <Function Name="GetFriendsTrips" IsBound="true">
         <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />

--- a/docs/csdl/TripService.xml
+++ b/docs/csdl/TripService.xml
@@ -154,13 +154,6 @@
               <PropertyPath>Name</PropertyPath>
             </Collection>
           </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-            <Record>
-              <PropertyValue Property="UpdateMethod">
-                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
-              </PropertyValue>
-            </Record>
-          </Annotation>
         </EntitySet>
         <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
         <EntitySet Name="NewComePeople" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />

--- a/docs/csdl/TripService.xml
+++ b/docs/csdl/TripService.xml
@@ -117,10 +117,6 @@
         <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
         <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
       </Function>
-      <Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person">
-        <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
-      </Function>
       <Function Name="GetFriendsTrips" IsBound="true">
         <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
@@ -153,6 +149,13 @@
             <Collection>
               <PropertyPath>Name</PropertyPath>
             </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="UpdateMethod">
+                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+              </PropertyValue>
+            </Record>
           </Annotation>
         </EntitySet>
         <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />

--- a/docs/csdl/TripService.xml
+++ b/docs/csdl/TripService.xml
@@ -35,7 +35,15 @@
         <Property Name="Name" Type="Edm.String" />
         <Property Name="IcaoCode" Type="Edm.String" Nullable="false" />
         <Property Name="IataCode" Type="Edm.String" />
-        <Property Name="Location" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation" />
+        <Property Name="Location" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation">
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="UpdateMethod">
+                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </Property>
       </EntityType>
       <ComplexType Name="Location">
         <Property Name="Address" Type="Edm.String" />

--- a/docs/csdl/TripService.xml
+++ b/docs/csdl/TripService.xml
@@ -154,6 +154,13 @@
               <PropertyPath>Name</PropertyPath>
             </Collection>
           </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="UpdateMethod">
+                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
         </EntitySet>
         <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
         <EntitySet Name="NewComePeople" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPutOperationHandler.cs
@@ -7,8 +7,8 @@ using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
-internal class ComplexPropertyPatchOperationHandler : ComplexPropertyUpdateOperationHandler
+internal class ComplexPropertyPutOperationHandler : ComplexPropertyUpdateOperationHandler
 {
     /// <inheritdoc />
-    public override OperationType OperationType => OperationType.Patch;
+    public override OperationType OperationType => OperationType.Put;
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+
+namespace Microsoft.OpenApi.OData.Operation;
+
+internal abstract class ComplexPropertyUpdateOperationHandler : ComplexPropertyBaseOperationHandler
+{
+    /// <inheritdoc/>
+    protected override void SetBasicInfo(OpenApiOperation operation)
+    {
+        // Summary
+        operation.Summary = $"Update property {ComplexPropertySegment.Property.Name} value.";
+
+        // Description
+        operation.Description = Context.Model.GetDescriptionAnnotation(ComplexPropertySegment.Property);
+
+        // OperationId
+        if (Context.Settings.EnableOperationId)
+        {
+            string typeName = ComplexPropertySegment.ComplexType.Name;
+            operation.OperationId = ComplexPropertySegment.Property.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void SetRequestBody(OpenApiOperation operation)
+    {
+        OpenApiSchema schema =  ComplexPropertySegment.Property.Type.IsCollection() ?
+            new OpenApiSchema
+            {
+                Type = "array",
+                Items = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = ComplexPropertySegment.ComplexType.FullName()
+                    }
+                }
+            }
+        :
+            new OpenApiSchema
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = ComplexPropertySegment.ComplexType.FullName()
+                }
+            };
+
+        operation.RequestBody = new OpenApiRequestBody
+        {
+            Required = true,
+            Description = "New property values",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                {
+                    Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                    {
+                        Schema = schema
+                    }
+                }
+            }
+        };
+
+        base.SetRequestBody(operation);
+    }
+
+    /// <inheritdoc/>
+    protected override void SetResponses(OpenApiOperation operation)
+    {
+        operation.AddErrorResponses(Context.Settings, false);
+        base.SetResponses(operation);
+    }
+    protected override void SetSecurity(OpenApiOperation operation)
+    {
+        UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.UpdateRestrictions);
+        if (update == null || update.Permissions == null)
+        {
+            return;
+        }
+
+        operation.Security = Context.CreateSecurityRequirements(update.Permissions).ToList();
+    }
+
+    protected override void AppendCustomParameters(OpenApiOperation operation)
+    {
+        UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.UpdateRestrictions);
+        if (update == null)
+        {
+            return;
+        }
+
+        if (update.CustomHeaders != null)
+        {
+            AppendCustomParameters(operation, update.CustomHeaders, ParameterLocation.Header);
+        }
+
+        if (update.CustomQueryOptions != null)
+        {
+            AppendCustomParameters(operation, update.CustomQueryOptions, ParameterLocation.Query);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
@@ -80,7 +80,7 @@ internal abstract class ComplexPropertyUpdateOperationHandler : ComplexPropertyB
     /// <inheritdoc/>
     protected override void SetResponses(OpenApiOperation operation)
     {
-        operation.AddErrorResponses(Context.Settings, false);
+        operation.AddErrorResponses(Context.Settings, true);
         base.SetResponses(operation);
     }
     protected override void SetSecurity(OpenApiOperation operation)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPatchOperationHandler.cs
@@ -3,14 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.OData.Common;
-using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.Generator;
-using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -19,105 +12,9 @@ namespace Microsoft.OpenApi.OData.Operation
     /// The Path Item Object for the entity set contains the keyword patch with an Operation Object as value
     /// that describes the capabilities for updating the entity.
     /// </summary>
-    internal class EntityPatchOperationHandler : EntitySetOperationHandler
+    internal class EntityPatchOperationHandler : EntityUpdateOperationHandler
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Patch;
-
-        /// <inheritdoc/>
-        protected override void SetBasicInfo(OpenApiOperation operation)
-        {
-            // Summary
-            operation.Summary = "Update entity in " + EntitySet.Name;
-
-            IEdmEntityType entityType = EntitySet.EntityType();
-
-            // Description
-            operation.Description = Context.Model.GetDescriptionAnnotation(entityType);
-
-            // OperationId
-            if (Context.Settings.EnableOperationId)
-            {
-                string typeName = entityType.Name;
-                operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void SetRequestBody(OpenApiOperation operation)
-        {
-            OpenApiSchema schema = null;
-
-            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
-            {
-                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
-            }
-
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = EntitySet.EntityType().FullName()
-                    }
-                };
-            }
-
-            operation.RequestBody = new OpenApiRequestBody
-            {
-                Required = true,
-                Description = "New property values",
-                Content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                }
-            };
-
-            base.SetRequestBody(operation);
-        }
-
-        /// <inheritdoc/>
-        protected override void SetResponses(OpenApiOperation operation)
-        {
-            operation.AddErrorResponses(Context.Settings, true);
-            base.SetResponses(operation);
-        }
-
-        protected override void SetSecurity(OpenApiOperation operation)
-        {
-            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
-            if (update == null || update.Permissions == null)
-            {
-                return;
-            }
-
-            operation.Security = Context.CreateSecurityRequirements(update.Permissions).ToList();
-        }
-
-        protected override void AppendCustomParameters(OpenApiOperation operation)
-        {
-            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
-            if (update == null)
-            {
-                return;
-            }
-
-            if (update.CustomHeaders != null)
-            {
-                AppendCustomParameters(operation, update.CustomHeaders, ParameterLocation.Header);
-            }
-
-            if (update.CustomQueryOptions != null)
-            {
-                AppendCustomParameters(operation, update.CustomQueryOptions, ParameterLocation.Query);
-            }
-        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPutOperationHandler.cs
@@ -1,0 +1,128 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+
+namespace Microsoft.OpenApi.OData.Operation
+{
+    /// <summary>
+    /// Update an Entity
+    /// The Path Item Object for the entity set contains the keyword put with an Operation Object as value
+    /// that describes the capabilities for updating the entity.
+    /// </summary>
+    internal class EntityPutOperationHandler : EntitySetOperationHandler
+    {
+        /// <inheritdoc/>
+        public override OperationType OperationType => OperationType.Put;
+
+        /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            // Summary
+            operation.Summary = "Update entity in " + EntitySet.Name;
+
+            IEdmEntityType entityType = EntitySet.EntityType();
+
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(entityType);
+
+            // OperationId
+            if (Context.Settings.EnableOperationId)
+            {
+                string typeName = entityType.Name;
+                operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void SetRequestBody(OpenApiOperation operation)
+        {
+            OpenApiSchema schema = null;
+
+            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (schema == null)
+            {
+                schema = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = EntitySet.EntityType().FullName()
+                    }
+                };
+            }
+
+            operation.RequestBody = new OpenApiRequestBody
+            {
+                Required = true,
+                Description = "New property values",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                }
+            };
+
+            base.SetRequestBody(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetResponses(OpenApiOperation operation)
+        {
+            operation.Responses = new OpenApiResponses
+            {
+                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
+                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
+            };
+
+            base.SetResponses(operation);
+        }
+
+        protected override void SetSecurity(OpenApiOperation operation)
+        {
+            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+            if (update == null || update.Permissions == null)
+            {
+                return;
+            }
+
+            operation.Security = Context.CreateSecurityRequirements(update.Permissions).ToList();
+        }
+
+        protected override void AppendCustomParameters(OpenApiOperation operation)
+        {
+            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+            if (update == null)
+            {
+                return;
+            }
+
+            if (update.CustomHeaders != null)
+            {
+                AppendCustomParameters(operation, update.CustomHeaders, ParameterLocation.Header);
+            }
+
+            if (update.CustomQueryOptions != null)
+            {
+                AppendCustomParameters(operation, update.CustomQueryOptions, ParameterLocation.Query);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPutOperationHandler.cs
@@ -3,14 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.OData.Common;
-using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.Generator;
-using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -19,110 +12,9 @@ namespace Microsoft.OpenApi.OData.Operation
     /// The Path Item Object for the entity set contains the keyword put with an Operation Object as value
     /// that describes the capabilities for updating the entity.
     /// </summary>
-    internal class EntityPutOperationHandler : EntitySetOperationHandler
+    internal class EntityPutOperationHandler : EntityUpdateOperationHandler
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Put;
-
-        /// <inheritdoc/>
-        protected override void SetBasicInfo(OpenApiOperation operation)
-        {
-            // Summary
-            operation.Summary = "Update entity in " + EntitySet.Name;
-
-            IEdmEntityType entityType = EntitySet.EntityType();
-
-            // Description
-            operation.Description = Context.Model.GetDescriptionAnnotation(entityType);
-
-            // OperationId
-            if (Context.Settings.EnableOperationId)
-            {
-                string typeName = entityType.Name;
-                operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void SetRequestBody(OpenApiOperation operation)
-        {
-            OpenApiSchema schema = null;
-
-            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
-            {
-                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
-            }
-
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = EntitySet.EntityType().FullName()
-                    }
-                };
-            }
-
-            operation.RequestBody = new OpenApiRequestBody
-            {
-                Required = true,
-                Description = "New property values",
-                Content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                }
-            };
-
-            base.SetRequestBody(operation);
-        }
-
-        /// <inheritdoc/>
-        protected override void SetResponses(OpenApiOperation operation)
-        {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
-            base.SetResponses(operation);
-        }
-
-        protected override void SetSecurity(OpenApiOperation operation)
-        {
-            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
-            if (update == null || update.Permissions == null)
-            {
-                return;
-            }
-
-            operation.Security = Context.CreateSecurityRequirements(update.Permissions).ToList();
-        }
-
-        protected override void AppendCustomParameters(OpenApiOperation operation)
-        {
-            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
-            if (update == null)
-            {
-                return;
-            }
-
-            if (update.CustomHeaders != null)
-            {
-                AppendCustomParameters(operation, update.CustomHeaders, ParameterLocation.Header);
-            }
-
-            if (update.CustomQueryOptions != null)
-            {
-                AppendCustomParameters(operation, update.CustomQueryOptions, ParameterLocation.Query);
-            }
-        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -15,7 +15,7 @@ using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 namespace Microsoft.OpenApi.OData.Operation
 {
     /// <summary>
-    /// Base class for entity set update (patch or put) operation.
+    /// Base class for entity set update (patch or put) operations.
     /// </summary>
     internal abstract class EntityUpdateOperationHandler : EntitySetOperationHandler
     {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -1,0 +1,118 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+
+namespace Microsoft.OpenApi.OData.Operation
+{
+    /// <summary>
+    /// Base class for entity set update (patch or put) operation.
+    /// </summary>
+    internal abstract class EntityUpdateOperationHandler : EntitySetOperationHandler
+    {
+        /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            // Summary
+            operation.Summary = "Update entity in " + EntitySet.Name;
+
+            IEdmEntityType entityType = EntitySet.EntityType();
+
+            // Description
+            operation.Description = Context.Model.GetDescriptionAnnotation(entityType);
+
+            // OperationId
+            if (Context.Settings.EnableOperationId)
+            {
+                string typeName = entityType.Name;
+                operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void SetRequestBody(OpenApiOperation operation)
+        {
+            OpenApiSchema schema = null;
+
+            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (schema == null)
+            {
+                schema = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = EntitySet.EntityType().FullName()
+                    }
+                };
+            }
+
+            operation.RequestBody = new OpenApiRequestBody
+            {
+                Required = true,
+                Description = "New property values",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                }
+            };
+
+            base.SetRequestBody(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetResponses(OpenApiOperation operation)
+        {
+            operation.AddErrorResponses(Context.Settings, true);
+            base.SetResponses(operation);
+        }
+
+        protected override void SetSecurity(OpenApiOperation operation)
+        {
+            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+            if (update == null || update.Permissions == null)
+            {
+                return;
+            }
+
+            operation.Security = Context.CreateSecurityRequirements(update.Permissions).ToList();
+        }
+
+        protected override void AppendCustomParameters(OpenApiOperation operation)
+        {
+            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+            if (update == null)
+            {
+                return;
+            }
+
+            if (update.CustomHeaders != null)
+            {
+                AppendCustomParameters(operation, update.CustomHeaders, ParameterLocation.Header);
+            }
+
+            if (update.CustomQueryOptions != null)
+            {
+                AppendCustomParameters(operation, update.CustomQueryOptions, ParameterLocation.Query);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPutOperationHandler.cs
@@ -12,9 +12,9 @@ namespace Microsoft.OpenApi.OData.Operation
     /// The Path Item Object for the entity set contains the keyword patch with an Operation Object as value
     /// that describes the capabilities for updating the navigation property for a navigation source.
     /// </summary>
-    internal class NavigationPropertyPatchOperationHandler : NavigationPropertyUpdateOperationHandler
+    internal class NavigationPropertyPutOperationHandler : NavigationPropertyUpdateOperationHandler
     {
         /// <inheritdoc/>
-        public override OperationType OperationType => OperationType.Patch;
+        public override OperationType OperationType => OperationType.Put;
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -1,0 +1,113 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Generator;
+
+namespace Microsoft.OpenApi.OData.Operation
+{
+    /// <summary>
+    /// Update a navigation property for a navigation source.
+    /// The Path Item Object for the entity set contains the keyword patch / put with an Operation Object as value
+    /// that describes the capabilities for updating the navigation property for a navigation source.
+    /// </summary>
+    internal abstract class NavigationPropertyUpdateOperationHandler : NavigationPropertyOperationHandler
+    {
+        /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            // Summary
+            operation.Summary = "Update the navigation property " + NavigationProperty.Name + " in " + NavigationSource.Name;
+
+            // OperationId
+            if (Context.Settings.EnableOperationId)
+            {
+                string prefix = "Update";
+                operation.OperationId = GetOperationId(prefix);
+            }
+
+            base.SetBasicInfo(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetRequestBody(OpenApiOperation operation)
+        {
+            OpenApiSchema schema = null;
+
+            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(NavigationProperty.ToEntityType(), Context.Model);
+            }
+
+            if (schema == null)
+            {
+                schema = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = NavigationProperty.ToEntityType().FullName()
+                    }
+                };
+            }
+
+            operation.RequestBody = new OpenApiRequestBody
+            {
+                Required = true,
+                Description = "New navigation property values",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                }
+            };
+
+            base.SetRequestBody(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetResponses(OpenApiOperation operation)
+        {
+            operation.AddErrorResponses(Context.Settings, true);
+            base.SetResponses(operation);
+        }
+
+        protected override void SetSecurity(OpenApiOperation operation)
+        {
+            if (Restriction == null || Restriction.UpdateRestrictions == null)
+            {
+                return;
+            }
+
+            operation.Security = Context.CreateSecurityRequirements(Restriction.UpdateRestrictions.Permissions).ToList();
+        }
+
+        protected override void AppendCustomParameters(OpenApiOperation operation)
+        {
+            if (Restriction == null || Restriction.UpdateRestrictions == null)
+            {
+                return;
+            }
+
+            if (Restriction.UpdateRestrictions.CustomHeaders != null)
+            {
+                AppendCustomParameters(operation, Restriction.UpdateRestrictions.CustomHeaders, ParameterLocation.Header);
+            }
+
+            if (Restriction.UpdateRestrictions.CustomQueryOptions != null)
+            {
+                AppendCustomParameters(operation, Restriction.UpdateRestrictions.CustomQueryOptions, ParameterLocation.Query);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 {OperationType.Post, new EntitySetPostOperationHandler() }
             }},
 
-            // entity (Get/Patch/Delete)
+            // entity (Get/Patch/Put/Delete)
             {ODataPathKind.Entity, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new EntityGetOperationHandler() },

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 {OperationType.Get, new EntityGetOperationHandler() },
                 {OperationType.Patch, new EntityPatchOperationHandler() },
+                {OperationType.Put, new EntityPutOperationHandler() },
                 {OperationType.Delete, new EntityDeleteOperationHandler() }
             }},
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -54,11 +54,12 @@ namespace Microsoft.OpenApi.OData.Operation
                 {OperationType.Post, new EdmActionImportOperationHandler() }
             }},
 
-            // navigation property (Get/Patch/Post/Delete)
+            // navigation property (Get/Patch/Put/Post/Delete)
             {ODataPathKind.NavigationProperty, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new NavigationPropertyGetOperationHandler() },
                 {OperationType.Patch, new NavigationPropertyPatchOperationHandler() },
+                {OperationType.Put, new NavigationPropertyPutOperationHandler() },
                 {OperationType.Post, new NavigationPropertyPostOperationHandler() },
                 {OperationType.Delete, new NavigationPropertyDeleteOperationHandler() }
             }},

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -98,11 +98,12 @@ namespace Microsoft.OpenApi.OData.Operation
                 {OperationType.Get, new ODataTypeCastGetOperationHandler() },
             }},
 
-            // .../entity/propertyOfComplexType
+            // .../entity/propertyOfComplexType (Get/Patch/Put/Delete)
             {ODataPathKind.ComplexProperty, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new ComplexPropertyGetOperationHandler() },
                 {OperationType.Patch, new ComplexPropertyPatchOperationHandler() },
+                {OperationType.Put, new ComplexPropertyPutOperationHandler() },
                 {OperationType.Post, new ComplexPropertyPostOperationHandler() },
                 {OperationType.Delete, new ComplexPropertyDeleteOperationHandler() },
             }},

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
@@ -32,7 +32,14 @@ namespace Microsoft.OpenApi.OData.PathItem
             UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet);
             if (update == null || update.IsUpdatable)
             {
-                AddOperation(item, OperationType.Patch);
+                if (update != null && update.IsUpdateMethodPut)
+                {
+                    AddOperation(item, OperationType.Put);
+                }
+                else
+                {
+                    AddOperation(item, OperationType.Patch);
+                }
             }
 
             DeleteRestrictionsType delete = Context.Model.GetRecord<DeleteRestrictionsType>(EntitySet);

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -88,12 +88,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 {
                     if (LastSegmentIsKeySegment)
                     {
-                        // Need to check this scenario is valid or not?
-                        UpdateRestrictionsType update = restriction?.UpdateRestrictions;
-                        if (update == null || update.IsUpdatable)
-                        {
-                            AddOperation(item, OperationType.Patch);
-                        }
+                        AddUpdateOperation(item, restriction);
                     }
                     else
                     {
@@ -106,11 +101,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 }
                 else
                 {
-                    UpdateRestrictionsType update = restriction?.UpdateRestrictions;
-                    if (update == null || update.IsUpdatable)
-                    {
-                        AddOperation(item, OperationType.Patch);
-                    }
+                    AddUpdateOperation(item, restriction);
                 }
             }
 
@@ -182,6 +173,22 @@ namespace Microsoft.OpenApi.OData.PathItem
                 }
 
                 return;
+            }
+        }
+
+        private void AddUpdateOperation(OpenApiPathItem item, NavigationPropertyRestriction restriction)
+        {
+            UpdateRestrictionsType update = restriction?.UpdateRestrictions;
+            if (update == null || update.IsUpdatable)
+            {
+                if (update != null && update.IsUpdateMethodPut)
+                {
+                    AddOperation(item, OperationType.Put);
+                }
+                else
+                {
+                    AddOperation(item, OperationType.Patch);
+                }
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
@@ -12,6 +12,21 @@ using Microsoft.OpenApi.OData.Edm;
 namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
 {
     /// <summary>
+    /// Enumerates HTTP methods that can be used to update entities
+    /// </summary>
+    internal enum HttpMethod
+    {
+        /// <summary>
+        /// The HTTP PATCH Method
+        /// </summary>
+        PATCH,
+
+        /// <summary>
+        /// The HTTP PUT Method
+        /// </summary>
+        PUT
+    }
+    /// <summary>
     /// Complex Type: Org.OData.Capabilities.V1.UpdateRestrictionsType
     /// </summary>
     [Term("Org.OData.Capabilities.V1.UpdateRestrictions")]
@@ -32,6 +47,12 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// Gets the value indicating Entities can be inserted, updated, and deleted via a PATCH request with a delta payload.
         /// </summary>
         public bool? DeltaUpdateSupported { get; private set; }
+
+        /// <summary>
+        /// Gets the value indicating the HTTP Method (PUT or PATCH) for updating an entity. 
+        /// If null, PATCH should be supported and PUT MAY be supported.
+        /// </summary>
+        public HttpMethod? UpdateMethod { get; private set; }
 
         /// <summary>
         /// Gets the value indicating Members of collections can be updated via a PATCH request with a '/$filter(...)/$each' segment.
@@ -103,6 +124,11 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         }
 
         /// <summary>
+        /// Tests whether the update method for the entity has been explicitly specified as PUT
+        /// </summary>
+        public bool IsUpdateMethodPut => UpdateMethod.HasValue && UpdateMethod.Value == HttpMethod.PUT;
+
+        /// <summary>
         /// Init the <see cref="UpdateRestrictionsType"/>.
         /// </summary>
         /// <param name="record">The input record.</param>
@@ -118,6 +144,9 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
 
             // DeltaUpdateSupported
             DeltaUpdateSupported = record.GetBoolean("DeltaUpdateSupported");
+
+            // UpdateMethod
+            UpdateMethod = record.GetEnum<HttpMethod>("UpdateMethod");
 
             // FilterSegmentSupported
             FilterSegmentSupported = record.GetBoolean("FilterSegmentSupported");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPutOperationHandlerTests.cs
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests;
+
+public class ComplexPropertyPutOperationHandlerTests
+{
+	private readonly ComplexPropertyPutOperationHandler _operationHandler = new();
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyDeleteOperationReturnsCorrectOperationForSingle(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("BillingAddress");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var put = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(put);
+		Assert.Equal("Update property BillingAddress value.", put.Summary);
+
+		Assert.NotNull(put.Parameters);
+		Assert.Equal(1, put.Parameters.Count); //id
+
+		Assert.NotNull(put.Responses);
+		Assert.Equal(2, put.Responses.Count);
+		Assert.Equal(new[] { "204", "default" }, put.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("BillingAddress.Address.UpdateAddress", put.OperationId);
+		}
+		else
+		{
+			Assert.Null(put.OperationId);
+		}
+	}
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void CreateComplexPropertyPostOperationReturnsCorrectOperationForCollection(bool enableOperationId)
+	{
+		// Arrange
+		var model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		var entity = entitySet.EntityType();
+		var property = entity.FindProperty("AlternativeAddresses");
+		var settings = new OpenApiConvertSettings
+		{
+			EnableOperationId = enableOperationId
+		};
+		var context = new ODataContext(model, settings);
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+
+		// Act
+		var put = _operationHandler.CreateOperation(context, path);
+
+		// Assert
+		Assert.NotNull(put);
+		Assert.Equal("Update property AlternativeAddresses value.", put.Summary);
+
+		Assert.NotNull(put.Parameters);
+		Assert.Equal(1, put.Parameters.Count); //id
+
+		Assert.NotNull(put.Responses);
+		Assert.Equal(2, put.Responses.Count);
+		Assert.Equal(new[] { "204", "default" }, put.Responses.Select(r => r.Key));
+
+		if (enableOperationId)
+		{
+			Assert.Equal("AlternativeAddresses.Address.UpdateAddress", put.OperationId);
+		}
+		else
+		{
+			Assert.Null(put.OperationId);
+		}
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
@@ -1,0 +1,168 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Tests;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests
+{
+    public class EntityPutOperationHandlerTests
+    {
+        private EntityPutOperationHandler _operationHandler = new EntityPutOperationHandler();
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateEntityPutOperationReturnsCorrectOperation(bool enableOperationId)
+        {
+            // Arrange
+            IEdmModel model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Customers");
+            OpenApiConvertSettings settings = new OpenApiConvertSettings
+            {
+                EnableOperationId = enableOperationId
+            };
+            ODataContext context = new ODataContext(model, settings);
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()));
+
+            // Act
+            var putOperation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(putOperation);
+            Assert.Equal("Update entity in Customers", putOperation.Summary);
+            Assert.Equal("A business customer.", putOperation.Description);
+            Assert.NotNull(putOperation.Tags);
+            var tag = Assert.Single(putOperation.Tags);
+            Assert.Equal("Customers.Customer", tag.Name);
+
+            Assert.NotNull(putOperation.Parameters);
+            Assert.Equal(1, putOperation.Parameters.Count);
+
+            Assert.NotNull(putOperation.RequestBody);
+
+            Assert.NotNull(putOperation.Responses);
+            Assert.Equal(2, putOperation.Responses.Count);
+            Assert.Equal(new[] { "204", "default" }, putOperation.Responses.Select(r => r.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("Customers.Customer.UpdateCustomer", putOperation.OperationId);
+            }
+            else
+            {
+                Assert.Null(putOperation.OperationId);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateEntityPutReturnsSecurityForUpdateRestrictions(bool enableAnnotation)
+        {
+            string annotation = @"<Annotation Term=""Org.OData.Capabilities.V1.UpdateRestrictions"">
+  <Record>
+    <PropertyValue Property=""Permissions"">
+      <Collection>
+        <Record>
+          <PropertyValue Property=""SchemeName"" String=""Delegated (work or school account)"" />
+          <PropertyValue Property=""Scopes"">
+            <Collection>
+              <Record>
+                <PropertyValue Property=""Scope"" String=""User.ReadBasic.All"" />
+              </Record>
+              <Record>
+                <PropertyValue Property=""Scope"" String=""User.Read.All"" />
+              </Record>
+            </Collection>
+          </PropertyValue>
+        </Record>
+        <Record>
+          <PropertyValue Property=""SchemeName"" String=""Application"" />
+          <PropertyValue Property=""Scopes"">
+            <Collection>
+              <Record>
+                <PropertyValue Property=""Scope"" String=""User.Read.All"" />
+              </Record>
+              <Record>
+                <PropertyValue Property=""Scope"" String=""Directory.Read.All"" />
+              </Record>
+            </Collection>
+          </PropertyValue>
+        </Record>
+      </Collection>
+    </PropertyValue>
+    <PropertyValue Property=""CustomHeaders"">
+      <Collection>
+        <Record>
+          <PropertyValue Property=""Name"" String=""odata-debug"" />
+          <PropertyValue Property=""Description"" String=""Debug support for OData services"" />
+          <PropertyValue Property=""Required"" Bool=""false"" />
+          <PropertyValue Property=""ExampleValues"">
+            <Collection>
+              <Record>
+                <PropertyValue Property=""Value"" String=""html"" />
+                <PropertyValue Property=""Description"" String=""Service responds with self-contained..."" />
+              </Record>
+              <Record>
+                <PropertyValue Property=""Value"" String=""json"" />
+                <PropertyValue Property=""Description"" String=""Service responds with JSON document..."" />
+              </Record>
+            </Collection>
+          </PropertyValue>
+        </Record>
+      </Collection>
+    </PropertyValue>
+  </Record>
+</Annotation>";
+
+            // Arrange
+            IEdmModel model = EntitySetGetOperationHandlerTests.GetEdmModel(enableAnnotation ? annotation : "");
+            ODataContext context = new ODataContext(model);
+            IEdmEntitySet customers = model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(customers); // guard
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(customers), new ODataKeySegment(customers.EntityType()));
+
+            // Act
+            var putOperation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(putOperation);
+            Assert.NotNull(putOperation.Security);
+
+            if (enableAnnotation)
+            {
+                Assert.Equal(2, putOperation.Security.Count);
+
+                string json = putOperation.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+                Assert.Contains(@"
+  ""security"": [
+    {
+      ""Delegated (work or school account)"": [
+        ""User.ReadBasic.All"",
+        ""User.Read.All""
+      ]
+    },
+    {
+      ""Application"": [
+        ""User.Read.All"",
+        ""Directory.Read.All""
+      ]
+    }
+  ],".ChangeLineBreaks(), json);
+
+                Assert.Contains(putOperation.Parameters, p => p.Name == "odata-debug" && p.In == Models.ParameterLocation.Header);
+            }
+            else
+            {
+                Assert.Empty(putOperation.Security);
+            }
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
@@ -1,0 +1,214 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.PathItem.Tests;
+using Microsoft.OpenApi.OData.Tests;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests
+{
+    public class NavigationPropertyPutOperationHandlerTests
+    {
+        private NavigationPropertyPutOperationHandler _operationHandler = new NavigationPropertyPutOperationHandler();
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateNavigationPutOperationReturnsCorrectOperation(bool enableOperationId)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.TripServiceModel;
+            OpenApiConvertSettings settings = new OpenApiConvertSettings
+            {
+                EnableOperationId = enableOperationId
+            };
+            ODataContext context = new ODataContext(model, settings);
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
+
+            IEdmEntityType person = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Person");
+            IEdmNavigationProperty navProperty = person.DeclaredNavigationProperties().First(c => c.Name == "BestFriend");
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(people), new ODataKeySegment(people.EntityType()), new ODataNavigationPropertySegment(navProperty));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Update the navigation property BestFriend in People", operation.Summary);
+            Assert.Equal("The best friend.", operation.Description);
+            Assert.NotNull(operation.Tags);
+            var tag = Assert.Single(operation.Tags);
+            Assert.Equal("People.Person", tag.Name);
+
+            Assert.NotNull(operation.Parameters);
+            Assert.Equal(1, operation.Parameters.Count);
+
+            Assert.NotNull(operation.RequestBody);
+            Assert.Equal("New navigation property values", operation.RequestBody.Description);
+
+            Assert.Equal(2, operation.Responses.Count);
+            Assert.Equal(new string[] { "204", "default" }, operation.Responses.Select(e => e.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("People.UpdateBestFriend", operation.OperationId);
+            }
+            else
+            {
+                Assert.Null(operation.OperationId);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateNavigationPuthOperationReturnsSecurityForUpdateRestrictions(bool enableAnnotation)
+        {
+            string annotation = @"<Annotation Term=""Org.OData.Capabilities.V1.NavigationRestrictions"">
+  <Record>
+   <PropertyValue Property=""RestrictedProperties"" >
+      <Collection>
+        <Record>
+          <PropertyValue Property=""NavigationProperty"" NavigationPropertyPath=""Orders"" />
+          <PropertyValue Property=""UpdateRestrictions"" >
+            <Record>
+              <PropertyValue Property=""Permissions"">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property=""SchemeName"" String=""Delegated (work or school account)"" />
+                    <PropertyValue Property=""Scopes"">
+                      <Collection>
+                        <Record>
+                          <PropertyValue Property=""Scope"" String=""User.ReadBasic.All"" />
+                        </Record>
+                        <Record>
+                          <PropertyValue Property=""Scope"" String=""User.Read.All"" />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                  </Record>
+                  <Record>
+                    <PropertyValue Property=""SchemeName"" String=""Application"" />
+                    <PropertyValue Property=""Scopes"">
+                      <Collection>
+                        <Record>
+                          <PropertyValue Property=""Scope"" String=""User.Read.All"" />
+                        </Record>
+                        <Record>
+                          <PropertyValue Property=""Scope"" String=""Directory.Read.All"" />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+              <PropertyValue Property=""Description"" String=""A brief description of GET '/me' request."" />
+              <PropertyValue Property=""CustomHeaders"">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property=""Name"" String=""odata-debug"" />
+                    <PropertyValue Property=""Description"" String=""Debug support for OData services"" />
+                    <PropertyValue Property=""Required"" Bool=""false"" />
+                    <PropertyValue Property=""ExampleValues"">
+                      <Collection>
+                        <Record>
+                          <PropertyValue Property=""Value"" String=""html"" />
+                          <PropertyValue Property=""Description"" String=""Service responds with self-contained..."" />
+                        </Record>
+                        <Record>
+                          <PropertyValue Property=""Value"" String=""json"" />
+                          <PropertyValue Property=""Description"" String=""Service responds with JSON document..."" />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </PropertyValue>
+        </Record>
+      </Collection>
+    </PropertyValue>
+  </Record>
+</Annotation>";
+
+            // Arrange
+            IEdmModel edmModel = NavigationPropertyPathItemHandlerTest.GetEdmModel(enableAnnotation ? annotation : "");
+            Assert.NotNull(edmModel);
+            ODataContext context = new ODataContext(edmModel);
+            IEdmEntitySet entitySet = edmModel.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(entitySet); // guard
+            IEdmEntityType entityType = entitySet.EntityType();
+
+            IEdmNavigationProperty property = entityType.DeclaredNavigationProperties().FirstOrDefault(c => c.Name == "Orders");
+            Assert.NotNull(property);
+
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet),
+                new ODataKeySegment(entityType),
+                new ODataNavigationPropertySegment(property),
+                new ODataKeySegment(property.DeclaringEntityType()));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.NotNull(operation.Security);
+
+            if (enableAnnotation)
+            {
+                Assert.Equal(2, operation.Security.Count);
+
+                string json = operation.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+                Assert.Contains(@"
+  ""security"": [
+    {
+      ""Delegated (work or school account)"": [
+        ""User.ReadBasic.All"",
+        ""User.Read.All""
+      ]
+    },
+    {
+      ""Application"": [
+        ""User.Read.All"",
+        ""Directory.Read.All""
+      ]
+    }
+  ],".ChangeLineBreaks(), json);
+
+                // with custom header
+                Assert.Contains(@"
+    {
+      ""name"": ""odata-debug"",
+      ""in"": ""header"",
+      ""description"": ""Debug support for OData services"",
+      ""schema"": {
+        ""type"": ""string""
+      },
+      ""examples"": {
+        ""example-1"": {
+          ""description"": ""Service responds with self-contained..."",
+          ""value"": ""html""
+        },
+        ""example-2"": {
+          ""description"": ""Service responds with JSON document..."",
+          ""value"": ""json""
+        }
+      }
+    }".ChangeLineBreaks(), json);
+
+            }
+            else
+            {
+                Assert.Empty(operation.Security);
+            }
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -41,10 +41,10 @@ public class ComplexPropertyPathItemHandlerTests
 		Assert.True(pathItem.Operations.ContainsKey(OperationType.Delete));
 	}
 
-	[Fact]
-	public void SetsPutUpdateOperationWithUpdateMethodUpdateRestrictions()
+    [Fact]
+    public void SetsPutUpdateOperationWithUpdateMethodUpdateRestrictions()
     {
-		string annotation = $@"
+        string annotation = $@"
 <Annotation Term=""Org.OData.Capabilities.V1.UpdateRestrictions"">
   <Record>
     <PropertyValue Property=""UpdateMethod"">
@@ -52,24 +52,24 @@ public class ComplexPropertyPathItemHandlerTests
     </PropertyValue>
   </Record>
 </Annotation>";
-		string target = $@"""NS.Default/Customers/BillingAddress""";
+        string target = $@"""NS.Customer/BillingAddress""";
 
-		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation);
-		var context = new ODataContext(model);
-		var entitySet = model.EntityContainer.FindEntitySet("Customers");
-		Assert.NotNull(entitySet); // guard
-		var entityType = entitySet.EntityType();
-		var property = entityType.FindProperty("BillingAddress");
-		Assert.NotNull(property); // guard
-		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entityType), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
-		Assert.Equal(ODataPathKind.ComplexProperty, path.Kind); // guard
-		var pathItem = _pathItemHandler.CreatePathItem(context, path);
-		Assert.NotNull(pathItem);
-		Assert.Equal(3, pathItem.Operations.Count);
-		Assert.True(pathItem.Operations.ContainsKey(OperationType.Get));
-		Assert.True(pathItem.Operations.ContainsKey(OperationType.Patch));
-		Assert.True(pathItem.Operations.ContainsKey(OperationType.Delete));
-	}
+        var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation, target: target);
+        var context = new ODataContext(model);
+        var entitySet = model.EntityContainer.FindEntitySet("Customers");
+        Assert.NotNull(entitySet); // guard
+        var entityType = entitySet.EntityType();
+        var property = entityType.FindProperty("BillingAddress");
+        Assert.NotNull(property); // guard
+        var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entityType), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+        Assert.Equal(ODataPathKind.ComplexProperty, path.Kind); // guard
+        var pathItem = _pathItemHandler.CreatePathItem(context, path);
+        Assert.NotNull(pathItem);
+        Assert.Equal(3, pathItem.Operations.Count);
+        Assert.True(pathItem.Operations.ContainsKey(OperationType.Get));
+        Assert.True(pathItem.Operations.ContainsKey(OperationType.Put));
+        Assert.True(pathItem.Operations.ContainsKey(OperationType.Delete));
+    }
 
 	[Fact]
 	public void DoesntSetDeleteOnNonNullableProperties()

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -40,6 +40,37 @@ public class ComplexPropertyPathItemHandlerTests
 		Assert.True(pathItem.Operations.ContainsKey(OperationType.Patch));
 		Assert.True(pathItem.Operations.ContainsKey(OperationType.Delete));
 	}
+
+	[Fact]
+	public void SetsPutUpdateOperationWithUpdateMethodUpdateRestrictions()
+    {
+		string annotation = $@"
+<Annotation Term=""Org.OData.Capabilities.V1.UpdateRestrictions"">
+  <Record>
+    <PropertyValue Property=""UpdateMethod"">
+      <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+    </PropertyValue>
+  </Record>
+</Annotation>";
+		string target = $@"""NS.Default/Customers/BillingAddress""";
+
+		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation);
+		var context = new ODataContext(model);
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		Assert.NotNull(entitySet); // guard
+		var entityType = entitySet.EntityType();
+		var property = entityType.FindProperty("BillingAddress");
+		Assert.NotNull(property); // guard
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entityType), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+		Assert.Equal(ODataPathKind.ComplexProperty, path.Kind); // guard
+		var pathItem = _pathItemHandler.CreatePathItem(context, path);
+		Assert.NotNull(pathItem);
+		Assert.Equal(3, pathItem.Operations.Count);
+		Assert.True(pathItem.Operations.ContainsKey(OperationType.Get));
+		Assert.True(pathItem.Operations.ContainsKey(OperationType.Patch));
+		Assert.True(pathItem.Operations.ContainsKey(OperationType.Delete));
+	}
+
 	[Fact]
 	public void DoesntSetDeleteOnNonNullableProperties()
 	{

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
@@ -174,6 +174,25 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             VerifyPathItemOperations(annotation, expected);
         }
 
+        [Theory]
+        [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Patch, OperationType.Delete })]
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
+        public void CreateEntityPathItemWorksForUpdateMethodRestrictionsCapabilities(bool updateMethod, OperationType[] expected)
+        {
+            // Arrange
+            string annotation = updateMethod ? $@"
+<Annotation Term=""Org.OData.Capabilities.V1.UpdateRestrictions"">
+  <Record>
+    <PropertyValue Property=""UpdateMethod"">
+      <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+    </PropertyValue>
+  </Record>
+</Annotation>" : "";
+
+            // Assert
+            VerifyPathItemOperations(annotation, expected);
+        }
+
         private void VerifyPathItemOperations(string annotation, OperationType[] expected)
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             Assert.Equal(expected, pathItem.Operations.Select(e => e.Key));
         }
 
-        public static IEdmModel GetEdmModel(string annotation)
+        public static IEdmModel GetEdmModel(string annotation, string target = "\"NS.Default/Customers\"")
         {
             const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
@@ -173,13 +173,13 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
       <EntityContainer Name =""Default"">
          <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
       </EntityContainer>
-      <Annotations Target=""NS.Default/Customers"">
-        {0}
+      <Annotations Target={0}>
+        {1}
       </Annotations>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>";
-            string modelText = string.Format(template, annotation);
+            string modelText = string.Format(template, target, annotation);
 
             IEdmModel model;
             IEnumerable<EdmError> errors;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -91,7 +91,15 @@
         <Property Name="Name" Type="Edm.String" />
         <Property Name="IcaoCode" Type="Edm.String" Nullable="false" />
         <Property Name="IataCode" Type="Edm.String" />
-        <Property Name="Location" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation" />
+        <Property Name="Location" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation">
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="UpdateMethod">
+                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </Property>
       </EntityType>
       <ComplexType Name="Location">
         <Property Name="Address" Type="Edm.String" />
@@ -286,6 +294,13 @@
             <Collection>
               <PropertyPath>Name</PropertyPath>
             </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+            <Record>
+              <PropertyValue Property="UpdateMethod">
+                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+              </PropertyValue>
+            </Record>
           </Annotation>
         </EntitySet>
         <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -180,7 +180,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "Airlines.Airline"
         ],
@@ -573,7 +573,7 @@
           }
         }
       },
-      "patch": {
+      "put": {
         "summary": "Update property Location value.",
         "operationId": "Location.AirportLocation.UpdateAirportLocation",
         "consumes": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -118,7 +118,7 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - Airlines.Airline
       summary: Update entity in Airlines
@@ -384,7 +384,7 @@ paths:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation'
         default:
           $ref: '#/responses/error'
-    patch:
+    put:
       summary: Update property Location value.
       operationId: Location.AirportLocation.UpdateAirportLocation
       consumes:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -207,7 +207,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "Airlines.Airline"
         ],
@@ -648,7 +648,7 @@
           }
         }
       },
-      "patch": {
+      "put": {
         "summary": "Update property Location value.",
         "operationId": "Location.AirportLocation.UpdateAirportLocation",
         "parameters": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -136,7 +136,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - Airlines.Airline
       summary: Update entity in Airlines
@@ -433,7 +433,7 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation'
         default:
           $ref: '#/components/responses/error'
-    patch:
+    put:
       summary: Update property Location value.
       operationId: Location.AirportLocation.UpdateAirportLocation
       parameters:


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/106
Fixes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/607

This PR adds  support for PUT operations for **entity sets** , **navigation properties** and **complex types** based on the annotated Http method in the _UpdateMethod_ property of _Org.OData.Capabilities.V1.UpdateRestrictions_ annotation for a given target element.

See: https://github.com/oasis-tcs/odata-vocabularies/blob/053724df1ab5d19cc198f2a52cf8a85a2be08d79/vocabularies/Org.OData.Capabilities.V1.xml#L676-L677