### PR TITLE
Fixes generation of `ODataTypeCast` paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -125,7 +125,7 @@ namespace Microsoft.OpenApi.OData.Common
         internal static string NavigationPropertyPath(this ODataPath path, string navigationPropertyName = null)
         {
             string value = string.Join("/",
-                path.Segments.Where(s => s is ODataNavigationPropertySegment).Select(e => e.Identifier));
+                path.Segments.OfType<ODataNavigationPropertySegment>().Select(e => e.Identifier));
             return navigationPropertyName == null ? value : $"{value}/{navigationPropertyName}";
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -125,7 +125,7 @@ namespace Microsoft.OpenApi.OData.Common
         internal static string NavigationPropertyPath(this ODataPath path, string navigationPropertyName = null)
         {
             string value = string.Join("/",
-               path.Segments.OfType<ODataNavigationPropertySegment>().Select(e => e.Identifier));
+                path.Segments.Where(s => s is ODataNavigationPropertySegment).Select(e => e.Identifier));
             return navigationPropertyName == null ? value : $"{value}/{navigationPropertyName}";
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -125,8 +125,7 @@ namespace Microsoft.OpenApi.OData.Common
         internal static string NavigationPropertyPath(this ODataPath path, string navigationPropertyName = null)
         {
             string value = string.Join("/",
-               path.Segments.Where(s => s is ODataNavigationPropertySegment).Select(e => e.Identifier));
-
+               path.Segments.OfType<ODataNavigationPropertySegment>().Select(e => e.Identifier));
             return navigationPropertyName == null ? value : $"{value}/{navigationPropertyName}";
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -125,8 +125,7 @@ namespace Microsoft.OpenApi.OData.Common
         internal static string NavigationPropertyPath(this ODataPath path, string navigationPropertyName = null)
         {
             string value = string.Join("/",
-                path.Segments.Where(s => !(s is ODataKeySegment || s is ODataNavigationSourceSegment 
-                || s is ODataStreamContentSegment || s is ODataStreamPropertySegment)).Select(e => e.Identifier));
+               path.Segments.Where(s => s is ODataNavigationPropertySegment).Select(e => e.Identifier));
 
             return navigationPropertyName == null ? value : $"{value}/{navigationPropertyName}";
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -559,7 +559,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 }
                 else
                 {
-                    foreach(var declaredNavigationProperty in targetType.DeclaredNavigationProperties())
+                    foreach (var declaredNavigationProperty in targetType.DeclaredNavigationProperties())
                     {
                         RetrieveNavigationPropertyPaths(declaredNavigationProperty, null, castPath, convertSettings);
                     }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -423,7 +423,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 }
                 // ~/entityset/{key}/collection-valued-Nav/subtype
                 // ~/entityset/{key}/single-valued-Nav/subtype
-                CreateTypeCastPaths(currentPath, convertSettings, navigationProperty.DeclaringType, navigationProperty, targetsMany);
+                CreateTypeCastPaths(currentPath, convertSettings, navEntityType, navigationProperty, targetsMany);
 
                 if ((navSourceRestrictionType?.Referenceable ?? false) ||
                     (navPropRestrictionType?.Referenceable ?? false))
@@ -439,7 +439,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         currentPath.Push(new ODataKeySegment(navEntityType));
                         CreateRefPath(currentPath);
 
-                        CreateTypeCastPaths(currentPath, convertSettings, navigationProperty.DeclaringType, navigationProperty, false); // ~/entityset/{key}/collection-valued-Nav/{id}/subtype
+                        CreateTypeCastPaths(currentPath, convertSettings, navEntityType, navigationProperty, false); // ~/entityset/{key}/collection-valued-Nav/{id}/subtype
                     }
 
                     // Get possible stream paths for the navigation entity type
@@ -456,7 +456,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         currentPath.Push(new ODataKeySegment(navEntityType));
                         AppendPath(currentPath.Clone());
 
-                        CreateTypeCastPaths(currentPath, convertSettings, navigationProperty.DeclaringType, navigationProperty, false); // ~/entityset/{key}/collection-valued-Nav/{id}/subtype
+                        CreateTypeCastPaths(currentPath, convertSettings, navEntityType, navigationProperty, false); // ~/entityset/{key}/collection-valued-Nav/{id}/subtype
                     }
 
                     // Get possible stream paths for the navigation entity type

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -548,10 +548,16 @@ namespace Microsoft.OpenApi.OData.Edm
                                 .OfType<IEdmStructuredType>()
                                 .ToArray();
 
