### PR TITLE
adds the ability to define error responses on error codes instead of default

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -46,6 +46,16 @@ namespace Microsoft.OpenApi.OData.Common
         public static string StatusCodeDefault = "default";
 
         /// <summary>
+        /// Status code class: 4XX
+        /// </summary>
+        public static string StatusCodeClass4XX = "4XX";
+
+        /// <summary>
+        /// Status code class: 5XX
+        /// </summary>
+        public static string StatusCodeClass5XX = "5XX";
+
+        /// <summary>
         /// Edm model error extension key.
         /// </summary>
         public static string xMsEdmModelError = "x-ms-edm-error-";

--- a/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
@@ -20,7 +20,8 @@ public static class OpenApiOperationExtensions
     /// <param name="operation">The operation.</param>
     /// <param name="settings">The settings.</param>
     /// <param name="addNoContent">Whether to add a 204 no content response.</param>
-    public static void AddErrorResponses(this OpenApiOperation operation, OpenApiConvertSettings settings, bool addNoContent = false) {
+    public static void AddErrorResponses(this OpenApiOperation operation, OpenApiConvertSettings settings, bool addNoContent = false)
+    {
         if (operation == null) {
             throw Error.ArgumentNull(nameof(operation));
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Generator;
+
+namespace Microsoft.OpenApi.OData.Common;
+
+/// <summary>
+/// Extensions methods for the OpenApiOperation class.
+/// </summary>
+public static class OpenApiOperationExtensions
+{
+    /// <summary>
+    /// Adds a default response to the operation or 4XX/5XX responses for the errors depending on the settings.
+    /// Also adds a 204 no content response when requested.
+    /// </summary>
+    /// <param name="operation">The operation.</param>
+    /// <param name="settings">The settings.</param>
+    /// <param name="addNoContent">Whether to add a 204 no content response.</param>
+    public static void AddErrorResponses(this OpenApiOperation operation, OpenApiConvertSettings settings, bool addNoContent = false) {
+        if (operation == null) {
+            throw Error.ArgumentNull(nameof(operation));
+        }
+        if(settings == null) {
+            throw Error.ArgumentNull(nameof(settings));
+        }
+
+		if(operation.Responses == null)
+		{
+			operation.Responses = new();
+		}
+
+        if(addNoContent)
+		{
+			operation.Responses.Add(Constants.StatusCode204, Constants.StatusCode204.GetResponse());
+		}
+
+        if(settings.ErrorResponsesAsDefault)
+        {
+            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+        }
+        else
+        {
+			operation.Responses.Add(Constants.StatusCodeClass4XX, Constants.StatusCodeClass4XX.GetResponse());
+			operation.Responses.Add(Constants.StatusCodeClass5XX, Constants.StatusCodeClass5XX.GetResponse());
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
@@ -86,13 +86,13 @@ namespace Microsoft.OpenApi.OData.Generator
                 Properties = new Dictionary<string, OpenApiSchema>
                 {
                     {
-                        "code", new OpenApiSchema { Type = "string" }
+                        "code", new OpenApiSchema { Type = "string", Nullable = false }
                     },
                     {
-                        "message", new OpenApiSchema { Type = "string" }
+                        "message", new OpenApiSchema { Type = "string", Nullable = false, }
                     },
                     {
-                        "target", new OpenApiSchema { Type = "string" }
+                        "target", new OpenApiSchema { Type = "string", Nullable = true }
                     },
                     {
                         "details",
@@ -137,13 +137,13 @@ namespace Microsoft.OpenApi.OData.Generator
                 Properties = new Dictionary<string, OpenApiSchema>
                 {
                     {
-                        "code", new OpenApiSchema { Type = "string" }
+                        "code", new OpenApiSchema { Type = "string", Nullable = false, }
                     },
                     {
-                        "message", new OpenApiSchema { Type = "string" }
+                        "message", new OpenApiSchema { Type = "string", Nullable = false, }
                     },
                     {
-                        "target", new OpenApiSchema { Type = "string" }
+                        "target", new OpenApiSchema { Type = "string", Nullable = true, }
                     }
                 }
             };

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -32,6 +32,24 @@ namespace Microsoft.OpenApi.OData.Generator
                 },
 
                 { Constants.StatusCode204, new OpenApiResponse { Description = "Success"} },
+                { Constants.StatusCodeClass4XX, new OpenApiResponse
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Response,
+                            Id = "error"
+                        }
+                    }
+                },
+                { Constants.StatusCodeClass5XX, new OpenApiResponse
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Response,
+                            Id = "error"
+                        }
+                    }
+                }
            };
 
         /// <summary>
@@ -41,8 +59,7 @@ namespace Microsoft.OpenApi.OData.Generator
         /// <returns>The created <see cref="OpenApiResponse"/>.</returns>
         public static OpenApiResponse GetResponse(this string statusCode)
         {
-            OpenApiResponse response;
-            if (_responses.TryGetValue(statusCode, out response))
+            if (_responses.TryGetValue(statusCode, out OpenApiResponse response))
             {
                 return response;
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -50,6 +50,10 @@ namespace Microsoft.OpenApi.OData.Generator
                     case EdmSchemaElementKind.TypeDefinition: // Type definition
                         {
                             IEdmType reference = (IEdmType)element;
+                            if(reference is IEdmComplexType &&
+                                reference.FullTypeName().EndsWith(context.Settings.InnerErrorComplexTypeName, StringComparison.Ordinal))
+                                continue;
+                            
                             schemas.Add(reference.FullTypeName(), context.CreateSchemaTypeSchema(reference));
                         }
                         break;
@@ -340,7 +344,7 @@ namespace Microsoft.OpenApi.OData.Generator
             return context.CreateSchema(typeDefinition.UnderlyingType);
         }
 
-        private static OpenApiSchema CreateSchemaTypeSchema(this ODataContext context, IEdmType edmType)
+        internal static OpenApiSchema CreateSchemaTypeSchema(this ODataContext context, IEdmType edmType)
         {
             Debug.Assert(context != null);
             Debug.Assert(edmType != null);

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -215,6 +215,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool AddEnumDescriptionExtension { get; set; } = false;
 
+        /// <summary>
+        /// Gets/sets a value indicating whether the error responses should be described as a default response or as 4XX and 5XX error responses.
+        /// </summary>
+        public bool ErrorResponsesAsDefault { get; set; } = true;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -251,6 +256,7 @@ namespace Microsoft.OpenApi.OData
                 RequireDerivedTypesConstraintForODataTypeCastSegments = this.RequireDerivedTypesConstraintForODataTypeCastSegments,
                 EnableDeprecationInformation = this.EnableDeprecationInformation,
                 AddEnumDescriptionExtension = this.AddEnumDescriptionExtension,
+                ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -220,6 +220,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool ErrorResponsesAsDefault { get; set; } = true;
 
+        /// <summary>
+        /// Gets/Sets the name of the complex type to look for in the main namespace to use as the inner error type.
+        /// </summary>
+        public string InnerErrorComplexTypeName { get; set; } = "InnerError";
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -257,6 +262,7 @@ namespace Microsoft.OpenApi.OData
                 EnableDeprecationInformation = this.EnableDeprecationInformation,
                 AddEnumDescriptionExtension = this.AddEnumDescriptionExtension,
                 ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
+                InnerErrorComplexTypeName = this.InnerErrorComplexTypeName
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyDeleteOperationHandler.cs
@@ -55,12 +55,7 @@ internal class ComplexPropertyDeleteOperationHandler : ComplexPropertyBaseOperat
     /// <inheritdoc/>
     protected override void SetResponses(OpenApiOperation operation)
     {
-        operation.Responses = new OpenApiResponses
-        {
-            { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-            { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-        };
-
+        operation.AddErrorResponses(Context.Settings, true);
         base.SetResponses(operation);
     }
     protected override void SetSecurity(OpenApiOperation operation)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -131,7 +131,7 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
             SetCollectionResponse(operation);
         else
             SetSingleResponse(operation);
-        operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+        operation.AddErrorResponses(Context.Settings, false);
 
         base.SetResponses(operation);
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPatchOperationHandler.cs
@@ -83,12 +83,7 @@ internal class ComplexPropertyPatchOperationHandler : ComplexPropertyBaseOperati
     /// <inheritdoc/>
     protected override void SetResponses(OpenApiOperation operation)
     {
-        operation.Responses = new OpenApiResponses
-        {
-            { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-            { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-        };
-
+        operation.AddErrorResponses(Context.Settings, true);
         base.SetResponses(operation);
     }
     protected override void SetSecurity(OpenApiOperation operation)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
@@ -96,12 +96,7 @@ internal class ComplexPropertyPostOperationHandler : ComplexPropertyBaseOperatio
     /// <inheritdoc/>
     protected override void SetResponses(OpenApiOperation operation)
     {
-        operation.Responses = new OpenApiResponses
-        {
-            { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-            { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-        };
-
+        operation.AddErrorResponses(Context.Settings, true);
         base.SetResponses(operation);
     }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
             };
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
@@ -62,12 +62,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+            operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
             };
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityPatchOperationHandler.cs
@@ -86,12 +86,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+            operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
@@ -145,7 +145,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 }
             };
 
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 }
             };
 
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
             };
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -61,12 +61,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+            operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MetadataGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MetadataGetOperationHandler.cs
@@ -69,7 +69,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
             };
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
@@ -67,12 +67,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+            operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
@@ -138,7 +138,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 };
             }
 
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPatchOperationHandler.cs
@@ -81,12 +81,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+            operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
@@ -120,7 +120,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
             };
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ODataTypeCastGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ODataTypeCastGetOperationHandler.cs
@@ -176,7 +176,7 @@ internal class ODataTypeCastGetOperationHandler : OperationHandler
 		else
 			SetCollectionResponse(operation);
 
