### PR TITLE
errors naming conventions improvements

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
@@ -17,6 +17,11 @@ namespace Microsoft.OpenApi.OData.Generator
     /// </summary>
     internal static class OpenApiErrorSchemaGenerator
     {
+        internal const string ODataErrorClassName = "ODataError";
+        internal const string MainErrorClassName = "MainError";
+        internal const string ErrorDetailsClassName = "ErrorDetails";
+        internal const string InnerErrorClassName = "InnerError";
+
         /// <summary>
         /// Create the dictionary of <see cref="OpenApiSchema"/> object.
         /// The name of each pair is the namespace-qualified name of the type. It uses the namespace instead of the alias.
@@ -31,16 +36,12 @@ namespace Microsoft.OpenApi.OData.Generator
 
             return new Dictionary<string, OpenApiSchema>()
             {
-                { $"{rootNamespaceName}{OdataErrorClassName}", CreateErrorSchema(rootNamespaceName) },
+                { $"{rootNamespaceName}{ODataErrorClassName}", CreateErrorSchema(rootNamespaceName) },
                 { $"{rootNamespaceName}{MainErrorClassName}", CreateErrorMainSchema(rootNamespaceName) },
                 { $"{rootNamespaceName}{ErrorDetailsClassName}", CreateErrorDetailSchema() },
                 { $"{rootNamespaceName}{InnerErrorClassName}", CreateInnerErrorSchema(context) }
             };
         }
-        internal const string OdataErrorClassName = "ODataError";
-        internal const string MainErrorClassName = "MainError";
-        internal const string ErrorDetailsClassName = "ErrorDetails";
-        internal const string InnerErrorClassName = "InnerError";
 
         /// <summary>
         /// Gets the error namespace name based on the root namespace of the model.

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
@@ -27,28 +27,36 @@ namespace Microsoft.OpenApi.OData.Generator
         public static IDictionary<string, OpenApiSchema> CreateODataErrorSchemas(this ODataContext context)
         {
             Utils.CheckArgumentNull(context, nameof(context));
+            var rootNamespaceName = context.GetErrorNamespaceName();
 
             return new Dictionary<string, OpenApiSchema>()
             {
-                // odata.error
-                { "odata.error", CreateErrorSchema() },
-
-                // odata.error.main
-                { "odata.error.main", CreateErrorMainSchema() },
-
-                // odata.error.detail
-                { "odata.error.detail", CreateErrorDetailSchema() },
-
-                // odata.error.innererror
-                { "odata.error.innererror", CreateInnerErrorSchema(context) }
+                { $"{rootNamespaceName}odataerror", CreateErrorSchema(rootNamespaceName) },
+                { $"{rootNamespaceName}mainerror", CreateErrorMainSchema(rootNamespaceName) },
+                { $"{rootNamespaceName}errordetails", CreateErrorDetailSchema() },
+                { $"{rootNamespaceName}innererror", CreateInnerErrorSchema(context) }
             };
         }
 
         /// <summary>
-        /// Create <see cref="OpenApiSchema"/> for "odata.error".
+        /// Gets the error namespace name based on the root namespace of the model.
+        /// </summary>
+        /// <param name="context">The OData to Open API context.</param>
+        /// <returns>The error namespace name.</returns>
+        public static string GetErrorNamespaceName(this ODataContext context) {
+            Utils.CheckArgumentNull(context, nameof(context));
+            var rootNamespaceName = context.Model.DeclaredNamespaces.OrderBy(ns => ns.Count(y => y == '.')).FirstOrDefault();
+            rootNamespaceName += (string.IsNullOrEmpty(rootNamespaceName) ? string.Empty : ".") +
+                                "odataerrors.";
+            return rootNamespaceName;
+        }
+
+        /// <summary>
+        /// Create <see cref="OpenApiSchema"/> for the error.
         /// </summary>
         /// <returns>The created <see cref="OpenApiSchema"/>.</returns>
-        public static OpenApiSchema CreateErrorSchema()
+        /// <param name="rootNamespaceName">The root namespace name. With a trailing dot.</param>
+        public static OpenApiSchema CreateErrorSchema(string rootNamespaceName)
         {
             return new OpenApiSchema
             {
@@ -66,7 +74,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,
-                                Id = "odata.error.main"
+                                Id = $"{rootNamespaceName}mainerror"
                             }
                         }
                     }
@@ -100,10 +108,11 @@ namespace Microsoft.OpenApi.OData.Generator
         }
 
         /// <summary>
-        /// Create <see cref="OpenApiSchema"/> for "odata.error.main".
+        /// Create <see cref="OpenApiSchema"/> for main property of the error.
         /// </summary>
+        /// <param name="rootNamespaceName">The root namespace name. With a trailing dot.</param>
         /// <returns>The created <see cref="OpenApiSchema"/>.</returns>
-        public static OpenApiSchema CreateErrorMainSchema()
+        public static OpenApiSchema CreateErrorMainSchema(string rootNamespaceName)
         {
             return new OpenApiSchema
             {
@@ -133,7 +142,7 @@ namespace Microsoft.OpenApi.OData.Generator
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,
-                                    Id = "odata.error.detail"
+                                    Id = $"{rootNamespaceName}errordetails"
                                 }
                             }
                         }
@@ -145,7 +154,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,
-                                Id = "odata.error.innererror"
+                                Id = $"{rootNamespaceName}innererror"
                             }
                         }
                     }
@@ -154,7 +163,7 @@ namespace Microsoft.OpenApi.OData.Generator
         }
 
         /// <summary>
