### PR TITLE
Sets the response type of functions returning `Edm.Stream` to `application/octet-stream`

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -184,13 +184,19 @@ namespace Microsoft.OpenApi.OData.Generator
                     schema = context.CreateEdmTypeSchema(operation.ReturnType);
                 }
 
+                string mediaType = Constants.ApplicationJsonMediaType;
+                if (operation.ReturnType.AsPrimitive()?.PrimitiveKind() == EdmPrimitiveTypeKind.Stream)
+                {
+                    mediaType = Constants.ApplicationOctetStreamMediaType;
+                }
+
                 OpenApiResponse response = new()
                 {
                     Description = "Success",
                     Content = new Dictionary<string, OpenApiMediaType>
                     {
                         {
-                            Constants.ApplicationJsonMediaType,
+                            mediaType,
                             new OpenApiMediaType
                             {
                                 Schema = schema

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -187,7 +187,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 string mediaType = Constants.ApplicationJsonMediaType;
                 if (operation.ReturnType.AsPrimitive()?.PrimitiveKind() == EdmPrimitiveTypeKind.Stream)
                 {
-                    // Responses of types Edm.Stream should be Octet-Stream
+                    // Responses of types Edm.Stream should be application/octet-stream
                     mediaType = Constants.ApplicationOctetStreamMediaType;
                 }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -187,6 +187,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 string mediaType = Constants.ApplicationJsonMediaType;
                 if (operation.ReturnType.AsPrimitive()?.PrimitiveKind() == EdmPrimitiveTypeKind.Stream)
                 {
+                    // Responses of types Edm.Stream should be Octet-Stream
                     mediaType = Constants.ApplicationOctetStreamMediaType;
                 }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -247,6 +247,32 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             }
         }
 
+        [Fact]
+        public void CreateResponseForEdmFunctionOfStreamReturnTypeReturnsCorrectResponse()
+        {
+            // Arrange
+            string operationName = "getMailboxUsageStorage";
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model);
+
+            // Act
+            OpenApiResponses responses;
+            IEdmOperation operation = model.SchemaElements.OfType<IEdmOperation>().First(o => o.Name == operationName);
+            Assert.NotNull(operation); // guard
+            ODataPath path = new(new ODataOperationSegment(operation));
+            responses = context.CreateResponses(operation, path);
+
+            // Assert
+            Assert.NotNull(responses);
+            Assert.NotEmpty(responses);
+            Assert.Equal(2, responses.Count);
+            Assert.Equal(new string[] { "200", "default" }, responses.Select(r => r.Key));
+
+            OpenApiResponse response = responses["200"];
+            Assert.NotNull(response.Content);
+            OpenApiMediaType mediaType = response.Content["application/octet-stream"];
+        }
+
         [Theory]
         [InlineData("ShareTrip", false, "204")]
         [InlineData("ResetDataSource", true, "204")]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/200

This PR:
- Sets the response types of functions returning `Edm.Stream` from `application/json` to `application/octet-stream`.
- Updates unit test and integration file to validate the above.