-		operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+		operation.AddErrorResponses(Context.Settings, false);
 
 		base.SetResponses(operation);
 	}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
@@ -81,12 +81,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+    		operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
@@ -122,7 +122,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 };
             }
 
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+    		operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -91,7 +91,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 }
             };
 
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+    		operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
@@ -65,12 +65,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+    		operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
@@ -111,7 +111,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 }
             };
 
-            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+    		operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonPatchOperationHandler.cs
@@ -83,12 +83,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            operation.Responses = new OpenApiResponses
-            {
-                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
-                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
-            };
-
+    		operation.AddErrorResponses(Context.Settings, true);
             base.SetResponses(operation);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -183,6 +183,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumDescriptionExtension.get -
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumDescriptionExtension.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ErrorResponsesAsDefault.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ErrorResponsesAsDefault.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.InnerErrorComplexTypeName.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.InnerErrorComplexTypeName.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -181,6 +181,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDeprecationInformation.get 
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDeprecationInformation.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumDescriptionExtension.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumDescriptionExtension.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.ErrorResponsesAsDefault.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.ErrorResponsesAsDefault.get -> bool
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
@@ -272,3 +274,5 @@ Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.RemovalDat
 Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Date.get -> System.DateTime?
 Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Date.set -> void
 Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiDeprecationExtension.Write(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.OpenApiSpecVersion specVersion) -> void