-        /// Create <see cref="OpenApiSchema"/> for "odata.error.detail".
+        /// Create <see cref="OpenApiSchema"/> for detail property of the error.
         /// </summary>
         /// <returns>The created <see cref="OpenApiSchema"/>.</returns>
         public static OpenApiSchema CreateErrorDetailSchema()

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
@@ -31,12 +31,16 @@ namespace Microsoft.OpenApi.OData.Generator
 
             return new Dictionary<string, OpenApiSchema>()
             {
-                { $"{rootNamespaceName}odataerror", CreateErrorSchema(rootNamespaceName) },
-                { $"{rootNamespaceName}mainerror", CreateErrorMainSchema(rootNamespaceName) },
-                { $"{rootNamespaceName}errordetails", CreateErrorDetailSchema() },
-                { $"{rootNamespaceName}innererror", CreateInnerErrorSchema(context) }
+                { $"{rootNamespaceName}{OdataErrorClassName}", CreateErrorSchema(rootNamespaceName) },
+                { $"{rootNamespaceName}{MainErrorClassName}", CreateErrorMainSchema(rootNamespaceName) },
+                { $"{rootNamespaceName}{ErrorDetailsClassName}", CreateErrorDetailSchema() },
+                { $"{rootNamespaceName}{InnerErrorClassName}", CreateInnerErrorSchema(context) }
             };
         }
+        internal const string OdataErrorClassName = "ODataError";
+        internal const string MainErrorClassName = "MainError";
+        internal const string ErrorDetailsClassName = "ErrorDetails";
+        internal const string InnerErrorClassName = "InnerError";
 
         /// <summary>
         /// Gets the error namespace name based on the root namespace of the model.
@@ -47,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Generator
             Utils.CheckArgumentNull(context, nameof(context));
             var rootNamespaceName = context.Model.DeclaredNamespaces.OrderBy(ns => ns.Count(y => y == '.')).FirstOrDefault();
             rootNamespaceName += (string.IsNullOrEmpty(rootNamespaceName) ? string.Empty : ".") +
-                                "odataerrors.";
+                                "ODataErrors.";
             return rootNamespaceName;
         }
 
@@ -74,7 +78,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,
-                                Id = $"{rootNamespaceName}mainerror"
+                                Id = $"{rootNamespaceName}{MainErrorClassName}"
                             }
                         }
                     }
@@ -142,7 +146,7 @@ namespace Microsoft.OpenApi.OData.Generator
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,
-                                    Id = $"{rootNamespaceName}errordetails"
+                                    Id = $"{rootNamespaceName}{ErrorDetailsClassName}"
                                 }
                             }
                         }
@@ -154,7 +158,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,
-                                Id = $"{rootNamespaceName}innererror"
+                                Id = $"{rootNamespaceName}{InnerErrorClassName}"
                             }
                         }
                     }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -276,7 +276,7 @@ namespace Microsoft.OpenApi.OData.Generator
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,
-                                    Id = $"{errorNamespaceName}{OpenApiErrorSchemaGenerator.OdataErrorClassName}"
+                                    Id = $"{errorNamespaceName}{OpenApiErrorSchemaGenerator.ODataErrorClassName}"
                                 }
                             }
                         }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OpenApi.OData.Generator
 
             var responses =  new Dictionary<string, OpenApiResponse>
             {
-                { "error", CreateErrorResponse() }
+                { "error", context.CreateErrorResponse() }
             };
 
             if(context.Settings.EnableDollarCountPath)
@@ -259,8 +259,9 @@ namespace Microsoft.OpenApi.OData.Generator
             };
         }
 
-        private static OpenApiResponse CreateErrorResponse()
+        private static OpenApiResponse CreateErrorResponse(this ODataContext context)
         {
+            var errorNamespaceName = context.GetErrorNamespaceName();
             return new OpenApiResponse
             {
                 Description = "error",
@@ -275,7 +276,7 @@ namespace Microsoft.OpenApi.OData.Generator
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,
-                                    Id = "odata.error"
+                                    Id = $"{errorNamespaceName}odataerror"
                                 }
                             }
                         }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -276,7 +276,7 @@ namespace Microsoft.OpenApi.OData.Generator
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,
-                                    Id = $"{errorNamespaceName}odataerror"
+                                    Id = $"{errorNamespaceName}{OpenApiErrorSchemaGenerator.OdataErrorClassName}"
                                 }
                             }
                         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
   ""content"": {
     ""application/json"": {
       ""schema"": {
-        ""$ref"": ""#/components/schemas/odata.error""
+        ""$ref"": ""#/components/schemas/odataerrors.odataerror""
       }
     }
   }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
   ""content"": {
     ""application/json"": {
       ""schema"": {
-        ""$ref"": ""#/components/schemas/odataerrors.odataerror""
+        ""$ref"": ""#/components/schemas/ODataErrors.ODataError""
       }
     }
   }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -2240,18 +2240,18 @@
         }
       }
     },
-    "DefaultNs.odataerrors.odataerror": {
+    "DefaultNs.ODataErrors.ODataError": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/DefaultNs.odataerrors.mainerror"
+          "$ref": "#/definitions/DefaultNs.ODataErrors.MainError"
         }
       }
     },
-    "DefaultNs.odataerrors.mainerror": {
+    "DefaultNs.ODataErrors.MainError": {
       "required": [
         "code",
         "message"
@@ -2270,15 +2270,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DefaultNs.odataerrors.errordetails"
+            "$ref": "#/definitions/DefaultNs.ODataErrors.ErrorDetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/DefaultNs.odataerrors.innererror"
+          "$ref": "#/definitions/DefaultNs.ODataErrors.InnerError"
         }
       }
     },
-    "DefaultNs.odataerrors.errordetails": {
+    "DefaultNs.ODataErrors.ErrorDetails": {
       "required": [
         "code",
         "message"
@@ -2296,7 +2296,7 @@
         }
       }
     },