-            foreach(var targetType in targetTypes) 
+            foreach(var targetType in targetTypes)
             {
                 var castPath = currentPath.Clone();
-                castPath.Push(new ODataTypeCastSegment(targetType));
+                var targetTypeSegment = new ODataTypeCastSegment(targetType);
+                if (castPath.Segments.FirstOrDefault(x => x.Identifier.Equals(targetTypeSegment.Identifier)) != null)
+                {
+                    continue;
+                }
+
+                castPath.Push(targetTypeSegment);
                 AppendPath(castPath);
                 if(targetsMany) 
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -552,10 +552,6 @@ namespace Microsoft.OpenApi.OData.Edm
             {
                 var castPath = currentPath.Clone();
                 var targetTypeSegment = new ODataTypeCastSegment(targetType);
-                if (castPath.Segments.FirstOrDefault(x => x.Identifier.Equals(targetTypeSegment.Identifier)) != null)
-                {
-                    continue;
-                }
 
                 castPath.Push(targetTypeSegment);
                 AppendPath(castPath);
@@ -565,10 +561,13 @@ namespace Microsoft.OpenApi.OData.Edm
                 }
                 else
                 {
-                    foreach (var declaredNavigationProperty in targetType.DeclaredNavigationProperties())
+                    if (convertSettings.ExpandDerivedTypesNavigationProperties)
                     {
-                        RetrieveNavigationPropertyPaths(declaredNavigationProperty, null, castPath, convertSettings);
-                    }
+                        foreach (var declaredNavigationProperty in targetType.DeclaredNavigationProperties())
+                        {
+                            RetrieveNavigationPropertyPaths(declaredNavigationProperty, null, castPath, convertSettings);
+                        }
+                    }                        
                 }
             }
         }

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -204,6 +204,11 @@ namespace Microsoft.OpenApi.OData
         public bool RequireDerivedTypesConstraintForODataTypeCastSegments { get; set; } = true;
 
         /// <summary>
+        /// Gets/Sets a value indicating whether or not to expand derived types to retrieve their declared navigation properties.
+        /// </summary>
+        public bool ExpandDerivedTypesNavigationProperties { get; set; } = true;
+
+        /// <summary>
         /// Gets/sets a value indicating whether or not to set the deprecated tag for the operation when a revision is present as well as the "x-ms-deprecation" extension with additional information.
         /// </summary>
         public bool EnableDeprecationInformation { get; set; } = true;
@@ -275,7 +280,8 @@ namespace Microsoft.OpenApi.OData
                 AddEnumDescriptionExtension = this.AddEnumDescriptionExtension,
                 ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
                 InnerErrorComplexTypeName = this.InnerErrorComplexTypeName,
-                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths
+                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths,
+                ExpandDerivedTypesNavigationProperties = this.ExpandDerivedTypesNavigationProperties
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -1,10 +1,12 @@
-﻿abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
+abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetPathItemName(Microsoft.OpenApi.OData.OpenApiConvertSettings settings, System.Collections.Generic.HashSet<string> parameters) -> string
 abstract Microsoft.OpenApi.OData.Edm.ODataSegment.Identifier.get -> string
 abstract Microsoft.OpenApi.OData.Edm.ODataSegment.Kind.get -> Microsoft.OpenApi.OData.Edm.ODataSegmentKind
 abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable>
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
+Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 static Microsoft.OpenApi.OData.Edm.EdmTypeExtensions.ShouldPathParameterBeQuoted(this Microsoft.OData.Edm.IEdmType edmType, Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -102,8 +102,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         [InlineData(true, false, false, 7)]
         [InlineData(false, true, false, 5)]
         [InlineData(false, true, true, 4)]
-        [InlineData(true, true, true, 5)]
-        [InlineData(true, true, false, 5)]
+        [InlineData(true, true, true, 8)]
+        [InlineData(true, true, false, 8)]
         public void GetOperationPathsForModelWithDerivedTypesConstraint(bool addAnnotation, bool getNavPropModel, bool requireConstraint, int expectedCount)
         {
             // Arrange
@@ -122,7 +122,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             Assert.NotNull(paths);
             Assert.Equal(expectedCount, paths.Count());
             var dollarCountPathsWithCastSegment = paths.Where(x => x.Kind == ODataPathKind.DollarCount && x.Any(y => y.Kind == ODataSegmentKind.TypeCast));
-            if(addAnnotation && !getNavPropModel)
+            if(addAnnotation)
               Assert.Single(dollarCountPathsWithCastSegment);
             else
               Assert.Empty(dollarCountPathsWithCastSegment);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -40,7 +40,10 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         {
             // Arrange
             IEdmModel model = EdmModelHelper.GraphBetaModel;
-            var settings = new OpenApiConvertSettings();
+            var settings = new OpenApiConvertSettings()
+            {
+                ExpandDerivedTypesNavigationProperties = false
+            };
             ODataPathProvider provider = new ODataPathProvider();
 
             // Act
@@ -48,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(14621, paths.Count());
+            Assert.Equal(14624, paths.Count());
         }
 
         [Fact]
@@ -59,7 +62,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             ODataPathProvider provider = new ODataPathProvider();
             var settings = new OpenApiConvertSettings
             {
-                RequireDerivedTypesConstraintForBoundOperations = true
+                RequireDerivedTypesConstraintForBoundOperations = true,
+                ExpandDerivedTypesNavigationProperties = false
             };
 
             // Act
@@ -67,7 +71,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(14579, paths.Count());
+            Assert.Equal(14582, paths.Count());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(12261, paths.Count());
+            Assert.Equal(14621, paths.Count());
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(12219, paths.Count());
+            Assert.Equal(14579, paths.Count());
         }
 
         [Fact]
@@ -122,20 +122,18 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             Assert.NotNull(paths);
             Assert.Equal(expectedCount, paths.Count());
             var dollarCountPathsWithCastSegment = paths.Where(x => x.Kind == ODataPathKind.DollarCount && x.Any(y => y.Kind == ODataSegmentKind.TypeCast));
-            if(addAnnotation)
+            if(addAnnotation && !getNavPropModel)
               Assert.Single(dollarCountPathsWithCastSegment);
-            else
-              Assert.Empty(dollarCountPathsWithCastSegment);
         }
         [Theory]
         [InlineData(false, false, true, 4)]
         [InlineData(false, false, false, 7)]
         [InlineData(true, false, true, 7)]
         [InlineData(true, false, false, 7)]
