### PR TITLE
Adds mapping object to discriminator objects

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -426,6 +426,15 @@ namespace Microsoft.OpenApi.OData.Generator
                     AnyOf = null
                 };
 
+                schema.Properties.Add("@odata.type", new OpenApiSchema
+                {
+                    Type = "string",
+                    Enum = new List<IOpenApiAny>
+                    {
+                        new OpenApiString(structuredType.FullTypeName())
+                    }
+                });
+
                 // It optionally can contain the field description,
                 // whose value is the value of the unqualified annotation Core.Description of the structured type.
                 if (structuredType.TypeKind == EdmTypeKind.Complex)

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -109,11 +109,6 @@ namespace Microsoft.OpenApi.OData
         public bool EnableDiscriminatorValue { get; set; } = false;
 
         /// <summary>
-        /// Gets/sets a value indicating whether or not to allow OpenAPI V3.0 discriminator value support.
-        /// </summary>
-        public bool EnableV3DiscriminatorValue { get; set; } = false;
-
-        /// <summary>
         /// Gets/sets a value indicating whether or not to show the derived types of a base type reference in the responses payload.
         /// </summary>
         public bool EnableDerivedTypesReferencesForResponses { get; set; } = false;
@@ -235,7 +230,6 @@ namespace Microsoft.OpenApi.OData
                 EnablePagination = this.EnablePagination,
                 PageableOperationName = this.PageableOperationName,
                 EnableDiscriminatorValue = this.EnableDiscriminatorValue,
-                EnableV3DiscriminatorValue = this.EnableV3DiscriminatorValue,
                 EnableDerivedTypesReferencesForResponses = this.EnableDerivedTypesReferencesForResponses,
                 EnableDerivedTypesReferencesForRequestBody = this.EnableDerivedTypesReferencesForRequestBody,
                 RoutePathPrefixProvider = this.RoutePathPrefixProvider,

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -109,6 +109,11 @@ namespace Microsoft.OpenApi.OData
         public bool EnableDiscriminatorValue { get; set; } = false;
 
         /// <summary>
+        /// Gets/sets a value indicating whether or not to allow OpenAPI V3.0 discriminator value support.
+        /// </summary>
+        public bool EnableV3DiscriminatorValue { get; set; } = false;
+
+        /// <summary>
         /// Gets/sets a value indicating whether or not to show the derived types of a base type reference in the responses payload.
         /// </summary>
         public bool EnableDerivedTypesReferencesForResponses { get; set; } = false;
@@ -230,6 +235,7 @@ namespace Microsoft.OpenApi.OData
                 EnablePagination = this.EnablePagination,
                 PageableOperationName = this.PageableOperationName,
                 EnableDiscriminatorValue = this.EnableDiscriminatorValue,
+                EnableV3DiscriminatorValue = this.EnableV3DiscriminatorValue,
                 EnableDerivedTypesReferencesForResponses = this.EnableDerivedTypesReferencesForResponses,
                 EnableDerivedTypesReferencesForRequestBody = this.EnableDerivedTypesReferencesForRequestBody,
                 RoutePathPrefixProvider = this.RoutePathPrefixProvider,

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableV3DiscriminatorValue.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableV3DiscriminatorValue.set -> void
 static Microsoft.OpenApi.OData.Edm.EdmTypeExtensions.ShouldPathParameterBeQuoted(this Microsoft.OData.Edm.IEdmType edmType, Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> bool
 Microsoft.OpenApi.OData.Edm.IODataPathProvider
 Microsoft.OpenApi.OData.Edm.IODataPathProvider.CanFilter(Microsoft.OData.Edm.IEdmElement element) -> bool

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,8 +5,6 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
-Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableV3DiscriminatorValue.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableV3DiscriminatorValue.set -> void
 static Microsoft.OpenApi.OData.Edm.EdmTypeExtensions.ShouldPathParameterBeQuoted(this Microsoft.OData.Edm.IEdmType edmType, Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> bool
 Microsoft.OpenApi.OData.Edm.IODataPathProvider
 Microsoft.OpenApi.OData.Edm.IODataPathProvider.CanFilter(Microsoft.OData.Edm.IEdmElement element) -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/EdmOperationProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/EdmOperationProviderTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var operations = provider.FindOperations(entitySet.EntityType(), false);
 
             // Assert
-            Assert.Equal(15, operations.Count());
+            Assert.Equal(29, operations.Count());
 
             // Act
             entitySet = model.EntityContainer.FindEntitySet("directoryObjects");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(50085, paths.Count());
+            Assert.Equal(29188, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(50070, paths.Count());
+            Assert.Equal(29154, paths.Count());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -81,6 +81,52 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Fact]
+        public void CreateStructuredTypeSchemaWithDiscriminatorValueEnabledReturnsCorrectSchema()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model, new OpenApiConvertSettings
+            {
+                EnableDiscriminatorValue = true,
+            });
+
+            IEdmEntityType entity = model.SchemaElements.OfType<IEdmEntityType>().First(t => t.Name == "directoryObject");
+            Assert.NotNull(entity); // Guard
+
+            // Act
+            var schema = context.CreateStructuredTypeSchema(entity);
+            string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            Assert.NotNull(json);
+            Assert.Equal(@"{
+  ""allOf"": [
+    {
+      ""$ref"": ""#/components/schemas/microsoft.graph.entity""
+    },
+    {
+      ""title"": ""directoryObject"",
+      ""type"": ""object"",
+      ""properties"": {
+        ""deletedDateTime"": {
+          ""pattern"": ""^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$"",
+          ""type"": ""string"",
+          ""format"": ""date-time"",
+          ""nullable"": true
+        }
+      },
+      ""discriminator"": {
+        ""propertyName"": ""@odata.type"",
+        ""mapping"": {
+          ""directoryObject"": ""#microsoft.graph.directoryObject""
+        }
+      }
+    }
+  ]
+}".ChangeLineBreaks(), json);
+        }
+
+        [Fact]
         public void CreateComplexTypeWithoutBaseSchemaReturnCorrectSchema()
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/118

This PR proposes:
- Adding a `mapping` object to the existing `discriminator` object in the schemas of structured types which have derived types.
- Adding a test to validate the above.
- Update the `Graph.Beta.OData.xml` test file.
- Fixing breaking tests due to the update above.

**NB:** The `x-ms-discriminator-value` extension which is being added to structured types that are derived types has not been removed so as not to break any existing experience for clients.

The `discriminator` object is enabled from the setting: `EnableDiscriminatorValue`