-    "DefaultNs.odataerrors.innererror": {
+    "DefaultNs.ODataErrors.InnerError": {
       "description": "The structure of this object is service-specific",
       "type": "object"
     },
@@ -2391,7 +2391,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/DefaultNs.odataerrors.odataerror"
+        "$ref": "#/definitions/DefaultNs.ODataErrors.ODataError"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -2240,18 +2240,18 @@
         }
       }
     },
-    "odata.error": {
+    "DefaultNs.odataerrors.odataerror": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/odata.error.main"
+          "$ref": "#/definitions/DefaultNs.odataerrors.mainerror"
         }
       }
     },
-    "odata.error.main": {
+    "DefaultNs.odataerrors.mainerror": {
       "required": [
         "code",
         "message"
@@ -2270,15 +2270,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/odata.error.detail"
+            "$ref": "#/definitions/DefaultNs.odataerrors.errordetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/odata.error.innererror"
+          "$ref": "#/definitions/DefaultNs.odataerrors.innererror"
         }
       }
     },
-    "odata.error.detail": {
+    "DefaultNs.odataerrors.errordetails": {
       "required": [
         "code",
         "message"
@@ -2296,7 +2296,7 @@
         }
       }
     },
-    "odata.error.innererror": {
+    "DefaultNs.odataerrors.innererror": {
       "description": "The structure of this object is service-specific",
       "type": "object"
     },
@@ -2391,7 +2391,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/odata.error"
+        "$ref": "#/definitions/DefaultNs.odataerrors.odataerror"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -1487,14 +1487,14 @@ definitions:
         '@odata.type': DefaultNs.City
       CountryOrRegion:
         '@odata.type': DefaultNs.CountryOrRegion
-  odata.error:
+  DefaultNs.odataerrors.odataerror:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/odata.error.main'
-  odata.error.main:
+        $ref: '#/definitions/DefaultNs.odataerrors.mainerror'
+  DefaultNs.odataerrors.mainerror:
     required:
       - code
       - message
@@ -1509,10 +1509,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/odata.error.detail'
+          $ref: '#/definitions/DefaultNs.odataerrors.errordetails'
       innererror:
-        $ref: '#/definitions/odata.error.innererror'
-  odata.error.detail:
+        $ref: '#/definitions/DefaultNs.odataerrors.innererror'
+  DefaultNs.odataerrors.errordetails:
     required:
       - code
       - message
@@ -1524,7 +1524,7 @@ definitions:
         type: string
       target:
         type: string
-  odata.error.innererror:
+  DefaultNs.odataerrors.innererror:
     description: The structure of this object is service-specific
     type: object
   ODataCountResponse:
@@ -1594,7 +1594,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/odata.error'
+      $ref: '#/definitions/DefaultNs.odataerrors.odataerror'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -1487,14 +1487,14 @@ definitions:
         '@odata.type': DefaultNs.City
       CountryOrRegion:
         '@odata.type': DefaultNs.CountryOrRegion
-  DefaultNs.odataerrors.odataerror:
+  DefaultNs.ODataErrors.ODataError:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/DefaultNs.odataerrors.mainerror'
-  DefaultNs.odataerrors.mainerror:
+        $ref: '#/definitions/DefaultNs.ODataErrors.MainError'
+  DefaultNs.ODataErrors.MainError:
     required:
       - code
       - message
@@ -1509,10 +1509,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/DefaultNs.odataerrors.errordetails'
+          $ref: '#/definitions/DefaultNs.ODataErrors.ErrorDetails'
       innererror:
-        $ref: '#/definitions/DefaultNs.odataerrors.innererror'
-  DefaultNs.odataerrors.errordetails:
+        $ref: '#/definitions/DefaultNs.ODataErrors.InnerError'
+  DefaultNs.ODataErrors.ErrorDetails:
     required:
       - code
       - message
@@ -1524,7 +1524,7 @@ definitions:
         type: string
       target:
         type: string
-  DefaultNs.odataerrors.innererror:
+  DefaultNs.ODataErrors.InnerError:
     description: The structure of this object is service-specific
     type: object
   ODataCountResponse:
@@ -1594,7 +1594,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/DefaultNs.odataerrors.odataerror'
+      $ref: '#/definitions/DefaultNs.ODataErrors.ODataError'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -2487,18 +2487,18 @@
           }
         }
       },
-      "DefaultNs.odataerrors.odataerror": {
+      "DefaultNs.ODataErrors.ODataError": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/DefaultNs.odataerrors.mainerror"
+            "$ref": "#/components/schemas/DefaultNs.ODataErrors.MainError"
           }
         }
       },
-      "DefaultNs.odataerrors.mainerror": {
+      "DefaultNs.ODataErrors.MainError": {
         "required": [
           "code",
           "message"
@@ -2518,15 +2518,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DefaultNs.odataerrors.errordetails"
+              "$ref": "#/components/schemas/DefaultNs.ODataErrors.ErrorDetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/DefaultNs.odataerrors.innererror"
+            "$ref": "#/components/schemas/DefaultNs.ODataErrors.InnerError"
           }
         }
       },
-      "DefaultNs.odataerrors.errordetails": {
+      "DefaultNs.ODataErrors.ErrorDetails": {
         "required": [
           "code",
           "message"
@@ -2545,7 +2545,7 @@
           }
         }
       },
-      "DefaultNs.odataerrors.innererror": {
+      "DefaultNs.ODataErrors.InnerError": {
         "type": "object",
         "description": "The structure of this object is service-specific"
       },
@@ -2608,7 +2608,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/DefaultNs.odataerrors.odataerror"
+              "$ref": "#/components/schemas/DefaultNs.ODataErrors.ODataError"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -2487,18 +2487,18 @@
           }
         }
       },
