### PR TITLE
Renames setting property

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -293,7 +293,7 @@ namespace Microsoft.OpenApi.OData.Edm
             Debug.Assert(complexProperty != null);
             Debug.Assert(convertSettings != null);
 
-            if (!convertSettings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths)
+            if (!convertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths)
                 return true;
 
             bool isReadable = _model.GetRecord<ReadRestrictionsType>(complexProperty, CapabilitiesConstants.ReadRestrictions)?.Readable ?? false;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -293,7 +293,7 @@ namespace Microsoft.OpenApi.OData.Edm
             Debug.Assert(complexProperty != null);
             Debug.Assert(convertSettings != null);
 
-            if (!convertSettings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties)
+            if (!convertSettings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths)
                 return true;
 
             bool isReadable = _model.GetRecord<ReadRestrictionsType>(complexProperty, CapabilitiesConstants.ReadRestrictions)?.Readable ?? false;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OpenApi.OData
         /// <summary>
         /// Gets/Sets a value indicating whether or not to use restrictions annotations to generate paths for complex properties.
         /// </summary>
-        public bool UseRestrictionAnnotationsToGeneratePathsForComplexProperties { get; set; } = true;
+        public bool UseRestrictionAnnotationsToGenerateComplexPropertyPaths { get; set; } = true;
 
         internal OpenApiConvertSettings Clone()
         {
@@ -268,7 +268,7 @@ namespace Microsoft.OpenApi.OData
                 AddEnumDescriptionExtension = this.AddEnumDescriptionExtension,
                 ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
                 InnerErrorComplexTypeName = this.InnerErrorComplexTypeName,
-                UseRestrictionAnnotationsToGeneratePathsForComplexProperties = this.UseRestrictionAnnotationsToGeneratePathsForComplexProperties
+                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = this.UseRestrictionAnnotationsToGenerateComplexPropertyPaths
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OpenApi.OData
         /// <summary>
         /// Gets/Sets a value indicating whether or not to use restrictions annotations to generate paths for complex properties.
         /// </summary>
-        public bool UseRestrictionAnnotationsToGenerateComplexPropertyPaths { get; set; } = true;
+        public bool RequireRestrictionAnnotationsToGenerateComplexPropertyPaths { get; set; } = true;
 
         internal OpenApiConvertSettings Clone()
         {
@@ -268,7 +268,7 @@ namespace Microsoft.OpenApi.OData
                 AddEnumDescriptionExtension = this.AddEnumDescriptionExtension,
                 ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
                 InnerErrorComplexTypeName = this.InnerErrorComplexTypeName,
-                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = this.UseRestrictionAnnotationsToGenerateComplexPropertyPaths
+                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -24,16 +24,16 @@ internal class ComplexPropertyItemHandler : PathItemHandler
 	protected override void SetOperations(OpenApiPathItem item)
 	{
         bool isReadable = Context.Model.GetRecord<ReadRestrictionsType>(ComplexProperty, CapabilitiesConstants.ReadRestrictions)?.Readable ?? false;
-		if ((Context.Settings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties && isReadable) ||
-			!Context.Settings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties)
+		if ((Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths && isReadable) ||
+			!Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths)
         {
 			AddOperation(item, OperationType.Get);
 		}		
 
 		UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexProperty, CapabilitiesConstants.UpdateRestrictions);
 		bool isUpdatable = update?.Updatable ?? false;
-		if ((Context.Settings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties && isUpdatable) ||
-			!Context.Settings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties) 
+		if ((Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths && isUpdatable) ||
+			!Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths) 
 		{
 			if (update != null && update.IsUpdateMethodPut)
 			{
@@ -48,8 +48,8 @@ internal class ComplexPropertyItemHandler : PathItemHandler
 		if (Path.LastSegment is ODataComplexPropertySegment segment && segment.Property.Type.IsCollection())
         {
 			bool isInsertable = Context.Model.GetRecord<InsertRestrictionsType>(ComplexProperty, CapabilitiesConstants.InsertRestrictions)?.Insertable ?? false;
-			if ((Context.Settings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties && isInsertable) ||
-				!Context.Settings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties)
+			if ((Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths && isInsertable) ||
+				!Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths)
 			{
 				AddOperation(item, OperationType.Post);
 			}

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -24,16 +24,16 @@ internal class ComplexPropertyItemHandler : PathItemHandler
 	protected override void SetOperations(OpenApiPathItem item)
 	{
         bool isReadable = Context.Model.GetRecord<ReadRestrictionsType>(ComplexProperty, CapabilitiesConstants.ReadRestrictions)?.Readable ?? false;
-		if ((Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths && isReadable) ||
-			!Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths)
+		if ((Context.Settings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths && isReadable) ||
+			!Context.Settings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths)
         {
 			AddOperation(item, OperationType.Get);
 		}		
 
 		UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexProperty, CapabilitiesConstants.UpdateRestrictions);
 		bool isUpdatable = update?.Updatable ?? false;
-		if ((Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths && isUpdatable) ||
-			!Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths) 
+		if ((Context.Settings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths && isUpdatable) ||
+			!Context.Settings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths) 
 		{
 			if (update != null && update.IsUpdateMethodPut)
 			{
@@ -48,8 +48,8 @@ internal class ComplexPropertyItemHandler : PathItemHandler
 		if (Path.LastSegment is ODataComplexPropertySegment segment && segment.Property.Type.IsCollection())
         {
 			bool isInsertable = Context.Model.GetRecord<InsertRestrictionsType>(ComplexProperty, CapabilitiesConstants.InsertRestrictions)?.Insertable ?? false;
-			if ((Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths && isInsertable) ||
-				!Context.Settings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths)
+			if ((Context.Settings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths && isInsertable) ||
+				!Context.Settings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths)
 			{
 				AddOperation(item, OperationType.Post);
 			}

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,8 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
-Microsoft.OpenApi.OData.OpenApiConvertSettings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.UseRestrictionAnnotationsToGeneratePathsForComplexProperties.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 static Microsoft.OpenApi.OData.Edm.EdmTypeExtensions.ShouldPathParameterBeQuoted(this Microsoft.OData.Edm.IEdmType edmType, Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> bool
 Microsoft.OpenApi.OData.Edm.IODataPathProvider
 Microsoft.OpenApi.OData.Edm.IODataPathProvider.CanFilter(Microsoft.OData.Edm.IEdmElement element) -> bool

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,8 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
-Microsoft.OpenApi.OData.OpenApiConvertSettings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.UseRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 static Microsoft.OpenApi.OData.Edm.EdmTypeExtensions.ShouldPathParameterBeQuoted(this Microsoft.OData.Edm.IEdmType edmType, Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> bool
 Microsoft.OpenApi.OData.Edm.IODataPathProvider
 Microsoft.OpenApi.OData.Edm.IODataPathProvider.CanFilter(Microsoft.OData.Edm.IEdmElement element) -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableKeyAsSegment = true,
-                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
+                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
             };
             ODataContext context = new ODataContext(model, settings);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathItemGeneratorTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableKeyAsSegment = true,
-                UseRestrictionAnnotationsToGeneratePathsForComplexProperties = useAnnotationToGeneratePath
+                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
             };
             ODataContext context = new ODataContext(model, settings);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableKeyAsSegment = true,
-                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
+                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
             };
             ODataContext context = new ODataContext(model, settings);
 
@@ -110,7 +110,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             {
                 EnableKeyAsSegment = true,
                 PathPrefix = "some/prefix",
-                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
+                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
             };
             ODataContext context = new ODataContext(model, settings);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiPathsGeneratorTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableKeyAsSegment = true,
-                UseRestrictionAnnotationsToGeneratePathsForComplexProperties = useAnnotationToGeneratePath
+                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
             };
             ODataContext context = new ODataContext(model, settings);
 
@@ -110,7 +110,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             {
                 EnableKeyAsSegment = true,
                 PathPrefix = "some/prefix",
-                UseRestrictionAnnotationsToGeneratePathsForComplexProperties = useAnnotationToGeneratePath
+                UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
             };
             ODataContext context = new ODataContext(model, settings);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -46,7 +46,7 @@ public class ComplexPropertyPathItemHandlerTests
 		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation, target: target);
 		var convertSettings = new OpenApiConvertSettings
 		{
-			UseRestrictionAnnotationsToGeneratePathsForComplexProperties = useAnnotationToGeneratePath
+			UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
 		};
 		var context = new ODataContext(model, convertSettings);
 		var entitySet = model.EntityContainer.FindEntitySet("Customers");
@@ -99,7 +99,7 @@ public class ComplexPropertyPathItemHandlerTests
         var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation, target: target);
 		var convertSettings = new OpenApiConvertSettings
 		{
-			UseRestrictionAnnotationsToGeneratePathsForComplexProperties = useAnnotationToGeneratePath
+			UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
 		};
 		var context = new ODataContext(model, convertSettings);
         var entitySet = model.EntityContainer.FindEntitySet("Customers");
@@ -157,7 +157,7 @@ public class ComplexPropertyPathItemHandlerTests
 		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation, target: target);
 		var convertSettings = new OpenApiConvertSettings
 		{
-			UseRestrictionAnnotationsToGeneratePathsForComplexProperties = useAnnotationToGeneratePath
+			UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
 		};
 		var context = new ODataContext(model, convertSettings);
 		var entitySet = model.EntityContainer.FindEntitySet("Customers");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -46,7 +46,7 @@ public class ComplexPropertyPathItemHandlerTests
 		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation, target: target);
 		var convertSettings = new OpenApiConvertSettings
 		{
-			UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
+			RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
 		};
 		var context = new ODataContext(model, convertSettings);
 		var entitySet = model.EntityContainer.FindEntitySet("Customers");
@@ -99,7 +99,7 @@ public class ComplexPropertyPathItemHandlerTests
         var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation, target: target);
 		var convertSettings = new OpenApiConvertSettings
 		{
-			UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
+			RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
 		};
 		var context = new ODataContext(model, convertSettings);
         var entitySet = model.EntityContainer.FindEntitySet("Customers");
@@ -157,7 +157,7 @@ public class ComplexPropertyPathItemHandlerTests
 		var model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: annotation, target: target);
 		var convertSettings = new OpenApiConvertSettings
 		{
-			UseRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
+			RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = useAnnotationToGeneratePath
 		};
 		var context = new ODataContext(model, convertSettings);
 		var entitySet = model.EntityContainer.FindEntitySet("Customers");


### PR DESCRIPTION
This PR:
- Renames the setting property `UseRestrictionAnnotationsToGeneratePathsForComplexProperties` to `UseRestrictionAnnotationsToGenerateComplexPropertyPaths`. The new name is more terse.