+Microsoft.OpenApi.OData.Common.OpenApiOperationExtensions
+static Microsoft.OpenApi.OData.Common.OpenApiOperationExtensions.AddErrorResponses(this Microsoft.OpenApi.Models.OpenApiOperation operation, Microsoft.OpenApi.OData.OpenApiConvertSettings settings, bool addNoContent = false) -> void

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/OpenApiOperationExtensionsTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/OpenApiOperationExtensionsTests.cs
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+using Xunit;
+using Microsoft.OpenApi.OData.Common;
+
+namespace Microsoft.OpenApi.OData.Tests;
+
+public class OpenApiOperationExtensionsTests
+{
+	[Theory]
+	[InlineData(true, true)]
+	[InlineData(false, true)]
+	[InlineData(true, false)]
+	[InlineData(false, false)]
+	public void AddsErrorResponses(bool addNoContent, bool errorAsDefault)
+	{
+		// Arrange
+		var settings = new OpenApiConvertSettings {
+			ErrorResponsesAsDefault = errorAsDefault,
+		};
+		var operation = new OpenApiOperation();
+
+		// Act
+		operation.AddErrorResponses(settings, addNoContent);
+
+		// Assert
+		Assert.NotNull(operation.Responses);
+		Assert.Equal((errorAsDefault ? 1 : 2) + (addNoContent ? 1 : 0), operation.Responses.Count);
+
+		if(addNoContent)
+		{
+			Assert.True(operation.Responses.ContainsKey("204"));
+		}
+		else
+		{
+			Assert.False(operation.Responses.ContainsKey("204"));
+		}
+		if(errorAsDefault)
+		{
+			Assert.True(operation.Responses.ContainsKey("default"));
+			Assert.False(operation.Responses.ContainsKey("4XX"));
+			Assert.False(operation.Responses.ContainsKey("5XX"));
+		}
+		else
+		{
+			Assert.False(operation.Responses.ContainsKey("default"));
+			Assert.True(operation.Responses.ContainsKey("4XX"));
+			Assert.True(operation.Responses.ContainsKey("5XX"));
+		}
+	}
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiErrorSchemaGeneraratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiErrorSchemaGeneraratorTests.cs
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Tests;
+public class OpenApiErrorSchemaGeneraratorTests
+{
+    [Fact]
+    public void AddsEmptyInnerErrorWhenNoComplexTypeIsProvided()
+    {
+        IEdmModel model = EdmModelHelper.ContractServiceModel;
+        OpenApiConvertSettings settings = new()
+        {
+			ErrorResponsesAsDefault = false,
+        };
+        ODataContext context = new(model, settings);
+
+        var schema = OpenApiErrorSchemaGenerator.CreateInnerErrorSchema(context);
+
+        Assert.Equal("object", schema.Type);
+        Assert.Empty(schema.Properties);
+    }
+    [Fact]
+    public void AddsInnerErrorPropertiesWhenComplexTypeIsProvided()
+    {
+        IEdmModel model = EdmModelHelper.TripServiceModel;
+        OpenApiConvertSettings settings = new()
+        {
+            ErrorResponsesAsDefault = false,
+        };
+        ODataContext context = new(model, settings);
+
+        var schema = OpenApiErrorSchemaGenerator.CreateInnerErrorSchema(context);
+
+        Assert.Equal("object", schema.Type);
+        Assert.NotEmpty(schema.Properties);
+        Assert.Contains("Date", schema.Properties.Keys);
+        Assert.Contains("RequestId", schema.Properties.Keys);
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -2274,8 +2274,7 @@
           }
         },
         "innererror": {
-          "description": "The structure of this object is service-specific",
-          "type": "object"
+          "$ref": "#/definitions/odata.error.innererror"
         }
       }
     },