-      "odata.error": {
+      "DefaultNs.odataerrors.odataerror": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/odata.error.main"
+            "$ref": "#/components/schemas/DefaultNs.odataerrors.mainerror"
           }
         }
       },
-      "odata.error.main": {
+      "DefaultNs.odataerrors.mainerror": {
         "required": [
           "code",
           "message"
@@ -2518,15 +2518,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/odata.error.detail"
+              "$ref": "#/components/schemas/DefaultNs.odataerrors.errordetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/odata.error.innererror"
+            "$ref": "#/components/schemas/DefaultNs.odataerrors.innererror"
           }
         }
       },
-      "odata.error.detail": {
+      "DefaultNs.odataerrors.errordetails": {
         "required": [
           "code",
           "message"
@@ -2545,7 +2545,7 @@
           }
         }
       },
-      "odata.error.innererror": {
+      "DefaultNs.odataerrors.innererror": {
         "type": "object",
         "description": "The structure of this object is service-specific"
       },
@@ -2608,7 +2608,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/odata.error"
+              "$ref": "#/components/schemas/DefaultNs.odataerrors.odataerror"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -1649,14 +1649,14 @@ components:
           '@odata.type': DefaultNs.City
         CountryOrRegion:
           '@odata.type': DefaultNs.CountryOrRegion
-    odata.error:
+    DefaultNs.odataerrors.odataerror:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/odata.error.main'
-    odata.error.main:
+          $ref: '#/components/schemas/DefaultNs.odataerrors.mainerror'
+    DefaultNs.odataerrors.mainerror:
       required:
         - code
         - message
@@ -1672,10 +1672,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/odata.error.detail'
+            $ref: '#/components/schemas/DefaultNs.odataerrors.errordetails'
         innererror:
-          $ref: '#/components/schemas/odata.error.innererror'
-    odata.error.detail:
+          $ref: '#/components/schemas/DefaultNs.odataerrors.innererror'
+    DefaultNs.odataerrors.errordetails:
       required:
         - code
         - message
@@ -1688,7 +1688,7 @@ components:
         target:
           type: string
           nullable: true
-    odata.error.innererror:
+    DefaultNs.odataerrors.innererror:
       type: object
       description: The structure of this object is service-specific
     ODataCountResponse:
@@ -1732,7 +1732,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/odata.error'
+            $ref: '#/components/schemas/DefaultNs.odataerrors.odataerror'
     ODataCountResponse:
       description: The count of the resource
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -1649,14 +1649,14 @@ components:
           '@odata.type': DefaultNs.City
         CountryOrRegion:
           '@odata.type': DefaultNs.CountryOrRegion
-    DefaultNs.odataerrors.odataerror:
+    DefaultNs.ODataErrors.ODataError:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/DefaultNs.odataerrors.mainerror'
-    DefaultNs.odataerrors.mainerror:
+          $ref: '#/components/schemas/DefaultNs.ODataErrors.MainError'
+    DefaultNs.ODataErrors.MainError:
       required:
         - code
         - message
@@ -1672,10 +1672,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/DefaultNs.odataerrors.errordetails'
+            $ref: '#/components/schemas/DefaultNs.ODataErrors.ErrorDetails'
         innererror:
-          $ref: '#/components/schemas/DefaultNs.odataerrors.innererror'
-    DefaultNs.odataerrors.errordetails:
+          $ref: '#/components/schemas/DefaultNs.ODataErrors.InnerError'
+    DefaultNs.ODataErrors.ErrorDetails:
       required:
         - code
         - message
@@ -1688,7 +1688,7 @@ components:
         target:
           type: string
           nullable: true
-    DefaultNs.odataerrors.innererror:
+    DefaultNs.ODataErrors.InnerError:
       type: object
       description: The structure of this object is service-specific
     ODataCountResponse:
@@ -1732,7 +1732,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/DefaultNs.odataerrors.odataerror'
+            $ref: '#/components/schemas/DefaultNs.ODataErrors.ODataError'
     ODataCountResponse:
       description: The count of the resource
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -11,18 +11,18 @@
   ],
   "paths": { },
   "definitions": {
-    "odata.error": {
+    "odataerrors.odataerror": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/odata.error.main"
+          "$ref": "#/definitions/odataerrors.mainerror"
         }
       }
     },
-    "odata.error.main": {
+    "odataerrors.mainerror": {
       "required": [
         "code",
         "message"
@@ -41,15 +41,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/odata.error.detail"
+            "$ref": "#/definitions/odataerrors.errordetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/odata.error.innererror"
+          "$ref": "#/definitions/odataerrors.innererror"
         }
       }
     },
-    "odata.error.detail": {
+    "odataerrors.errordetails": {
       "required": [
         "code",
         "message"
@@ -67,7 +67,7 @@
         }
       }
     },
-    "odata.error.innererror": {
+    "odataerrors.innererror": {
       "description": "The structure of this object is service-specific",
       "type": "object"
     },
@@ -114,7 +114,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/odata.error"
+        "$ref": "#/definitions/odataerrors.odataerror"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -11,18 +11,18 @@
   ],
   "paths": { },
   "definitions": {
-    "odataerrors.odataerror": {
+    "ODataErrors.ODataError": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/odataerrors.mainerror"
+          "$ref": "#/definitions/ODataErrors.MainError"
         }
       }
     },
-    "odataerrors.mainerror": {
+    "ODataErrors.MainError": {
       "required": [
         "code",
         "message"
@@ -41,15 +41,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/odataerrors.errordetails"
+            "$ref": "#/definitions/ODataErrors.ErrorDetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/odataerrors.innererror"
+          "$ref": "#/definitions/ODataErrors.InnerError"
         }
       }
     },
