### PR TITLE
Add support for declaring path parameters on path item object instead of operation object

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -226,6 +226,13 @@ namespace Microsoft.OpenApi.OData
         public string InnerErrorComplexTypeName { get; set; } = "InnerError";
 
         /// <summary>
+        /// Gets/Sets a value indicating whether path parameters should be declared on path item object.
+        /// If true, path parameters will be declared on the path item object, otherwise they 
+        /// will be declared on the operation object.
+        /// </summary>
+        public bool DeclarePathParametersOnPathItem { get; set; } = false;
+
+        /// <summary>
         /// Gets/Sets a value indicating whether or not to use restrictions annotations to generate paths for complex properties.
         /// </summary>
         public bool UseRestrictionAnnotationsToGeneratePathsForComplexProperties { get; set; } = true;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmFunctionImportOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmFunctionImportOperationHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 foreach (var param in Context.CreateParameters(functionImport.Function, OperationImportSegment.ParameterMappings))
                 {
-                    AppendParameter(operation, param);
+                    operation.Parameters.AppendParameter(param);
                 }
             }
             else
@@ -39,7 +39,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 // and it contains specific Parameter Objects for the allowed system query options.
                 foreach (var param in Context.CreateParameters(functionImport))
                 {
-                    AppendParameter(operation, param);
+                    operation.Parameters.AppendParameter(param);
                 }
             }
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -138,7 +138,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     IList<OpenApiParameter> parameters = Context.CreateParameters(function, OperationSegment.ParameterMappings);
                     foreach (var parameter in parameters)
                     {
-                        AppendParameter(operation, parameter);
+                        operation.Parameters.AppendParameter(parameter);
                     }
                 }
                 else
@@ -153,7 +153,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     {
                         foreach (var parameter in parameters)
                         {
-                            AppendParameter(operation, parameter);
+                            operation.Parameters.AppendParameter(parameter);
                         }
                     }
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.ShowLinks)
             {
                 links = Context.CreateLinks(entityType: EntitySet.EntityType(), entityName: EntitySet.Name,
-                        entityKind: EntitySet.ContainerElementKind.ToString(), parameters: operation.Parameters);
+                        entityKind: EntitySet.ContainerElementKind.ToString(), PathParameters);
             }
 
             if (schema == null)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     string operationId = GetOperationId();
 
                     links = Context.CreateLinks(entityType: NavigationProperty.ToEntityType(), entityName: NavigationProperty.Name,
-                            entityKind: NavigationProperty.PropertyKind.ToString(), parameters: operation.Parameters,
+                            entityKind: NavigationProperty.PropertyKind.ToString(), parameters: PathParameters,
                             navPropOperationId: operationId);
                 }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -49,7 +49,10 @@ namespace Microsoft.OpenApi.OData.Operation
                These need to be set before Responses, as the Parameters
                will be used in the Responses when creating Links.
             */
-            SetParameters(operation);
+            if (!Context.Settings.DeclarePathParametersOnPathItem)
+            {
+                SetParameters(operation);
+            }
 
             // Responses
             SetResponses(operation);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -25,6 +25,11 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected IDictionary<ODataSegment, IDictionary<string, string>> ParameterMappings;
 