-        [InlineData(false, true, false, 5)]
+        [InlineData(false, true, false, 8)]
         [InlineData(false, true, true, 5)]
-        [InlineData(true, true, true, 5)]
-        [InlineData(true, true, false, 5)]
+        [InlineData(true, true, true, 8)]
+        [InlineData(true, true, false, 8)]
         public void GetTypeCastPathsForModelWithDerivedTypesConstraint(bool addAnnotation, bool getNavPropModel, bool requireConstraint, int expectedCount)
         {
             // Arrange
@@ -154,7 +152,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             Assert.NotNull(paths);
             Assert.Equal(expectedCount, paths.Count());
             var dollarCountPathsWithCastSegment = paths.Where(x => x.Kind == ODataPathKind.DollarCount && x.Any(y => y.Kind == ODataSegmentKind.TypeCast));
-            if((addAnnotation || !requireConstraint) && !getNavPropModel)
+            if(addAnnotation || !requireConstraint)
               Assert.Single(dollarCountPathsWithCastSegment);
             else
               Assert.Empty(dollarCountPathsWithCastSegment);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiLinkGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiLinkGeneratorTests.cs
@@ -22,7 +22,8 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             IEdmModel model = EdmModelHelper.GraphBetaModel;
             OpenApiConvertSettings settings = new()
             {
-                ShowLinks = true
+                ShowLinks = true,
+                ExpandDerivedTypesNavigationProperties = false
             };
             ODataContext context = new(model, settings);
             IEdmSingleton admin = model.EntityContainer.FindSingleton("admin");
@@ -70,7 +71,8 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             IEdmModel model = EdmModelHelper.GraphBetaModel;
             OpenApiConvertSettings settings = new()
             {
-                ShowLinks = true
+                ShowLinks = true,
+                ExpandDerivedTypesNavigationProperties = false
             };
             ODataContext context = new(model, settings);
             IEdmSingleton singleton = model.EntityContainer.FindSingleton("admin");
@@ -137,7 +139,8 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             IEdmModel model = EdmModelHelper.GraphBetaModel;
             OpenApiConvertSettings settings = new()
             {
-                ShowLinks = true
+                ShowLinks = true,
+                ExpandDerivedTypesNavigationProperties = false
             };
             ODataContext context = new(model, settings);
             IEdmSingleton singleton = model.EntityContainer.FindSingleton("admin");
@@ -176,7 +179,8 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             IEdmModel model = EdmModelHelper.GraphBetaModel;
             OpenApiConvertSettings settings = new()
             {
-                ShowLinks = true
+                ShowLinks = true,
+                ExpandDerivedTypesNavigationProperties = false
             };
             ODataContext context = new(model, settings);
             IEdmEntitySet entityset = model.EntityContainer.FindEntitySet("agreements");


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/199

This PR:
- Fixes how OData type cast paths from navigation properties are being generated. The entity type targeting the navigation property is used in the argument in the method `CreateTypeCastPaths()` instead of the entity type declaring the navigation property.
- Updated tests and integration test file due to the above fix.
- Added a new setting `ExpandDerivedTypesNavigationProperties` that can be used to evaluate whether or not to expand derived types navigation properties. When this setting is set to `true`, we end up generating over 219K paths for the beta version of Graph (with a maximum of 1 type cast segment allowed in a path). This is because we have deeply nested derived types in our metadata. This needs to be set to `false` when generating OpenAPI documents for Graph. Trying to limit the  number of type cast segments in a path does not help much. As described above, limiting the number of type cast segments in a path to 1 leads to a path count of over 219K (using the Graph beta integration test file in the test project). All this while ensuring circular generation of type cast segments is avoided and only ensuring unique type cast segments in the path.
- Refactored code in the `Utils.cs` class.