-    "odataerrors.errordetails": {
+    "ODataErrors.ErrorDetails": {
       "required": [
         "code",
         "message"
@@ -67,7 +67,7 @@
         }
       }
     },
-    "odataerrors.innererror": {
+    "ODataErrors.InnerError": {
       "description": "The structure of this object is service-specific",
       "type": "object"
     },
@@ -114,7 +114,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/odataerrors.odataerror"
+        "$ref": "#/definitions/ODataErrors.ODataError"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -8,14 +8,14 @@ schemes:
   - http
 paths: { }
 definitions:
-  odata.error:
+  odataerrors.odataerror:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/odata.error.main'
-  odata.error.main:
+        $ref: '#/definitions/odataerrors.mainerror'
+  odataerrors.mainerror:
     required:
       - code
       - message
@@ -30,10 +30,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/odata.error.detail'
+          $ref: '#/definitions/odataerrors.errordetails'
       innererror:
-        $ref: '#/definitions/odata.error.innererror'
-  odata.error.detail:
+        $ref: '#/definitions/odataerrors.innererror'
+  odataerrors.errordetails:
     required:
       - code
       - message
@@ -45,7 +45,7 @@ definitions:
         type: string
       target:
         type: string
-  odata.error.innererror:
+  odataerrors.innererror:
     description: The structure of this object is service-specific
     type: object
   ODataCountResponse:
@@ -83,7 +83,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/odata.error'
+      $ref: '#/definitions/odataerrors.odataerror'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -8,14 +8,14 @@ schemes:
   - http
 paths: { }
 definitions:
-  odataerrors.odataerror:
+  ODataErrors.ODataError:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/odataerrors.mainerror'
-  odataerrors.mainerror:
+        $ref: '#/definitions/ODataErrors.MainError'
+  ODataErrors.MainError:
     required:
       - code
       - message
@@ -30,10 +30,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/odataerrors.errordetails'
+          $ref: '#/definitions/ODataErrors.ErrorDetails'
       innererror:
-        $ref: '#/definitions/odataerrors.innererror'
-  odataerrors.errordetails:
+        $ref: '#/definitions/ODataErrors.InnerError'
+  ODataErrors.ErrorDetails:
     required:
       - code
       - message
@@ -45,7 +45,7 @@ definitions:
         type: string
       target:
         type: string
-  odataerrors.innererror:
+  ODataErrors.InnerError:
     description: The structure of this object is service-specific
     type: object
   ODataCountResponse:
@@ -83,7 +83,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/odataerrors.odataerror'
+      $ref: '#/definitions/ODataErrors.ODataError'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -13,18 +13,18 @@
   "paths": { },
   "components": {
     "schemas": {
-      "odata.error": {
+      "odataerrors.odataerror": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/odata.error.main"
+            "$ref": "#/components/schemas/odataerrors.mainerror"
           }
         }
       },
-      "odata.error.main": {
+      "odataerrors.mainerror": {
         "required": [
           "code",
           "message"
@@ -44,15 +44,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/odata.error.detail"
+              "$ref": "#/components/schemas/odataerrors.errordetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/odata.error.innererror"
+            "$ref": "#/components/schemas/odataerrors.innererror"
           }
         }
       },
-      "odata.error.detail": {
+      "odataerrors.errordetails": {
         "required": [
           "code",
           "message"
@@ -71,7 +71,7 @@
           }
         }
       },
-      "odata.error.innererror": {
+      "odataerrors.innererror": {
         "type": "object",
         "description": "The structure of this object is service-specific"
       },
@@ -86,7 +86,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/odata.error"
+              "$ref": "#/components/schemas/odataerrors.odataerror"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -13,18 +13,18 @@
   "paths": { },
   "components": {
     "schemas": {
-      "odataerrors.odataerror": {
+      "ODataErrors.ODataError": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/odataerrors.mainerror"
+            "$ref": "#/components/schemas/ODataErrors.MainError"
           }
         }
       },
-      "odataerrors.mainerror": {
+      "ODataErrors.MainError": {
         "required": [
           "code",
           "message"
@@ -44,15 +44,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/odataerrors.errordetails"
+              "$ref": "#/components/schemas/ODataErrors.ErrorDetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/odataerrors.innererror"
+            "$ref": "#/components/schemas/ODataErrors.InnerError"
           }
         }
       },
-      "odataerrors.errordetails": {
+      "ODataErrors.ErrorDetails": {
         "required": [
           "code",
           "message"
@@ -71,7 +71,7 @@
           }
         }
       },
-      "odataerrors.innererror": {
+      "ODataErrors.InnerError": {
         "type": "object",
         "description": "The structure of this object is service-specific"
       },
@@ -86,7 +86,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/odataerrors.odataerror"
+              "$ref": "#/components/schemas/ODataErrors.ODataError"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -8,14 +8,14 @@ servers:
 paths: { }
 components:
   schemas:
-    odataerrors.odataerror:
+    ODataErrors.ODataError:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/odataerrors.mainerror'
-    odataerrors.mainerror:
+          $ref: '#/components/schemas/ODataErrors.MainError'
+    ODataErrors.MainError:
       required:
         - code
         - message
@@ -31,10 +31,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/odataerrors.errordetails'
+            $ref: '#/components/schemas/ODataErrors.ErrorDetails'
         innererror:
-          $ref: '#/components/schemas/odataerrors.innererror'
-    odataerrors.errordetails:
+          $ref: '#/components/schemas/ODataErrors.InnerError'
+    ODataErrors.ErrorDetails:
       required:
         - code
         - message
@@ -47,7 +47,7 @@ components:
         target:
           type: string
           nullable: true
-    odataerrors.innererror:
+    ODataErrors.InnerError:
       type: object
       description: The structure of this object is service-specific
     ODataCountResponse:
@@ -59,7 +59,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/odataerrors.odataerror'
+            $ref: '#/components/schemas/ODataErrors.ODataError'
     ODataCountResponse:
       description: The count of the resource
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -8,14 +8,14 @@ servers:
 paths: { }
 components:
   schemas:
-    odata.error:
+    odataerrors.odataerror:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/odata.error.main'
-    odata.error.main:
+          $ref: '#/components/schemas/odataerrors.mainerror'
+    odataerrors.mainerror:
       required:
         - code
         - message
@@ -31,10 +31,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/odata.error.detail'
+            $ref: '#/components/schemas/odataerrors.errordetails'
         innererror:
-          $ref: '#/components/schemas/odata.error.innererror'
-    odata.error.detail:
+          $ref: '#/components/schemas/odataerrors.innererror'
+    odataerrors.errordetails:
       required:
         - code
         - message
@@ -47,7 +47,7 @@ components:
         target:
           type: string
           nullable: true
-    odata.error.innererror:
+    odataerrors.innererror:
       type: object
       description: The structure of this object is service-specific
     ODataCountResponse:
@@ -59,7 +59,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/odata.error'
+            $ref: '#/components/schemas/odataerrors.odataerror'
     ODataCountResponse:
       description: The count of the resource
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -5815,18 +5815,18 @@
         }
       }
     },