+        /// <summary>
+        /// The path parameters in the path
+        /// </summary>
+        protected IList<OpenApiParameter> PathParameters;
+
         /// <inheritdoc/>
         public virtual OpenApiOperation CreateOperation(ODataContext context, ODataPath path)
         {
@@ -139,9 +144,10 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <param name="operation">The <see cref="OpenApiOperation"/>.</param>
         protected virtual void SetParameters(OpenApiOperation operation)
         {
+            PathParameters = Path.CreatePathParameters(Context);
             if (!Context.Settings.DeclarePathParametersOnPathItem)
             {
-                foreach(var parameter in Path.CreatePathParameters(Context))
+                foreach (var parameter in PathParameters)
                 {
                     operation.Parameters.AppendParameter(parameter);
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -49,10 +49,7 @@ namespace Microsoft.OpenApi.OData.Operation
                These need to be set before Responses, as the Parameters
                will be used in the Responses when creating Links.
             */
-            if (!Context.Settings.DeclarePathParametersOnPathItem)
-            {
-                SetParameters(operation);
-            }
+            SetParameters(operation);
 
             // Responses
             SetResponses(operation);
@@ -142,12 +139,15 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <param name="operation">The <see cref="OpenApiOperation"/>.</param>
         protected virtual void SetParameters(OpenApiOperation operation)
         {
-            foreach (ODataKeySegment keySegment in Path.OfType<ODataKeySegment>())
+            if (!Context.Settings.DeclarePathParametersOnPathItem)
             {
-                IDictionary<string, string> mapping = ParameterMappings[keySegment];
-                foreach (var p in Context.CreateKeyParameters(keySegment, mapping))
+                foreach (ODataKeySegment keySegment in Path.OfType<ODataKeySegment>())
                 {
-                    AppendParameter(operation, p);
+                    IDictionary<string, string> mapping = ParameterMappings[keySegment];
+                    foreach (var p in Context.CreateKeyParameters(keySegment, mapping))
+                    {
+                        AppendParameter(operation, p);
+                    }
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -141,26 +141,13 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             if (!Context.Settings.DeclarePathParametersOnPathItem)
             {
-                foreach (ODataKeySegment keySegment in Path.OfType<ODataKeySegment>())
+                foreach(var parameter in Path.CreatePathParameters(Context))
                 {
-                    IDictionary<string, string> mapping = ParameterMappings[keySegment];
-                    foreach (var p in Context.CreateKeyParameters(keySegment, mapping))
-                    {
-                        AppendParameter(operation, p);
-                    }
+                    operation.Parameters.AppendParameter(parameter);
                 }
             }
 
             AppendCustomParameters(operation);
-
-            // Add the route prefix parameter v1{data}
-            if (Context.Settings.RoutePathPrefixProvider != null && Context.Settings.RoutePathPrefixProvider.Parameters != null)
-            {
-                foreach (var parameter in Context.Settings.RoutePathPrefixProvider.Parameters)
-                {
-                    operation.Parameters.Add(parameter);
-                }
-            }
         }
 
         /// <summary>
@@ -250,32 +237,8 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
 
-                AppendParameter(operation, parameter);
+                operation.Parameters.AppendParameter(parameter);
             }
-        }
-
-        protected static void AppendParameter(OpenApiOperation operation, OpenApiParameter parameter)
-        {
-            HashSet<string> set = new HashSet<string>(operation.Parameters.Select(p => p.Name));
-
-            if (!set.Contains(parameter.Name))
-            {
-                operation.Parameters.Add(parameter);
-                return;
-            }
-
-            int index = 1;
-            string originalName = parameter.Name;
-            string newName;
-            do
-            {
-                newName = originalName + index.ToString();
-                index++;
-            }
-            while (set.Contains(newName));
-
-            parameter.Name = newName;
-            operation.Parameters.Add(parameter);
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
@@ -96,7 +96,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     string operationId = GetOperationId();
 
                     links = Context.CreateLinks(entityType: NavigationProperty.ToEntityType(), entityName: NavigationProperty.Name,
-                            entityKind: NavigationProperty.PropertyKind.ToString(), parameters: operation.Parameters,
+                            entityKind: NavigationProperty.PropertyKind.ToString(), parameters: PathParameters,
                             navPropOperationId: operationId);
                 }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.ShowLinks)
             {
                 links = Context.CreateLinks(entityType: Singleton.EntityType(), entityName: Singleton.Name,
-                        entityKind: Singleton.ContainerElementKind.ToString(), parameters: operation.Parameters);
+                        entityKind: Singleton.ContainerElementKind.ToString(), parameters: PathParameters);
             }
 
             if (schema == null)

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
@@ -130,7 +130,7 @@ namespace Microsoft.OpenApi.OData.PathItem
             }
 
             // Add the route prefix parameter v1{data}
-            if (Context.Settings.RoutePathPrefixProvider != null && Context.Settings.RoutePathPrefixProvider.Parameters != null)
+            if (Context.Settings.RoutePathPrefixProvider?.Parameters != null)
             {
                 foreach (var parameter in Context.Settings.RoutePathPrefixProvider.Parameters)
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -120,47 +119,10 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// <param name="item">The <see cref="OpenApiPathItem"/>.</param>
         protected virtual void SetParameters(OpenApiPathItem item)
         {
-            foreach (ODataKeySegment keySegment in Path.OfType<ODataKeySegment>())
+            foreach (var parameter in Path.CreatePathParameters(Context))
             {
-                IDictionary<string, string> mapping = ParameterMappings[keySegment];
-                foreach (var parameter in Context.CreateKeyParameters(keySegment, mapping))
-                {
-                    AppendParameter(item, parameter);
-                }
+                item.Parameters.AppendParameter(parameter);
             }
-
-            // Add the route prefix parameter v1{data}
-            if (Context.Settings.RoutePathPrefixProvider?.Parameters != null)
-            {
-                foreach (var parameter in Context.Settings.RoutePathPrefixProvider.Parameters)
-                {
-                    item.Parameters.Add(parameter);
-                }
-            }
-        }
-
-        protected static void AppendParameter(OpenApiPathItem item, OpenApiParameter parameter)
-        {
-            HashSet<string> set = new HashSet<string>(item.Parameters.Select(p => p.Name));
-
-            if (!set.Contains(parameter.Name))
-            {
-                item.Parameters.Add(parameter);
-                return;
-            }
-
-            int index = 1;
-            string originalName = parameter.Name;
-            string newName;
-            do
-            {
-                newName = originalName + index.ToString();
-                index++;
-            }
-            while (set.Contains(newName));
-
-            parameter.Name = newName;
-            item.Parameters.Add(parameter);
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -34,16 +33,12 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// </summary>
         protected ODataPath Path { get; private set; }
 
-        protected IDictionary<ODataSegment, IDictionary<string, string>> ParameterMappings;
-
         /// <inheritdoc/>
         public virtual OpenApiPathItem CreatePathItem(ODataContext context, ODataPath path)
         {
             Context = context ?? throw Error.ArgumentNull(nameof(context));
 
             Path = path ?? throw Error.ArgumentNull(nameof(path));
-
-            ParameterMappings = path.CalculateParameterMapping(context.Settings);
 
             Initialize(context, path);
 

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -187,6 +187,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.ErrorResponsesAsDefault.set -> vo
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ErrorResponsesAsDefault.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.InnerErrorComplexTypeName.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.InnerErrorComplexTypeName.get -> string
+Microsoft.OpenApi.OData.OpenApiConvertSettings.DeclarePathParametersOnPathItem.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.DeclarePathParametersOnPathItem.set -> void
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.Identifier.get -> string
 override Microsoft.OpenApi.OData.Edm.ODataDollarCountSegment.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
@@ -76,6 +76,45 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
                 pathItem.Operations.Select(o => o.Key));
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateEntityPathItemReturnsCorrectPathItemWithPathParameters(bool declarePathParametersOnPathItem)
+        {
+            // Arrange
+            IEdmModel model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: "");
+            OpenApiConvertSettings convertSettings = new OpenApiConvertSettings
+            {
+                DeclarePathParametersOnPathItem = declarePathParametersOnPathItem,
+            };
+            ODataContext context = new ODataContext(model, convertSettings);
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(entitySet); // guard
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()));
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+
+            Assert.NotNull(pathItem.Operations);
+            Assert.NotEmpty(pathItem.Operations);
+            Assert.Equal(3, pathItem.Operations.Count);
+            Assert.Equal(new OperationType[] { OperationType.Get, OperationType.Patch, OperationType.Delete },
+                pathItem.Operations.Select(o => o.Key));
+
+            if (declarePathParametersOnPathItem)
+            {
+                Assert.NotEmpty(pathItem.Parameters);
+                Assert.Equal(1, pathItem.Parameters.Count);
+            }
+            else
+            {
+                Assert.Empty(pathItem.Parameters);
+            }
+        }
+
         [Fact]
         public void CreateEntityPathItemReturnsCorrectPathItemWithReferences()
         {


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/159

This PR add support for declaring path parameters on the [path item](https://spec.openapis.org/oas/latest.html#path-item-object) object instead of the [operation ](https://spec.openapis.org/oas/latest.html#operation-object) object. This feature is controlled by a new flag (`DeclarePathParametersOnPathItem`) on `OpenApiConvertSettings`

Example usage:
---
```cs
    OpenApiConvertSettings settings = new()
    {
        DeclarePathParametersOnPathItem = true,
    };
    ODataContext context = new ODataContext(model, settings);
```

Example output
---
```diff
  '/Airports/{IcaoCode}':
    description: Provides operations to manage the collection of Airport entities.
    get:
      tags:
        - Airports.Airport
      summary: Get entity from Airports by key
      operationId: Airports.Airport.GetAirport
      parameters:
-       - name: IcaoCode
-         in: path
-         description: 'key: IcaoCode of Airport'
-         required: true
-         schema:
-           type: string
-         x-ms-docs-key-type: Airport
        - name: $select
          in: query
          description: Select properties to be returned
          style: form
          explode: false
          schema:
            uniqueItems: true
            type: array
            items:
              enum:
                - Name
                - IcaoCode
                - IataCode
                - Location
              type: string
        - name: $expand
          in: query
          description: Expand related entities
          style: form
          explode: false
          schema:
            uniqueItems: true
            type: array
            items:
              enum:
                - '*'
              type: string
      responses:
        '200':
          description: Retrieved entity
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
        default:
          $ref: '#/components/responses/error'
      x-ms-docs-operation-type: operation
    patch:
      tags:
        - Airports.Airport
      summary: Update entity in Airports
      operationId: Airports.Airport.UpdateAirport
      parameters:
-       - name: IcaoCode
-         in: path
-         description: 'key: IcaoCode of Airport'
-         required: true
-         schema:
-           type: string
-         x-ms-docs-key-type: Airport
      requestBody:
        description: New property values
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport'
        required: true
      responses:
        '204':
          description: Success
        default:
          $ref: '#/components/responses/error'
      x-ms-docs-operation-type: operation
    delete:
      tags:
        - Airports.Airport
      summary: Delete entity from Airports
      operationId: Airports.Airport.DeleteAirport
      parameters:
-       - name: IcaoCode
-         in: path
-         description: 'key: IcaoCode of Airport'
-         required: true
-         schema:
-           type: string
-         x-ms-docs-key-type: Airport
        - name: If-Match
          in: header
          description: ETag
          schema:
            type: string
      responses:
        '204':
          description: Success
        default:
          $ref: '#/components/responses/error'
      x-ms-docs-operation-type: operation
+   parameters:
+   - name: IcaoCode
+      in: path
+      description: 'key: IcaoCode of Airport'
+      required: true
+      schema:
+        type: string
+      x-ms-docs-key-type: Airport
```
