### PR TITLE
[Fix] Set `UnresolvedReference=true` for schemas with OpenAPIReference objects

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -37,6 +37,7 @@ namespace Microsoft.OpenApi.OData.Common
 
             OpenApiSchema baseTypeSchema = new()
 			{
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -49,6 +50,7 @@ namespace Microsoft.OpenApi.OData.Common
             {
                 OpenApiSchema derivedTypeSchema = new()
 				{
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -283,6 +283,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.Geography"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeographyPoint:
                     schema.Reference = new OpenApiReference
@@ -290,6 +291,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeographyPoint"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeographyLineString:
                     schema.Reference = new OpenApiReference
@@ -297,6 +299,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeographyLineString"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeographyPolygon:
                     schema.Reference = new OpenApiReference
@@ -304,6 +307,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeographyPolygon"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeographyCollection:
                     schema.Reference = new OpenApiReference
@@ -311,6 +315,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeographyCollection"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeographyMultiPolygon:
                     schema.Reference = new OpenApiReference
@@ -318,6 +323,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeographyMultiPolygon"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeographyMultiLineString:
                     schema.Reference = new OpenApiReference
@@ -325,6 +331,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeographyMultiLineString"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeographyMultiPoint:
                     schema.Reference = new OpenApiReference
@@ -332,14 +339,15 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeographyMultiPoint"
                     };
+                    schema.UnresolvedReference = true;
                     break;
-
                 case EdmPrimitiveTypeKind.Geometry: // Geometry
                     schema.Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,
                         Id = "Edm.Geometry"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeometryPoint:
                     schema.Reference = new OpenApiReference
@@ -347,6 +355,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeometryPoint"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeometryLineString:
                     schema.Reference = new OpenApiReference
@@ -354,6 +363,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeometryLineString"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeometryPolygon:
                     schema.Reference = new OpenApiReference
@@ -361,6 +371,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeometryPolygon"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeometryCollection:
                     schema.Reference = new OpenApiReference
@@ -368,6 +379,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeometryCollection"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeometryMultiPolygon:
                     schema.Reference = new OpenApiReference
@@ -375,6 +387,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeometryMultiPolygon"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeometryMultiLineString:
                     schema.Reference = new OpenApiReference
@@ -382,6 +395,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeometryMultiLineString"
                     };
+                    schema.UnresolvedReference = true;
                     break;
                 case EdmPrimitiveTypeKind.GeometryMultiPoint:
                     schema.Reference = new OpenApiReference
@@ -389,6 +403,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Type = ReferenceType.Schema,
                         Id = "Edm.GeometryMultiPoint"
                     };
+                    schema.UnresolvedReference = true;
                     break;
 
                 case EdmPrimitiveTypeKind.None:
@@ -432,6 +447,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Type = ReferenceType.Schema,
                     Id = typeReference.Definition.FullTypeName()
                 };
+                schema.UnresolvedReference = true;
             }
 
             return schema;
@@ -474,6 +490,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Type = ReferenceType.Schema,
                     Id = typeReference.Definition.FullTypeName()
                 };
+                schema.UnresolvedReference = true;
             }
 
             return schema;
@@ -512,6 +529,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Type = ReferenceType.Schema,
                     Id = reference.Definition.FullTypeName()
                 };
+                schema.UnresolvedReference = true;
             }
             
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -414,6 +414,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 {
                     new OpenApiSchema
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Schema,
@@ -455,6 +456,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 {
                     new OpenApiSchema
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Schema,
@@ -492,6 +494,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 {
                     new OpenApiSchema
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
@@ -63,6 +63,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         "error",
                         new OpenApiSchema
                         {
+                            UnresolvedReference = true,
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,
@@ -130,6 +131,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Type = "array",
                             Items = new OpenApiSchema
                             {
+                                UnresolvedReference = true,
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,
@@ -142,6 +144,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         "innererror",
                         new OpenApiSchema
                         {
+                            UnresolvedReference = true,
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -232,6 +232,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 return new OpenApiParameter
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference { Type = ReferenceType.Parameter, Id = "top" }
                 };
             }
@@ -255,6 +256,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 return new OpenApiParameter
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference { Type = ReferenceType.Parameter, Id = "skip" }
                 };
             }
@@ -278,6 +280,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 return new OpenApiParameter
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference { Type = ReferenceType.Parameter, Id = "search" }
                 };
             }