-    "Default.odataerrors.odataerror": {
+    "Default.ODataErrors.ODataError": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/Default.odataerrors.mainerror"
+          "$ref": "#/definitions/Default.ODataErrors.MainError"
         }
       }
     },
-    "Default.odataerrors.mainerror": {
+    "Default.ODataErrors.MainError": {
       "required": [
         "code",
         "message"
@@ -5845,15 +5845,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Default.odataerrors.errordetails"
+            "$ref": "#/definitions/Default.ODataErrors.ErrorDetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/Default.odataerrors.innererror"
+          "$ref": "#/definitions/Default.ODataErrors.InnerError"
         }
       }
     },
-    "Default.odataerrors.errordetails": {
+    "Default.ODataErrors.ErrorDetails": {
       "required": [
         "code",
         "message"
@@ -5871,7 +5871,7 @@
         }
       }
     },
-    "Default.odataerrors.innererror": {
+    "Default.ODataErrors.InnerError": {
       "description": "The structure of this object is service-specific",
       "type": "object"
     },
@@ -6073,7 +6073,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/Default.odataerrors.odataerror"
+        "$ref": "#/definitions/Default.ODataErrors.ODataError"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -5815,18 +5815,18 @@
         }
       }
     },
-    "odata.error": {
+    "Default.odataerrors.odataerror": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/odata.error.main"
+          "$ref": "#/definitions/Default.odataerrors.mainerror"
         }
       }
     },
-    "odata.error.main": {
+    "Default.odataerrors.mainerror": {
       "required": [
         "code",
         "message"
@@ -5845,15 +5845,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/odata.error.detail"
+            "$ref": "#/definitions/Default.odataerrors.errordetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/odata.error.innererror"
+          "$ref": "#/definitions/Default.odataerrors.innererror"
         }
       }
     },
-    "odata.error.detail": {
+    "Default.odataerrors.errordetails": {
       "required": [
         "code",
         "message"
@@ -5871,7 +5871,7 @@
         }
       }
     },
-    "odata.error.innererror": {
+    "Default.odataerrors.innererror": {
       "description": "The structure of this object is service-specific",
       "type": "object"
     },
@@ -6073,7 +6073,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/odata.error"
+        "$ref": "#/definitions/Default.odataerrors.odataerror"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -4267,14 +4267,14 @@ definitions:
       ApprovedDate: string (timestamp)
       Document:
         '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
-  Default.odataerrors.odataerror:
+  Default.ODataErrors.ODataError:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/Default.odataerrors.mainerror'
-  Default.odataerrors.mainerror:
+        $ref: '#/definitions/Default.ODataErrors.MainError'
+  Default.ODataErrors.MainError:
     required:
       - code
       - message
@@ -4289,10 +4289,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/Default.odataerrors.errordetails'
+          $ref: '#/definitions/Default.ODataErrors.ErrorDetails'
       innererror:
-        $ref: '#/definitions/Default.odataerrors.innererror'
-  Default.odataerrors.errordetails:
+        $ref: '#/definitions/Default.ODataErrors.InnerError'
+  Default.ODataErrors.ErrorDetails:
     required:
       - code
       - message
@@ -4304,7 +4304,7 @@ definitions:
         type: string
       target:
         type: string
-  Default.odataerrors.innererror:
+  Default.ODataErrors.InnerError:
     description: The structure of this object is service-specific
     type: object
   ODataCountResponse:
@@ -4445,7 +4445,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/Default.odataerrors.odataerror'
+      $ref: '#/definitions/Default.ODataErrors.ODataError'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -4267,14 +4267,14 @@ definitions:
       ApprovedDate: string (timestamp)
       Document:
         '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
-  odata.error:
+  Default.odataerrors.odataerror:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/odata.error.main'
-  odata.error.main:
+        $ref: '#/definitions/Default.odataerrors.mainerror'
+  Default.odataerrors.mainerror:
     required:
       - code
       - message
@@ -4289,10 +4289,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/odata.error.detail'
+          $ref: '#/definitions/Default.odataerrors.errordetails'
       innererror:
-        $ref: '#/definitions/odata.error.innererror'
-  odata.error.detail:
+        $ref: '#/definitions/Default.odataerrors.innererror'
+  Default.odataerrors.errordetails:
     required:
       - code
       - message
@@ -4304,7 +4304,7 @@ definitions:
         type: string
       target:
         type: string
-  odata.error.innererror:
+  Default.odataerrors.innererror:
     description: The structure of this object is service-specific
     type: object
   ODataCountResponse:
@@ -4445,7 +4445,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/odata.error'
+      $ref: '#/definitions/Default.odataerrors.odataerror'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -6544,18 +6544,18 @@
           }
         }
       },