@@ -2296,6 +2295,10 @@
           "type": "string"
         }
       }
+    },
+    "odata.error.innererror": {
+      "description": "The structure of this object is service-specific",
+      "type": "object"
     },
     "ODataCountResponse": {
       "format": "int32",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -1511,8 +1511,7 @@ definitions:
         items:
           $ref: '#/definitions/odata.error.detail'
       innererror:
-        description: The structure of this object is service-specific
-        type: object
+        $ref: '#/definitions/odata.error.innererror'
   odata.error.detail:
     required:
       - code
@@ -1525,6 +1524,9 @@ definitions:
         type: string
       target:
         type: string
+  odata.error.innererror:
+    description: The structure of this object is service-specific
+    type: object
   ODataCountResponse:
     format: int32
     type: integer

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -2522,8 +2522,7 @@
             }
           },
           "innererror": {
-            "type": "object",
-            "description": "The structure of this object is service-specific"
+            "$ref": "#/components/schemas/odata.error.innererror"
           }
         }
       },
@@ -2545,6 +2544,10 @@
             "nullable": true
           }
         }
+      },
+      "odata.error.innererror": {
+        "type": "object",
+        "description": "The structure of this object is service-specific"
       },
       "ODataCountResponse": {
         "type": "integer",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -2512,7 +2512,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "details": {
             "type": "array",
@@ -2540,7 +2541,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -1674,8 +1674,7 @@ components:
           items:
             $ref: '#/components/schemas/odata.error.detail'
         innererror:
-          type: object
-          description: The structure of this object is service-specific
+          $ref: '#/components/schemas/odata.error.innererror'
     odata.error.detail:
       required:
         - code
@@ -1689,6 +1688,9 @@ components:
         target:
           type: string
           nullable: true
+    odata.error.innererror:
+      type: object
+      description: The structure of this object is service-specific
     ODataCountResponse:
       type: integer
       format: int32

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -1668,6 +1668,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
         details:
           type: array
           items:
@@ -1687,6 +1688,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
     ODataCountResponse:
       type: integer
       format: int32

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -45,8 +45,7 @@
           }
         },
         "innererror": {
-          "description": "The structure of this object is service-specific",
-          "type": "object"
+          "$ref": "#/definitions/odata.error.innererror"
         }
       }
     },