@@ -301,6 +304,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 return new OpenApiParameter
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference { Type = ReferenceType.Parameter, Id = "count" }
                 };
             }
@@ -324,6 +328,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 return new OpenApiParameter
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference { Type = ReferenceType.Parameter, Id = "filter" }
                 };
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -23,6 +23,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 { Constants.StatusCodeDefault,
                     new OpenApiResponse
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Response,
@@ -34,6 +35,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 { Constants.StatusCode204, new OpenApiResponse { Description = "Success"} },
                 { Constants.StatusCodeClass4XX, new OpenApiResponse
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Response,
@@ -43,6 +45,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 },
                 { Constants.StatusCodeClass5XX, new OpenApiResponse
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Response,
@@ -222,6 +225,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         {
                             Schema = new OpenApiSchema
                             {
+                                UnresolvedReference = true,
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,
@@ -238,6 +242,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             OpenApiSchema schema = new()
             {
+                UnresolvedReference = true,
                 Reference = new() {
                     Type = ReferenceType.Schema,
                     Id = Constants.DollarCountSchemaName
@@ -272,6 +277,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         {
                             Schema = new OpenApiSchema
                             {
+                                UnresolvedReference = true,
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -161,6 +161,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,
@@ -407,6 +408,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         // 1. a JSON Reference to the Schema Object of the base type
                         new OpenApiSchema
                         {
+                            UnresolvedReference = true,
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSecurityRequirementGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSecurityRequirementGenerator.cs
@@ -38,6 +38,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         [
                             new OpenApiSecurityScheme
                             {
+                                UnresolvedReference = true,
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.SecurityScheme,
@@ -70,6 +71,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         [
                             new OpenApiSecurityScheme
                             {
+                                UnresolvedReference = true,
                                 Reference = new OpenApiReference
                                 {
                                     Type = ReferenceType.SecurityScheme,

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSpatialTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSpatialTypeSchemaGenerator.cs
@@ -77,6 +77,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -93,6 +94,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -109,6 +111,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -125,6 +128,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -141,6 +145,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -157,6 +162,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -173,6 +179,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -189,6 +196,7 @@ namespace Microsoft.OpenApi.OData.Generator
         {
             return new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
@@ -208,13 +216,13 @@ namespace Microsoft.OpenApi.OData.Generator
                 Type = "object",
                 AnyOf = new List<OpenApiSchema>
                 {
-                    new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryPoint" } },
-                    new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryLineString" } },
-                    new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryPolygon" } },
-                    new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryMultiPoint" } },
-                    new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryMultiLineString" } },
-                    new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryMultiPolygon" } },
-                    new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryCollection" } }
+                    new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryPoint" } },
+                    new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryLineString" } },
+                    new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryPolygon" } },
+                    new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryMultiPoint" } },
+                    new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryMultiLineString" } },
+                    new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryMultiPolygon" } },
+                    new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryCollection" } }
                 }
             };
         }
@@ -240,7 +248,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Default = new OpenApiString("Point")
                         }
                     },
-                    { "coordinates", new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } } }
+                    { "coordinates", new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } } }
                 },
                 Required = new HashSet<string>
                 {
@@ -272,7 +280,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     { "coordinates", new OpenApiSchema
                         {
                             Type = "array",
-                            Items = new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" }},
+                            Items = new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" }},
                             MinItems = 2
                         }
                     }
@@ -310,7 +318,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Items = new OpenApiSchema
                             {
                                 Type = "array",
-                                Items = new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } }
+                                Items = new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } }
                             },
                             MinItems = 4
                         }
@@ -346,7 +354,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     { "coordinates", new OpenApiSchema
                         {
                             Type = "array",
-                            Items = new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" }}
+                            Items = new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" }}
                         }
                     }
                 },
@@ -383,7 +391,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             Items = new OpenApiSchema
                             {
                                 Type = "array",
-                                Items = new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } }
+                                Items = new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } }
                             },
                             MinItems = 2
                         }