-      "odata.error": {
+      "Default.odataerrors.odataerror": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/odata.error.main"
+            "$ref": "#/components/schemas/Default.odataerrors.mainerror"
           }
         }
       },
-      "odata.error.main": {
+      "Default.odataerrors.mainerror": {
         "required": [
           "code",
           "message"
@@ -6575,15 +6575,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/odata.error.detail"
+              "$ref": "#/components/schemas/Default.odataerrors.errordetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/odata.error.innererror"
+            "$ref": "#/components/schemas/Default.odataerrors.innererror"
           }
         }
       },
-      "odata.error.detail": {
+      "Default.odataerrors.errordetails": {
         "required": [
           "code",
           "message"
@@ -6602,7 +6602,7 @@
           }
         }
       },
-      "odata.error.innererror": {
+      "Default.odataerrors.innererror": {
         "type": "object",
         "description": "The structure of this object is service-specific"
       },
@@ -6773,7 +6773,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/odata.error"
+              "$ref": "#/components/schemas/Default.odataerrors.odataerror"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -6544,18 +6544,18 @@
           }
         }
       },
-      "Default.odataerrors.odataerror": {
+      "Default.ODataErrors.ODataError": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/Default.odataerrors.mainerror"
+            "$ref": "#/components/schemas/Default.ODataErrors.MainError"
           }
         }
       },
-      "Default.odataerrors.mainerror": {
+      "Default.ODataErrors.MainError": {
         "required": [
           "code",
           "message"
@@ -6575,15 +6575,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Default.odataerrors.errordetails"
+              "$ref": "#/components/schemas/Default.ODataErrors.ErrorDetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/Default.odataerrors.innererror"
+            "$ref": "#/components/schemas/Default.ODataErrors.InnerError"
           }
         }
       },
-      "Default.odataerrors.errordetails": {
+      "Default.ODataErrors.ErrorDetails": {
         "required": [
           "code",
           "message"
@@ -6602,7 +6602,7 @@
           }
         }
       },
-      "Default.odataerrors.innererror": {
+      "Default.ODataErrors.InnerError": {
         "type": "object",
         "description": "The structure of this object is service-specific"
       },
@@ -6773,7 +6773,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/Default.odataerrors.odataerror"
+              "$ref": "#/components/schemas/Default.ODataErrors.ODataError"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -4752,14 +4752,14 @@ components:
         ApprovedDate: string (timestamp)
         Document:
           '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
-    Default.odataerrors.odataerror:
+    Default.ODataErrors.ODataError:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/Default.odataerrors.mainerror'
-    Default.odataerrors.mainerror:
+          $ref: '#/components/schemas/Default.ODataErrors.MainError'
+    Default.ODataErrors.MainError:
       required:
         - code
         - message
@@ -4775,10 +4775,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/Default.odataerrors.errordetails'
+            $ref: '#/components/schemas/Default.ODataErrors.ErrorDetails'
         innererror:
-          $ref: '#/components/schemas/Default.odataerrors.innererror'
-    Default.odataerrors.errordetails:
+          $ref: '#/components/schemas/Default.ODataErrors.InnerError'
+    Default.ODataErrors.ErrorDetails:
       required:
         - code
         - message
@@ -4791,7 +4791,7 @@ components:
         target:
           type: string
           nullable: true
-    Default.odataerrors.innererror:
+    Default.ODataErrors.InnerError:
       type: object
       description: The structure of this object is service-specific
     ODataCountResponse:
@@ -4907,7 +4907,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Default.odataerrors.odataerror'
+            $ref: '#/components/schemas/Default.ODataErrors.ODataError'
     ODataCountResponse:
       description: The count of the resource
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -4752,14 +4752,14 @@ components:
         ApprovedDate: string (timestamp)
         Document:
           '@odata.type': Siterra.Documents.BusinessLogic.Entities.Document.Document
-    odata.error:
+    Default.odataerrors.odataerror:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/odata.error.main'
-    odata.error.main:
+          $ref: '#/components/schemas/Default.odataerrors.mainerror'
+    Default.odataerrors.mainerror:
       required:
         - code
         - message
@@ -4775,10 +4775,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/odata.error.detail'
+            $ref: '#/components/schemas/Default.odataerrors.errordetails'
         innererror:
-          $ref: '#/components/schemas/odata.error.innererror'
-    odata.error.detail:
+          $ref: '#/components/schemas/Default.odataerrors.innererror'
+    Default.odataerrors.errordetails:
       required:
         - code
         - message
@@ -4791,7 +4791,7 @@ components:
         target:
           type: string
           nullable: true
-    odata.error.innererror:
+    Default.odataerrors.innererror:
       type: object
       description: The structure of this object is service-specific
     ODataCountResponse:
@@ -4907,7 +4907,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/odata.error'
+            $ref: '#/components/schemas/Default.odataerrors.odataerror'
     ODataCountResponse:
       description: The count of the resource
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -28739,18 +28739,18 @@
         "type": "number"
       }
     },
-    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror"
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError"
         }
       }
     },
-    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError": {
       "required": [
         "code",
         "message"
@@ -28769,15 +28769,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails"
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror"
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError"
         }
       }
     },
-    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails": {
       "required": [
         "code",
         "message"
@@ -28795,7 +28795,7 @@
         }
       }
     },