@@ -67,6 +66,10 @@
           "type": "string"
         }
       }
+    },
+    "odata.error.innererror": {
+      "description": "The structure of this object is service-specific",
+      "type": "object"
     },
     "ODataCountResponse": {
       "format": "int32",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -32,8 +32,7 @@ definitions:
         items:
           $ref: '#/definitions/odata.error.detail'
       innererror:
-        description: The structure of this object is service-specific
-        type: object
+        $ref: '#/definitions/odata.error.innererror'
   odata.error.detail:
     required:
       - code
@@ -46,6 +45,9 @@ definitions:
         type: string
       target:
         type: string
+  odata.error.innererror:
+    description: The structure of this object is service-specific
+    type: object
   ODataCountResponse:
     format: int32
     type: integer

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -38,7 +38,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "details": {
             "type": "array",
@@ -66,7 +67,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -48,8 +48,7 @@
             }
           },
           "innererror": {
-            "type": "object",
-            "description": "The structure of this object is service-specific"
+            "$ref": "#/components/schemas/odata.error.innererror"
           }
         }
       },
@@ -71,6 +70,10 @@
             "nullable": true
           }
         }
+      },
+      "odata.error.innererror": {
+        "type": "object",
+        "description": "The structure of this object is service-specific"
       },
       "ODataCountResponse": {
         "type": "integer",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -33,8 +33,7 @@ components:
           items:
             $ref: '#/components/schemas/odata.error.detail'
         innererror:
-          type: object
-          description: The structure of this object is service-specific
+          $ref: '#/components/schemas/odata.error.innererror'
     odata.error.detail:
       required:
         - code
@@ -48,6 +47,9 @@ components:
         target:
           type: string
           nullable: true
+    odata.error.innererror:
+      type: object
+      description: The structure of this object is service-specific
     ODataCountResponse:
       type: integer
       format: int32

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -27,6 +27,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
         details:
           type: array
           items:
@@ -46,6 +47,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
     ODataCountResponse:
       type: integer
       format: int32

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -5849,8 +5849,7 @@
           }
         },
         "innererror": {
-          "description": "The structure of this object is service-specific",
-          "type": "object"
+          "$ref": "#/definitions/odata.error.innererror"
         }
       }
     },
@@ -5871,6 +5870,10 @@
           "type": "string"
         }
       }
+    },
+    "odata.error.innererror": {
+      "description": "The structure of this object is service-specific",
+      "type": "object"
     },
     "ODataCountResponse": {
       "format": "int32",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -4291,8 +4291,7 @@ definitions:
         items:
           $ref: '#/definitions/odata.error.detail'
       innererror:
-        description: The structure of this object is service-specific
-        type: object
+        $ref: '#/definitions/odata.error.innererror'
   odata.error.detail:
     required:
       - code
@@ -4305,6 +4304,9 @@ definitions:
         type: string
       target:
         type: string
+  odata.error.innererror:
+    description: The structure of this object is service-specific
+    type: object
   ODataCountResponse:
     format: int32
     type: integer

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -6579,8 +6579,7 @@
             }
           },
           "innererror": {
-            "type": "object",
-            "description": "The structure of this object is service-specific"
+            "$ref": "#/components/schemas/odata.error.innererror"
           }
         }
       },
@@ -6602,6 +6601,10 @@
             "nullable": true
           }
         }
+      },
+      "odata.error.innererror": {
+        "type": "object",
+        "description": "The structure of this object is service-specific"
       },
       "ODataCountResponse": {
         "type": "integer",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -6569,7 +6569,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "details": {
             "type": "array",
@@ -6597,7 +6598,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -4771,6 +4771,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
         details:
           type: array
           items:
@@ -4790,6 +4791,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
     ODataCountResponse:
       type: integer
       format: int32

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -4777,8 +4777,7 @@ components:
           items:
             $ref: '#/components/schemas/odata.error.detail'
         innererror:
-          type: object
-          description: The structure of this object is service-specific
+          $ref: '#/components/schemas/odata.error.innererror'
     odata.error.detail:
       required:
         - code
@@ -4792,6 +4791,9 @@ components:
         target:
           type: string
           nullable: true
+    odata.error.innererror:
+      type: object
+      description: The structure of this object is service-specific
     ODataCountResponse:
       type: integer
       format: int32

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -2,6 +2,10 @@
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
     <Schema Namespace="Microsoft.OData.Service.Sample.TrippinInMemory.Models" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <ComplexType Name="InnerError">
+        <Property Name="Date" Type="Edm.DateTimeOffset" />
+        <Property Name="RequestId" Type="Edm.String" />
+      </ComplexType>
       <EntityType Name="Person">
         <Key>
           <PropertyRef Name="UserName" />

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -28773,8 +28773,7 @@
           }
         },
         "innererror": {
-          "description": "The structure of this object is service-specific",
-          "type": "object"
+          "$ref": "#/definitions/odata.error.innererror"
         }
       }
     },
