### PR TITLE
Fixes paths for functions with structured or collection-valued parameters

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -139,9 +139,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 functionName.Append(function.FullName());
             }
             functionName.Append("(");
-
-            // Structured or collection-valued parameters are represented as a parameter alias in the path template
-            // and the parameters array contains a Parameter Object for the parameter alias as a query option of type string.
+            
             int skip = function.IsBound ? 1 : 0;
             functionName.Append(string.Join(",", function.Parameters.Skip(skip).Select(p =>
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -143,18 +143,11 @@ namespace Microsoft.OpenApi.OData.Edm
             // Structured or collection-valued parameters are represented as a parameter alias in the path template
             // and the parameters array contains a Parameter Object for the parameter alias as a query option of type string.
             int skip = function.IsBound ? 1 : 0;
-            functionName.Append(String.Join(",", function.Parameters.Skip(skip).Select(p =>
+            functionName.Append(string.Join(",", function.Parameters.Skip(skip).Select(p =>
             {
                 string uniqueName = Utils.GetUniqueName(p.Name, parameters);
-                if (p.Type.IsStructured() || p.Type.IsCollection())
-                {
-                    return p.Name + "=@" + uniqueName;
-                }
-                else
-                {
-                    var quote = p.Type.Definition.ShouldPathParameterBeQuoted(settings) ? "'" : string.Empty;
-                    return p.Name + $"={quote}{{{uniqueName}}}{quote}";
-                }
+                var quote = p.Type.Definition.ShouldPathParameterBeQuoted(settings) ? "'" : string.Empty;
+                return p.Name + $"={quote}{{{uniqueName}}}{quote}";
             })));
 
             functionName.Append(")");

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -81,17 +81,14 @@ namespace Microsoft.OpenApi.OData.Generator
                     }
                 }                
 
-                OpenApiParameter parameter;
-                // Structured or collection-valued parameters are represented as a parameter alias
-                // in the path template and the parameters array contains a Parameter Object for
-                // the parameter alias as a query option of type string.
+                OpenApiParameter parameter;                
                 if (edmParameter.Type.IsStructured() ||
                     edmParameter.Type.IsCollection())
                 {
                     parameter = new OpenApiParameter
                     {
                         Name = parameterNameMapping == null ? edmParameter.Name : parameterNameMapping[edmParameter.Name],
-                        In = ParameterLocation.Query, // as query option
+                        In = ParameterLocation.Path,
                         Required = true,
 
                         // Create schema in the Content property to indicate that the parameters are serialized as JSON

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
@@ -75,9 +75,9 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
         [Theory]
         [InlineData(true, true, "MyFunction(param={param})")]
-        [InlineData(true, false, "MyFunction(entity=@entity,param={param})")]
+        [InlineData(true, false, "MyFunction(entity={entity},param={param})")]
         [InlineData(false, true, "NS.MyFunction(param={param})")]
-        [InlineData(false, false, "NS.MyFunction(entity=@entity,param={param})")]
+        [InlineData(false, false, "NS.MyFunction(entity={entity},param={param})")]
         public void GetPathItemNameReturnsCorrectFunctionLiteral(bool unqualifiedCall, bool isBound, string expected)
         {
             // Arrange & Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
@@ -407,7 +407,7 @@ schema:
             string json1 = parameter1.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
             string expectedPayload1 = $@"{{
   ""name"": ""ids"",
-  ""in"": ""query"",
+  ""in"": ""path"",
   ""description"": ""The URL-encoded JSON object"",
   ""required"": true,
   ""content"": {{


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/202

This PR: 
- Replaces parameter alias for structured and collection-valued parameters with `{...}`. 
- Replaces the `in` property value of the parameter object from `in:query` to `in: path`.
- Updates the tests appropriately.

Addresses: https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/913 and https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/902