-    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError": {
       "title": "InnerError",
       "type": "object",
       "properties": {
@@ -29007,7 +29007,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror"
+        "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -28739,18 +28739,18 @@
         "type": "number"
       }
     },
-    "odata.error": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror": {
       "required": [
         "error"
       ],
       "type": "object",
       "properties": {
         "error": {
-          "$ref": "#/definitions/odata.error.main"
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror"
         }
       }
     },
-    "odata.error.main": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror": {
       "required": [
         "code",
         "message"
@@ -28769,15 +28769,15 @@
         "details": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/odata.error.detail"
+            "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails"
           }
         },
         "innererror": {
-          "$ref": "#/definitions/odata.error.innererror"
+          "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror"
         }
       }
     },
-    "odata.error.detail": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails": {
       "required": [
         "code",
         "message"
@@ -28795,7 +28795,7 @@
         }
       }
     },
-    "odata.error.innererror": {
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror": {
       "title": "InnerError",
       "type": "object",
       "properties": {
@@ -29007,7 +29007,7 @@
     "error": {
       "description": "error",
       "schema": {
-        "$ref": "#/definitions/odata.error"
+        "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror"
       }
     },
     "ODataCountResponse": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -20352,14 +20352,14 @@ definitions:
     type: array
     items:
       type: number
-  odata.error:
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/odata.error.main'
-  odata.error.main:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror'
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror:
     required:
       - code
       - message
@@ -20374,10 +20374,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/odata.error.detail'
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails'
       innererror:
-        $ref: '#/definitions/odata.error.innererror'
-  odata.error.detail:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror'
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails:
     required:
       - code
       - message
@@ -20389,7 +20389,7 @@ definitions:
         type: string
       target:
         type: string
-  odata.error.innererror:
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror:
     title: InnerError
     type: object
     properties:
@@ -20537,7 +20537,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/odata.error'
+      $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -20352,14 +20352,14 @@ definitions:
     type: array
     items:
       type: number
-  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror:
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError:
     required:
       - error
     type: object
     properties:
       error:
-        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror'
-  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError'
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError:
     required:
       - code
       - message
@@ -20374,10 +20374,10 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails'
+          $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails'
       innererror:
-        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror'
-  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails:
+        $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError'
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails:
     required:
       - code
       - message
@@ -20389,7 +20389,7 @@ definitions:
         type: string
       target:
         type: string
-  Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror:
+  Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError:
     title: InnerError
     type: object
     properties:
@@ -20537,7 +20537,7 @@ responses:
   error:
     description: error
     schema:
-      $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror'
+      $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError'
   ODataCountResponse:
     description: The count of the resource
     schema:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -32208,18 +32208,18 @@
           "type": "number"
         }
       },
-      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror"
+            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError"
           }
         }
       },
-      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError": {
         "required": [
           "code",
           "message"
@@ -32239,15 +32239,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails"
+              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror"
+            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError"
           }
         }
       },
-      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails": {
         "required": [
           "code",
           "message"
@@ -32266,7 +32266,7 @@
           }
         }
       },
-      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError": {
         "title": "InnerError",
         "type": "object",
         "properties": {
@@ -32449,7 +32449,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror"
+              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -32208,18 +32208,18 @@
           "type": "number"
         }
       },
-      "odata.error": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror": {
         "required": [
           "error"
         ],
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/odata.error.main"
+            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror"
           }
         }
       },
-      "odata.error.main": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror": {
         "required": [
           "code",
           "message"
@@ -32239,15 +32239,15 @@
           "details": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/odata.error.detail"
+              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails"
             }
           },
           "innererror": {
-            "$ref": "#/components/schemas/odata.error.innererror"
+            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror"
           }
         }
       },
-      "odata.error.detail": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails": {
         "required": [
           "code",
           "message"
@@ -32266,7 +32266,7 @@
           }
         }
       },
-      "odata.error.innererror": {
+      "Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror": {
         "title": "InnerError",
         "type": "object",
         "properties": {
@@ -32449,7 +32449,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/odata.error"
+              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror"
             }
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -22435,14 +22435,14 @@ components:
       type: array
       items:
         type: number
-    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror:
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror'
-    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror:
+          $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError'
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.MainError:
       required:
         - code
         - message
@@ -22458,10 +22458,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails'
+            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails'
         innererror:
-          $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror'
-    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails:
+          $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError'
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails:
       required:
         - code
         - message
@@ -22474,7 +22474,7 @@ components:
         target:
           type: string
           nullable: true
-    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror:
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError:
       title: InnerError
       type: object
       properties:
@@ -22599,7 +22599,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror'
+            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ODataError'
     ODataCountResponse:
       description: The count of the resource
       content:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -22435,14 +22435,14 @@ components:
       type: array
       items:
         type: number
-    odata.error:
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror:
       required:
         - error
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/odata.error.main'
-    odata.error.main:
+          $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror'
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.mainerror:
       required:
         - code
         - message
@@ -22458,10 +22458,10 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/odata.error.detail'
+            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails'
         innererror:
-          $ref: '#/components/schemas/odata.error.innererror'
-    odata.error.detail:
+          $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror'
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.errordetails:
       required:
         - code
         - message
@@ -22474,7 +22474,7 @@ components:
         target:
           type: string
           nullable: true
-    odata.error.innererror:
+    Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.innererror:
       title: InnerError
       type: object
       properties:
@@ -22599,7 +22599,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/odata.error'
+            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.odataerrors.odataerror'
     ODataCountResponse:
       description: The count of the resource
       content:


### PR DESCRIPTION
- fixes #172 
- moved error definitions under main namespace
- renames types to avoid conflicts with native types or naming conventions