@@ -28792,6 +28791,20 @@
           "type": "string"
         },
         "target": {
+          "type": "string"
+        }
+      }
+    },
+    "odata.error.innererror": {
+      "title": "InnerError",
+      "type": "object",
+      "properties": {
+        "Date": {
+          "format": "date-time",
+          "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+          "type": "string"
+        },
+        "RequestId": {
           "type": "string"
         }
       }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -20376,8 +20376,7 @@ definitions:
         items:
           $ref: '#/definitions/odata.error.detail'
       innererror:
-        description: The structure of this object is service-specific
-        type: object
+        $ref: '#/definitions/odata.error.innererror'
   odata.error.detail:
     required:
       - code
@@ -20389,6 +20388,16 @@ definitions:
       message:
         type: string
       target:
+        type: string
+  odata.error.innererror:
+    title: InnerError
+    type: object
+    properties:
+      Date:
+        format: date-time
+        pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+        type: string
+      RequestId:
         type: string
   ODataCountResponse:
     format: int32

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -32243,8 +32243,7 @@
             }
           },
           "innererror": {
-            "type": "object",
-            "description": "The structure of this object is service-specific"
+            "$ref": "#/components/schemas/odata.error.innererror"
           }
         }
       },
@@ -32262,6 +32261,22 @@
             "type": "string"
           },
           "target": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "odata.error.innererror": {
+        "title": "InnerError",
+        "type": "object",
+        "properties": {
+          "Date": {
+            "pattern": "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "RequestId": {
             "type": "string",
             "nullable": true
           }
@@ -32616,6 +32631,12 @@
       }
     },
     "examples": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.InnerError": {
+        "value": {
+          "Date": "0001-01-01T00:00:00.0000000+00:00",
+          "RequestId": "String"
+        }
+      },
       "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person": {
         "value": {
           "AddressInfo": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -32233,7 +32233,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "details": {
             "type": "array",
@@ -32261,7 +32262,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -22460,8 +22460,7 @@ components:
           items:
             $ref: '#/components/schemas/odata.error.detail'
         innererror:
-          type: object
-          description: The structure of this object is service-specific
+          $ref: '#/components/schemas/odata.error.innererror'
     odata.error.detail:
       required:
         - code
@@ -22473,6 +22472,18 @@ components:
         message:
           type: string
         target:
+          type: string
+          nullable: true
+    odata.error.innererror:
+      title: InnerError
+      type: object
+      properties:
+        Date:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        RequestId:
           type: string
           nullable: true
     ODataCountResponse:
@@ -22702,6 +22713,10 @@ components:
       schema:
         type: string
   examples:
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.InnerError:
+      value:
+        Date: '0001-01-01T00:00:00.0000000+00:00'
+        RequestId: String
     Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person:
       value:
         AddressInfo:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -22454,6 +22454,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
         details:
           type: array
           items:
@@ -22473,6 +22474,7 @@ components:
           type: string
         target:
           type: string
+          nullable: true
     ODataCountResponse:
       type: integer
       format: int32


### PR DESCRIPTION
fixes #165

This PR adds a new setting `ErrorResponsesAsDefault` default `true` to avoid breaking existing users.

When true, the error responses will only be described as the following

```JSON
"responses": {
          "200": {
            "$ref": "#/components/responses/ODataCountResponse"
          },
          "default": {
            "$ref": "#/components/responses/error"
          }
        }
```

When false they'll be described as the following

```JSON
"responses": {
          "200": {
            "$ref": "#/components/responses/ODataCountResponse"
          },
          "4XX": {
            "$ref": "#/components/responses/error"
          },
          "5XX": {
            "$ref": "#/components/responses/error"
          }
        }
```

This change is made so client generators can "better understand" what the error payloads look like and generate more accurate SDKs.