@@ -425,7 +433,7 @@ namespace Microsoft.OpenApi.OData.Generator
                                 Items = new OpenApiSchema
                                 {
                                     Type = "array",
-                                    Items = new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } }
+                                    Items = new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "GeoJSON.position" } }
                                 }
                             },
                             MinItems = 4
@@ -462,7 +470,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     { "coordinates", new OpenApiSchema
                         {
                             Type = "array",
-                            Items = new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.Geometry" } }
+                            Items = new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.Geometry" } }
                         }
                     }
                 },

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -143,6 +143,7 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
                 Constants.StatusCode200,
                 new OpenApiResponse
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference()
                     {
                         Type = ReferenceType.Response,
@@ -160,6 +161,7 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
         {
             schema = new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
@@ -69,6 +69,7 @@ internal class ComplexPropertyPostOperationHandler : ComplexPropertyBaseOperatio
             Type = "array",
             Items = new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
@@ -42,6 +42,7 @@ internal abstract class ComplexPropertyUpdateOperationHandler : ComplexPropertyB
                 Type = "array",
                 Items = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,
@@ -52,6 +53,7 @@ internal abstract class ComplexPropertyUpdateOperationHandler : ComplexPropertyB
         :
             new OpenApiSchema
             {
+                UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -60,6 +60,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     Constants.StatusCode200,
                     new OpenApiResponse
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference() {
                             Type = ReferenceType.Response,
                             Id = Constants.DollarCountSchemaName

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -84,6 +84,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
@@ -136,6 +136,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     Constants.StatusCode200,
                     new OpenApiResponse
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference()
                         {
                             Type = ReferenceType.Response,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -165,6 +165,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -52,6 +52,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
@@ -75,6 +75,7 @@ namespace Microsoft.OpenApi.OData.Operation
                         Constants.StatusCode200,
                         new OpenApiResponse
                         {
+                            UnresolvedReference = true,
                             Reference = new OpenApiReference()
                             {
                                 Type = ReferenceType.Response,
@@ -98,6 +99,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 {
                     schema = new OpenApiSchema
                     {
+                        UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
@@ -52,6 +52,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,
@@ -92,6 +93,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -49,6 +49,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ODataTypeCastGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ODataTypeCastGetOperationHandler.cs
@@ -188,6 +188,7 @@ internal class ODataTypeCastGetOperationHandler : OperationHandler
 				Constants.StatusCode200,
 				new OpenApiResponse
 				{
+					UnresolvedReference = true,
 					Reference = new OpenApiReference()
 					{
 						Type = ReferenceType.Response,
@@ -210,6 +211,7 @@ internal class ODataTypeCastGetOperationHandler : OperationHandler
 		{
 			schema = new OpenApiSchema
 			{
+				UnresolvedReference = true,
 				Reference = new OpenApiReference
 				{
 					Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
@@ -73,6 +73,7 @@ namespace Microsoft.OpenApi.OData.Operation
                         Constants.StatusCode200,
                         new OpenApiResponse
                         {
+                            UnresolvedReference = true,
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Response,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
@@ -49,6 +49,7 @@ namespace Microsoft.OpenApi.OData.Operation
                         {
                             Schema = new()
                             {
+                                UnresolvedReference = true,
                                 Reference = new OpenApiReference {
                                     Id = Constants.ReferenceUpdateSchemaName,
                                     Type = ReferenceType.Schema

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
@@ -81,6 +81,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonPatchOperationHandler.cs
@@ -54,6 +54,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 schema = new OpenApiSchema
                 {
+                    UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
                         Type = ReferenceType.Schema,


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/171

This PR proposes:
- Setting `UnresolvedReference = true` for schemas with `OpenAPIReference` objects which are references to other model objects.