### PR TITLE
fixes a bug where switch to semver versions would make comparison script fail

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -180,7 +180,6 @@ stages:
         inputs:
           targetType: 'filePath'
           filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
-          arguments: '-projectVersion "$(VersionFullSemantic)"'
 
       - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
         displayName: 'ESRP CodeSigning Nuget Packages'


### PR DESCRIPTION
once we deployed preview1 to nuget, this switched the package to semver mode, and to a different API endpoint.
This PR fixes the version comparison script.