### PR TITLE
Adds support for reading custom attributes

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -151,7 +151,7 @@ namespace Microsoft.OpenApi.OData.Common
 
             foreach (var item in customXMLAttributesMapping)
             {
-                string attributeName = item.Key.Split(':').Last(); // example, ags:IsHidden --> IsHidden
+                string attributeName = item.Key.Split(':').Last(); // example, 'ags:IsHidden' --> 'IsHidden'
                 string extensionName = item.Value;
                 EdmStringConstant customXMLAttribute = model.DirectValueAnnotationsManager.GetDirectValueAnnotations(element)?
                                 .Where(x => x.Name.Equals(attributeName, StringComparison.OrdinalIgnoreCase))?

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -133,7 +133,32 @@ namespace Microsoft.OpenApi.OData.Common
                 || s is ODataStreamContentSegment || s is ODataStreamPropertySegment)).Select(e => e.Identifier));
 
             return navigationPropertyName == null ? value : $"{value}/{navigationPropertyName}";
-        }                
+        }
+
+        /// <summary>
+        /// Attempts to add the specified key and value to the dictionary.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the keys in the dictionary</typeparam>
+        /// <typeparam name="TValue">The type of the values in the dictionary</typeparam>
+        /// <param name="dictionary">A dictionary with keys of type TKey and values of type TValue.</param>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add.</param>
+        /// <returns>true when the key and value are successfully added to the dictionary; 
+        /// false when the dictionary already contains the specified key, 
+        /// in which case nothing gets added.</returns>
+        /// <exception cref="System.ArgumentNullException">dictionary is null.</exception>
+        internal static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary,
+            TKey key, TValue value)
+        {
+            CheckArgumentNull(dictionary, nameof(dictionary));
+
+            if (!dictionary.ContainsKey(key))
+            {
+                dictionary.Add(key, value);
+                return true;
+            }
+            return false;
+        }
 
         /// <summary>
         /// Adds a mapping of custom extension values against custom attribute values for a given element to the provided
@@ -158,10 +183,7 @@ namespace Microsoft.OpenApi.OData.Common
             {
                 foreach (var item in atrributesValueMap)
                 {
-                    if (!extensions.ContainsKey(item.Key))
-                    {
-                        extensions.Add(item.Key, new OpenApiString(item.Value));
-                    }
+                    extensions.TryAdd(item.Key, new OpenApiString(item.Value));
                 }
             }
         }
@@ -194,9 +216,9 @@ namespace Microsoft.OpenApi.OData.Common
                                 .FirstOrDefault()?.Value as EdmStringConstant;
                 string attributeValue = customXMLAttribute?.Value;
 
-                if (!atrributesValueMap.ContainsKey(extensionName) && !string.IsNullOrEmpty(attributeValue))
+                if (!string.IsNullOrEmpty(attributeValue))
                 {
-                    atrributesValueMap.Add(extensionName, attributeValue);
+                    atrributesValueMap.TryAdd(extensionName, attributeValue);
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -327,9 +327,10 @@ namespace Microsoft.OpenApi.OData.Generator
             // structure properties
             foreach (var property in structuredType.DeclaredStructuralProperties())
             {
-                // OpenApiSchema propertySchema = property.Type.CreateSchema();
-                // propertySchema.Default = property.DefaultValueString != null ? new OpenApiString(property.DefaultValueString) : null;
-                properties.Add(property.Name, context.CreatePropertySchema(property));
+                OpenApiSchema propertySchema = context.CreatePropertySchema(property);
+                propertySchema.Description = context.Model.GetDescriptionAnnotation(property);
+                propertySchema.Extensions.AddCustomAtributesToExtensions(context, property);
+                properties.Add(property.Name, propertySchema);
             }
 
             // navigation properties
@@ -337,6 +338,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 OpenApiSchema propertySchema = context.CreateEdmTypeSchema(property.Type);
                 propertySchema.Description = context.Model.GetDescriptionAnnotation(property);
+                propertySchema.Extensions.AddCustomAtributesToExtensions(context, property);
                 properties.Add(property.Name, propertySchema);
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OpenApi.OData
                 ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
                 InnerErrorComplexTypeName = this.InnerErrorComplexTypeName,
                 RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths,
-                ExpandDerivedTypesNavigationProperties = this.ExpandDerivedTypesNavigationProperties
+                ExpandDerivedTypesNavigationProperties = this.ExpandDerivedTypesNavigationProperties,
                 CustomXMLAttributesMapping = this.CustomXMLAttributesMapping
             };
 

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Extensions;
@@ -236,6 +237,11 @@ namespace Microsoft.OpenApi.OData
         /// Gets/Sets a value indicating whether or not to use restrictions annotations to generate paths for complex properties.
         /// </summary>
         public bool RequireRestrictionAnnotationsToGenerateComplexPropertyPaths { get; set; } = true;
+
+        /// <summary>
+        /// Gets/sets a dictionary containing a mapping of custom atttribute names and extension names.
+        /// </summary>
+        public Dictionary<string, string> CustomXMLAttributesMapping { get; set; } = new();
 
         internal OpenApiConvertSettings Clone()
         {

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -281,7 +281,8 @@ namespace Microsoft.OpenApi.OData
                 AddEnumDescriptionExtension = this.AddEnumDescriptionExtension,
                 ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
                 InnerErrorComplexTypeName = this.InnerErrorComplexTypeName,
-                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths
+                RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths,
+                CustomXMLAttributesMapping = this.CustomXMLAttributesMapping
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -65,4 +65,10 @@ internal class ComplexPropertyItemHandler : PathItemHandler
 		ODataComplexPropertySegment navigationSourceSegment = path.LastSegment as ODataComplexPropertySegment;
 		ComplexProperty = navigationSourceSegment.Property;
 	}
+
+	/// <inheritdoc/>
+	protected override void SetExtensions(OpenApiPathItem item)
+	{
+		AddCustomAtributesToPathExtension(item, ComplexProperty);
+	}
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ComplexPropertyItemHandler.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
@@ -69,6 +70,6 @@ internal class ComplexPropertyItemHandler : PathItemHandler
 	/// <inheritdoc/>
 	protected override void SetExtensions(OpenApiPathItem item)
 	{
-		AddCustomAtributesToPathExtension(item, ComplexProperty);
+		item.Extensions.AddCustomAtributesToExtensions(Context, ComplexProperty);
 	}
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
@@ -3,9 +3,15 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.OpenApi.OData.PathItem
 {
@@ -46,6 +52,26 @@ namespace Microsoft.OpenApi.OData.PathItem
             if (delete == null || delete.IsDeletable)
             {
                 AddOperation(item, OperationType.Delete);
+            }
+        }
+
+        protected override void SetExtensions(OpenApiPathItem pathItem)
+        {
+            base.SetExtensions(pathItem);
+
+            // Retrieve custom attributes, if present
+            Dictionary<string, string> atrributesValueMap = 
+                Context.Model.GetCustomXMLAtrributesValueMapping(EntitySet.EntityType(), Context.Settings.CustomXMLAttributesMapping);
+
+            if (atrributesValueMap?.Any() ?? false)
+            {
+                foreach (var item in atrributesValueMap)
+                {
+                    if (!pathItem.Extensions.ContainsKey(item.Key))
+                    {
+                        pathItem.Extensions.Add(item.Key, new OpenApiString(item.Value));
+                    }                    
+                }
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
@@ -54,7 +55,7 @@ namespace Microsoft.OpenApi.OData.PathItem
         protected override void SetExtensions(OpenApiPathItem pathItem)
         {
             base.SetExtensions(pathItem);
-            AddCustomAtributesToPathExtension(pathItem, EntitySet.EntityType());
+            pathItem.Extensions.AddCustomAtributesToExtensions(Context, EntitySet.EntityType());
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
@@ -4,14 +4,9 @@
 // ------------------------------------------------------------
 
 using Microsoft.OData.Edm;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.OpenApi.OData.PathItem
 {
@@ -55,24 +50,11 @@ namespace Microsoft.OpenApi.OData.PathItem
             }
         }
 
+        /// <inheritdoc/>
         protected override void SetExtensions(OpenApiPathItem pathItem)
         {
             base.SetExtensions(pathItem);
-
-            // Retrieve custom attributes, if present
-            Dictionary<string, string> atrributesValueMap = 
-                Context.Model.GetCustomXMLAtrributesValueMapping(EntitySet.EntityType(), Context.Settings.CustomXMLAttributesMapping);
-
-            if (atrributesValueMap?.Any() ?? false)
-            {
-                foreach (var item in atrributesValueMap)
-                {
-                    if (!pathItem.Extensions.ContainsKey(item.Key))
-                    {
-                        pathItem.Extensions.Add(item.Key, new OpenApiString(item.Value));
-                    }                    
-                }
-            }
+            AddCustomAtributesToPathExtension(pathItem, EntitySet.EntityType());
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntitySetPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntitySetPathItemHandler.cs
@@ -4,14 +4,9 @@
 // ------------------------------------------------------------
 
 using Microsoft.OData.Edm;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.OpenApi.OData.PathItem
 {
@@ -60,24 +55,11 @@ namespace Microsoft.OpenApi.OData.PathItem
             pathItem.Description = $"Provides operations to manage the collection of {EntitySet.EntityType().Name} entities.";
         }
 
+        /// <inheritdoc/>
         protected override void SetExtensions(OpenApiPathItem pathItem)
         {
             base.SetExtensions(pathItem);
-
-            // Retrieve custom attributes, if present
-            Dictionary<string, string> atrributesValueMap = 
-                Context.Model.GetCustomXMLAtrributesValueMapping(EntitySet, Context.Settings.CustomXMLAttributesMapping);
-
-            if (atrributesValueMap?.Any() ?? false)
-            {               
-                foreach (var item in atrributesValueMap)
-                {
-                    if (!pathItem.Extensions.ContainsKey(item.Key))
-                    {
-                        pathItem.Extensions.Add(item.Key, new OpenApiString(item.Value));
-                    }
-                }
-            }
+            AddCustomAtributesToPathExtension(pathItem, EntitySet);            
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntitySetPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntitySetPathItemHandler.cs
@@ -4,9 +4,14 @@
 // ------------------------------------------------------------
 
 using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.OpenApi.OData.PathItem
 {
@@ -53,6 +58,26 @@ namespace Microsoft.OpenApi.OData.PathItem
         {
             base.SetBasicInfo(pathItem);
             pathItem.Description = $"Provides operations to manage the collection of {EntitySet.EntityType().Name} entities.";
+        }
+
+        protected override void SetExtensions(OpenApiPathItem pathItem)
+        {
+            base.SetExtensions(pathItem);
+
+            // Retrieve custom attributes, if present
+            Dictionary<string, string> atrributesValueMap = 
+                Context.Model.GetCustomXMLAtrributesValueMapping(EntitySet, Context.Settings.CustomXMLAttributesMapping);
+
+            if (atrributesValueMap?.Any() ?? false)
+            {               
+                foreach (var item in atrributesValueMap)
+                {
+                    if (!pathItem.Extensions.ContainsKey(item.Key))
+                    {
+                        pathItem.Extensions.Add(item.Key, new OpenApiString(item.Value));
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntitySetPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntitySetPathItemHandler.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
@@ -59,7 +60,7 @@ namespace Microsoft.OpenApi.OData.PathItem
         protected override void SetExtensions(OpenApiPathItem pathItem)
         {
             base.SetExtensions(pathItem);
-            AddCustomAtributesToPathExtension(pathItem, EntitySet);            
+            pathItem.Extensions.AddCustomAtributesToExtensions(Context, EntitySet);            
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Collections.Generic;
@@ -243,20 +242,9 @@ namespace Microsoft.OpenApi.OData.PathItem
 
                 item.Extensions.Add(Constants.xMsDosGroupPath, array);
 
-                // Retrieve custom attributes, if present
-                Dictionary<string, string> atrributesValueMap =
-                Context.Model.GetCustomXMLAtrributesValueMapping(NavigationProperty, Context.Settings.CustomXMLAttributesMapping);
+                base.SetExtensions(item);
 
-                if (atrributesValueMap?.Any() ?? false)
-                {
-                    foreach (var kvPair in atrributesValueMap)
-                    {
-                        if (!item.Extensions.ContainsKey(kvPair.Key))
-                        {
-                            item.Extensions.Add(kvPair.Key, new OpenApiString(kvPair.Value));
-                        }
-                    }
-                }
+                AddCustomAtributesToPathExtension(item, NavigationProperty);                               
             }
         }
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -244,7 +244,7 @@ namespace Microsoft.OpenApi.OData.PathItem
 
                 base.SetExtensions(item);
 
-                AddCustomAtributesToPathExtension(item, NavigationProperty);                               
+                item.Extensions.AddCustomAtributesToExtensions(Context, NavigationProperty);
             }
         }
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -240,12 +240,11 @@ namespace Microsoft.OpenApi.OData.PathItem
                     array.Add(new OpenApiString(p.GetPathItemName(settings)));
                 }
 
-                item.Extensions.Add(Constants.xMsDosGroupPath, array);
-
-                base.SetExtensions(item);
-
-                item.Extensions.AddCustomAtributesToExtensions(Context, NavigationProperty);
+                item.Extensions.Add(Constants.xMsDosGroupPath, array);   
             }
+
+            base.SetExtensions(item);
+            item.Extensions.AddCustomAtributesToExtensions(Context, NavigationProperty);
         }
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiPathItem pathItem)

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -242,6 +242,21 @@ namespace Microsoft.OpenApi.OData.PathItem
                 }
 
                 item.Extensions.Add(Constants.xMsDosGroupPath, array);
+
+                // Retrieve custom attributes, if present
+                Dictionary<string, string> atrributesValueMap =
+                Context.Model.GetCustomXMLAtrributesValueMapping(NavigationProperty, Context.Settings.CustomXMLAttributesMapping);
+
+                if (atrributesValueMap?.Any() ?? false)
+                {
+                    foreach (var kvPair in atrributesValueMap)
+                    {
+                        if (!item.Extensions.ContainsKey(kvPair.Key))
+                        {
+                            item.Extensions.Add(kvPair.Key, new OpenApiString(kvPair.Value));
+                        }
+                    }
+                }
             }
         }
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 
 namespace Microsoft.OpenApi.OData.PathItem;
@@ -44,6 +45,6 @@ internal class ODataTypeCastPathItemHandler : PathItemHandler
     protected override void SetExtensions(OpenApiPathItem pathItem)
     {
         base.SetExtensions(pathItem);
-        AddCustomAtributesToPathExtension(pathItem, StructuredType);
+        pathItem.Extensions.AddCustomAtributesToExtensions(Context, StructuredType);
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/ODataTypeCastPathItemHandler.cs
@@ -32,10 +32,18 @@ internal class ODataTypeCastPathItemHandler : PathItemHandler
         }
     }
     private IEdmStructuredType StructuredType { get; set; }
+
     /// <inheritdoc/>
     protected override void SetBasicInfo(OpenApiPathItem pathItem)
     {
         base.SetBasicInfo(pathItem);
         pathItem.Description = $"Casts the previous resource to {(StructuredType as IEdmNamedElement).Name}.";
+    }
+
+    /// <inheritdoc/>
+    protected override void SetExtensions(OpenApiPathItem pathItem)
+    {
+        base.SetExtensions(pathItem);
+        AddCustomAtributesToPathExtension(pathItem, StructuredType);
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationImportPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationImportPathItemHandler.cs
@@ -70,6 +70,7 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// <inheritdoc/>
         protected override void SetExtensions(OpenApiPathItem item)
         {
+            base.SetExtensions(item);
             item.Extensions.AddCustomAtributesToExtensions(Context, EdmOperationImport);
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationImportPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationImportPathItemHandler.cs
@@ -64,5 +64,11 @@ namespace Microsoft.OpenApi.OData.PathItem
             base.SetBasicInfo(pathItem);
             pathItem.Description = $"Provides operations to call the {EdmOperationImport.Name} method.";
         }
+
+        /// <inheritdoc/>
+        protected override void SetExtensions(OpenApiPathItem item)
+        {
+            AddCustomAtributesToPathExtension(item, EdmOperationImport);
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationImportPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationImportPathItemHandler.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
@@ -58,6 +59,7 @@ namespace Microsoft.OpenApi.OData.PathItem
             ODataOperationImportSegment operationImportSegment = path.FirstSegment as ODataOperationImportSegment;
             EdmOperationImport = operationImportSegment.OperationImport;
         }
+
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiPathItem pathItem)
         {
@@ -68,7 +70,7 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// <inheritdoc/>
         protected override void SetExtensions(OpenApiPathItem item)
         {
-            AddCustomAtributesToPathExtension(item, EdmOperationImport);
+            item.Extensions.AddCustomAtributesToExtensions(Context, EdmOperationImport);
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationPathItemHandler.cs
@@ -93,7 +93,10 @@ namespace Microsoft.OpenApi.OData.PathItem
 
                 item.Extensions.Add(Constants.xMsDosGroupPath, array);
             }
+
+            AddCustomAtributesToPathExtension(item, EdmOperation);            
         }
+
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiPathItem pathItem)
         {

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationPathItemHandler.cs
@@ -94,6 +94,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 item.Extensions.Add(Constants.xMsDosGroupPath, array);
             }
 
+            base.SetExtensions(item);
             item.Extensions.AddCustomAtributesToExtensions(Context, EdmOperation);            
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/OperationPathItemHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 item.Extensions.Add(Constants.xMsDosGroupPath, array);
             }
 
-            AddCustomAtributesToPathExtension(item, EdmOperation);            
+            item.Extensions.AddCustomAtributesToExtensions(Context, EdmOperation);            
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
@@ -1,9 +1,13 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -117,6 +121,35 @@ namespace Microsoft.OpenApi.OData.PathItem
             foreach (var parameter in Path.CreatePathParameters(Context))
             {
                 item.Parameters.AppendParameter(parameter);
+            }
+        }
+
+        /// <summary>
+        /// Retrieve custom attributes annotated on the provided element and
+        /// appends their values to the custom extension values provided in the
+        /// CustomXMLAttributesMapping dictionary setting.
+        /// </summary>
+        /// <param name="item">The path item.</param>
+        /// <param name="element">The target element.</param>
+        protected virtual void AddCustomAtributesToPathExtension(OpenApiPathItem item, IEdmElement element)
+        {
+            if (item == null || element == null)
+            {
+                return;
+            }
+
+            Dictionary<string, string> atrributesValueMap =
+                Context.Model.GetCustomXMLAtrributesValueMapping(element, Context.Settings.CustomXMLAttributesMapping);
+
+            if (atrributesValueMap?.Any() ?? false)
+            {
+                foreach (var kvPair in atrributesValueMap)
+                {
+                    if (!item.Extensions.ContainsKey(kvPair.Key))
+                    {
+                        item.Extensions.Add(kvPair.Key, new OpenApiString(kvPair.Value));
+                    }
+                }
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -121,35 +122,6 @@ namespace Microsoft.OpenApi.OData.PathItem
             foreach (var parameter in Path.CreatePathParameters(Context))
             {
                 item.Parameters.AppendParameter(parameter);
-            }
-        }
-
-        /// <summary>
-        /// Retrieve custom attributes annotated on the provided element and
-        /// appends their values to the custom extension values provided in the
-        /// CustomXMLAttributesMapping dictionary setting.
-        /// </summary>
-        /// <param name="item">The path item.</param>
-        /// <param name="element">The target element.</param>
-        protected virtual void AddCustomAtributesToPathExtension(OpenApiPathItem item, IEdmElement element)
-        {
-            if (item == null || element == null)
-            {
-                return;
-            }
-
-            Dictionary<string, string> atrributesValueMap =
-                Context.Model.GetCustomXMLAtrributesValueMapping(element, Context.Settings.CustomXMLAttributesMapping);
-
-            if (atrributesValueMap?.Any() ?? false)
-            {
-                foreach (var kvPair in atrributesValueMap)
-                {
-                    if (!item.Extensions.ContainsKey(kvPair.Key))
-                    {
-                        item.Extensions.Add(kvPair.Key, new OpenApiString(kvPair.Value));
-                    }
-                }
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/SingletonPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/SingletonPathItemHandler.cs
@@ -49,11 +49,19 @@ namespace Microsoft.OpenApi.OData.PathItem
             ODataNavigationSourceSegment navigationSourceSegment = path.FirstSegment as ODataNavigationSourceSegment;
             Singleton = navigationSourceSegment.NavigationSource as IEdmSingleton;
         }
+
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiPathItem pathItem)
         {
             base.SetBasicInfo(pathItem);
             pathItem.Description = $"Provides operations to manage the {Singleton.EntityType().Name} singleton.";
+        }
+
+        /// <inheritdoc/>
+        protected override void SetExtensions(OpenApiPathItem pathItem)
+        {
+            base.SetExtensions(pathItem);
+            AddCustomAtributesToPathExtension(pathItem, Singleton);            
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/SingletonPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/SingletonPathItemHandler.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
@@ -61,7 +62,7 @@ namespace Microsoft.OpenApi.OData.PathItem
         protected override void SetExtensions(OpenApiPathItem pathItem)
         {
             base.SetExtensions(pathItem);
-            AddCustomAtributesToPathExtension(pathItem, Singleton);            
+            pathItem.Extensions.AddCustomAtributesToExtensions(Context, Singleton);            
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
+Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>
+Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 static Microsoft.OpenApi.OData.Edm.EdmTypeExtensions.ShouldPathParameterBeQuoted(this Microsoft.OData.Edm.IEdmType edmType, Microsoft.OpenApi.OData.OpenApiConvertSettings settings) -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -127,6 +127,70 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Fact]
+        public void CreateStructuredTypePropertiesSchemaWithCustomAttributeReturnsCorrectSchema()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model);
+            context.Settings.CustomXMLAttributesMapping.Add("IsHidden", "x-ms-isHidden");
+            IEdmEntityType entity = model.SchemaElements.OfType<IEdmEntityType>().First(t => t.Name == "userSettings");
+            Assert.NotNull(entity); // Guard
+
+            // Act
+            OpenApiSchema schema = context.CreateStructuredTypeSchema(entity);
+            string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            Assert.NotNull(json);
+            Assert.Equal(@"{
+  ""allOf"": [
+    {
+      ""$ref"": ""#/components/schemas/microsoft.graph.entity""
+    },
+    {
+      ""title"": ""userSettings"",
+      ""type"": ""object"",
+      ""properties"": {
+        ""contributionToContentDiscoveryAsOrganizationDisabled"": {
+          ""type"": ""boolean"",
+          ""x-ms-isHidden"": ""true""
+        },
+        ""contributionToContentDiscoveryDisabled"": {
+          ""type"": ""boolean"",
+          ""x-ms-isHidden"": ""true""
+        },
+        ""itemInsights"": {
+          ""anyOf"": [
+            {
+              ""$ref"": ""#/components/schemas/microsoft.graph.userInsightsSettings""
+            }
+          ],
+          ""nullable"": true,
+          ""x-ms-isHidden"": ""true""
+        },
+        ""regionalAndLanguageSettings"": {
+          ""anyOf"": [
+            {
+              ""$ref"": ""#/components/schemas/microsoft.graph.regionalAndLanguageSettings""
+            }
+          ],
+          ""nullable"": true
+        },
+        ""shiftPreferences"": {
+          ""anyOf"": [
+            {
+              ""$ref"": ""#/components/schemas/microsoft.graph.shiftPreferences""
+            }
+          ],
+          ""nullable"": true
+        }
+      }
+    }
+  ]
+}".ChangeLineBreaks(), json);
+        }
+
+        [Fact]
         public void CreateComplexTypeWithoutBaseSchemaReturnCorrectSchema()
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -183,7 +183,7 @@ public class ComplexPropertyPathItemHandlerTests
 		}		
 	}
 	[Fact]
-	private void CreateComplexPropertyPathItemAddsCustomAttributeValuesToPathExtension()
+	public void CreateComplexPropertyPathItemAddsCustomAttributeValuesToPathExtensions()
     {
 		// Arrange
 		var model = EntitySetPathItemHandlerTests.GetEdmModel("");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ComplexPropertyPathItemHandlerTests.cs
@@ -5,6 +5,8 @@
 
 using System;
 using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Xunit;
@@ -179,5 +181,30 @@ public class ComplexPropertyPathItemHandlerTests
         {
 			Assert.False(pathItem.Operations.ContainsKey(OperationType.Post));
 		}		
+	}
+	[Fact]
+	private void CreateComplexPropertyPathItemAddsCustomAttributeValuesToPathExtension()
+    {
+		// Arrange
+		var model = EntitySetPathItemHandlerTests.GetEdmModel("");
+		ODataContext context = new(model);
+		context.Settings.CustomXMLAttributesMapping.Add("ags:IsHidden", "x-ms-isHidden");
+		var entitySet = model.EntityContainer.FindEntitySet("Customers");
+		Assert.NotNull(entitySet); // guard
+		var entityType = entitySet.EntityType();
+		var property = entityType.FindProperty("AlternativeAddresses");
+		Assert.NotNull(property); // guard
+		var path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entityType), new ODataComplexPropertySegment(property as IEdmStructuralProperty));
+        Assert.Equal(ODataPathKind.ComplexProperty, path.Kind); // guard
+
+        // Act
+        var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+		// Assert
+		Assert.NotNull(pathItem.Extensions);
+
+		pathItem.Extensions.TryGetValue("x-ms-isHidden", out IOpenApiExtension isHiddenExtension);
+		string isHiddenValue = (isHiddenExtension as OpenApiString)?.Value;
+		Assert.Equal("true", isHiddenValue);
 	}
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Any;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
@@ -4,8 +4,11 @@
 // ------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Properties;
@@ -250,6 +253,41 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             Assert.NotNull(pathItem.Operations);
             Assert.NotEmpty(pathItem.Operations);
             Assert.Equal(expected, pathItem.Operations.Select(e => e.Key));
+        }
+
+        [Fact]
+        private void CreateEntityPathItemAddsCustomAttributeValuesToPathExtension()
+        {
+            // Arrange
+            IEdmModel model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: "");
+            ODataContext context = new(model);
+            context.Settings.CustomXMLAttributesMapping = new()
+            {
+                {
+                    "ags:IsHidden", "x-ms-isHidden"
+                },
+                {
+                    "isOwner", "x-ms-isOwner"
+                }
+            };
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(entitySet); // guard
+            ODataPath path = new(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()));
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+            Assert.NotNull(pathItem.Extensions);
+
+            pathItem.Extensions.TryGetValue("x-ms-isHidden", out IOpenApiExtension isHiddenExtension);
+            string isHiddenValue = (isHiddenExtension as OpenApiString)?.Value;
+            Assert.Equal("true", isHiddenValue);
+
+            pathItem.Extensions.TryGetValue("x-ms-isOwner", out IOpenApiExtension isOwnerExtension);
+            string isOwnerValue = (isOwnerExtension as OpenApiString)?.Value;
+            Assert.Equal("true", isOwnerValue);
         }
     }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Fact]
-        private void CreateEntityPathItemAddsCustomAttributeValuesToPathExtension()
+        public void CreateEntityPathItemAddsCustomAttributeValuesToPathExtensions()
         {
             // Arrange
             IEdmModel model = EntitySetPathItemHandlerTests.GetEdmModel(annotation: "");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         {
             const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" xmlns:ags=""http://aggregator.microsoft.com/internal"">
   <edmx:DataServices>
-    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"" xmlns:ags=""http://aggregator.microsoft.com/internal"">
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
       <ComplexType Name=""Address"">
         <Property Name=""City"" Type=""Edm.String"" />
       </ComplexType>
@@ -192,7 +192,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
         <Property Name=""BillingAddress"" Type=""NS.Address"" />
         <Property Name=""MailingAddress"" Type=""NS.Address"" Nullable=""false"" />
-        <Property Name=""AlternativeAddresses"" Type=""Collection(NS.Address)"" Nullable=""false"" />
+        <Property Name=""AlternativeAddresses"" Type=""Collection(NS.Address)"" Nullable=""false"" ags:IsHidden=""true""/>
       </EntityType>
       <EntityContainer Name =""Default"">
          <EntitySet Name=""Customers"" EntityType=""NS.Customer"" ags:IsHidden=""true""/>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Validation;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Properties;
@@ -153,15 +154,38 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             Assert.Equal(expected, pathItem.Operations.Select(e => e.Key));
         }
 
-        public static IEdmModel GetEdmModel(string annotation, string target = "\"NS.Default/Customers\"")
+        [Fact]
+        private void CreateEntitySetPathItemAddsCustomAttributeValuesToPathExtension()
         {
-            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+            // Arrange
+            IEdmModel model = GetEdmModel(annotation: "");
+            ODataContext context = new(model);
+            context.Settings.CustomXMLAttributesMapping.Add("ags:IsHidden", "x-ms-isHidden");
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Customers");
+            Assert.NotNull(entitySet); // guard
+            ODataPath path = new(new ODataNavigationSourceSegment(entitySet));
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+            Assert.NotNull(pathItem.Extensions);
+
+            pathItem.Extensions.TryGetValue("x-ms-isHidden", out var value);
+            string isHiddenValue = (value as OpenApiString)?.Value;
+            Assert.Equal("true", isHiddenValue);
+        }
+
+        public static IEdmModel GetEdmModel(string annotation, string target = "\"NS.Default/Customers\"", string customXMLAttribute = null)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" xmlns:ags=""http://aggregator.microsoft.com/internal"">
   <edmx:DataServices>
-    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"" xmlns:ags=""http://aggregator.microsoft.com/internal"">
       <ComplexType Name=""Address"">
         <Property Name=""City"" Type=""Edm.String"" />
       </ComplexType>
-      <EntityType Name=""Customer"">
+      <EntityType Name=""Customer"" ags:IsOwner=""true"" ags:IsHidden=""true"">
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
@@ -171,7 +195,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         <Property Name=""AlternativeAddresses"" Type=""Collection(NS.Address)"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
-         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" ags:IsHidden=""true""/>
       </EntityContainer>
       <Annotations Target={0}>
         {1}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntitySetPathItemHandlerTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Fact]
-        private void CreateEntitySetPathItemAddsCustomAttributeValuesToPathExtension()
+        public void CreateEntitySetPathItemAddsCustomAttributeValuesToPathExtensions()
         {
             // Arrange
             IEdmModel model = GetEdmModel(annotation: "");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/NavigationPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/NavigationPropertyPathItemHandlerTests.cs
@@ -403,31 +403,8 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
                 expected = new[] { OperationType.Get };
             }
 
-            //if (!isContainment || hasRestrictions)
-            //{
-            //    if (isCollection)
-            //    {
-            //        expected = new[] { OperationType.Get };
-            //    }
-            //    else
-            //    {
-            //        expected = new[] { OperationType.Get, OperationType.Delete };
-            //    }
-            //}
-            //else
-            //{
-            //    if (isCollection)
-            //    {
-            //        expected = new[] { OperationType.Get, OperationType.Patch };
-            //    }
-            //    else
-            //    {
-            //        expected = new[] { OperationType.Get, OperationType.Patch, OperationType.Delete };
-            //    }
-            //}
-
             Assert.Equal(expected, pathItem.Operations.Select(o => o.Key));
-        }       
+        }
 
         [Theory]
         [MemberData(nameof(CollectionNavigationPropertyData))]
@@ -495,7 +472,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Fact]
-        private void CreateNavigationPropertyPathItemAddsCustomAttributeValuesToPathExtension()
+        public void CreateNavigationPropertyPathItemAddsCustomAttributeValuesToPathExtensions()
         {
             // Arrange
             IEdmModel model = GetEdmModel(annotation: "");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/NavigationPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/NavigationPropertyPathItemHandlerTests.cs
@@ -521,7 +521,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         {
             const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" xmlns:ags=""http://aggregator.microsoft.com/internal"">
   <edmx:DataServices>
-    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"" xmlns:ags=""http://aggregator.microsoft.com/internal"">
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
       <EntityType Name=""Customer"">
         <Key>
           <PropertyRef Name=""ID"" />

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
@@ -1,0 +1,65 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Tests;
+using Microsoft.OpenApi.OData.Edm;
+using System.Linq;
+using Xunit;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Any;
+
+namespace Microsoft.OpenApi.OData.PathItem.Tests
+{
+    public class ODataTypeCastPathItemHandlerTests
+    {
+        private ODataTypeCastPathItemHandler _pathItemHandler = new();
+
+        [Fact]
+        private void CreateODataTypeCastPathItemAddsCustomAttributeValuesToPathExtension()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.TripServiceModel;
+            ODataContext context = new(model);
+            context.Settings.CustomXMLAttributesMapping = new()
+            {
+                {
+                    "ags:IsHidden",
+                    "x-ms-isHidden"
+                },
+                {
+                    "WorkloadName",
+                    "x-ms-workloadName"
+                }
+            };
+            
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
+
+            IEdmEntityType person = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Person");
+            IEdmEntityType employee = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Employee");
+            IEdmNavigationProperty navProperty = person.DeclaredNavigationProperties().First(c => c.Name == "Friends");
+            ODataPath path = new(new ODataNavigationSourceSegment(people),
+                                                                    new ODataKeySegment(people.EntityType()),
+                                                                    new ODataNavigationPropertySegment(navProperty),
+                                                                    new ODataTypeCastSegment(employee));
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+            Assert.NotNull(pathItem.Extensions);
+
+            pathItem.Extensions.TryGetValue("x-ms-isHidden", out IOpenApiExtension isHiddenExtension);
+            string isHiddenValue = (isHiddenExtension as OpenApiString)?.Value;
+            Assert.Equal("true", isHiddenValue);
+
+            pathItem.Extensions.TryGetValue("x-ms-workloadName", out IOpenApiExtension isOwnerExtension);
+            string isOwnerValue = (isOwnerExtension as OpenApiString)?.Value;
+            Assert.Equal("People", isOwnerValue);
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         private readonly ODataTypeCastPathItemHandler _pathItemHandler = new();
 
         [Fact]
-        private void CreateODataTypeCastPathItemAddsCustomAttributeValuesToPathExtension()
+        public void CreateODataTypeCastPathItemAddsCustomAttributeValuesToPathExtensions()
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
 {
     public class ODataTypeCastPathItemHandlerTests
     {
-        private ODataTypeCastPathItemHandler _pathItemHandler = new();
+        private readonly ODataTypeCastPathItemHandler _pathItemHandler = new();
 
         [Fact]
         private void CreateODataTypeCastPathItemAddsCustomAttributeValuesToPathExtension()

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationImportPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationImportPathItemHandlerTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         [Theory]
         [InlineData("GetNearestAirport")]
         [InlineData("ResetDataSource")]
-        private void CreateOperationImportPathItemAddsCustomAttributeValuesToPathExtension(string operationImport)
+        public void CreateOperationImportPathItemAddsCustomAttributeValuesToPathExtensions(string operationImport)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationImportPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationImportPathItemHandlerTests.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Xml.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Properties;
@@ -120,6 +122,32 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
                 Assert.Equal(operationType, operationKeyValue.Key);
                 Assert.NotNull(operationKeyValue.Value);
             }
+        }
+
+        [Theory]
+        [InlineData("GetNearestAirport")]
+        [InlineData("ResetDataSource")]
+        private void CreateOperationImportPathItemAddsCustomAttributeValuesToPathExtension(string operationImport)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.TripServiceModel;
+            ODataContext context = new(model);
+            context.Settings.CustomXMLAttributesMapping.Add("ags:IsHidden", "x-ms-isHidden");
+            IEdmOperationImport edmOperationImport = model.EntityContainer
+                .OperationImports().FirstOrDefault(o => o.Name == operationImport);
+            Assert.NotNull(edmOperationImport); // guard
+            ODataPath path = new(new ODataOperationImportSegment(edmOperationImport));
+
+            // Act
+            OpenApiPathItem pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+            Assert.NotNull(pathItem.Extensions);
+
+            pathItem.Extensions.TryGetValue("x-ms-isHidden", out IOpenApiExtension isHiddenExtension);
+            string isHiddenValue = (isHiddenExtension as OpenApiString)?.Value;
+            Assert.Equal("true", isHiddenValue);
         }
 
         public static IEdmModel GetEdmModel(string annotation)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationPathItemHandlerTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         [Theory]
         [InlineData("GetFriendsTrips")]
         [InlineData("ShareTrip")]
-        private void CreateOperationPathItemAddsCustomAttributeValuesToPathExtension(string operationName)
+        public void CreateOperationPathItemAddsCustomAttributeValuesToPathExtensions(string operationName)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/OperationPathItemHandlerTests.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Properties;
@@ -83,6 +85,48 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
 
             Assert.Equal(expectSummary, operationKeyValue.Value.Summary);
             Assert.NotEmpty(pathItem.Description);
+        }
+
+        [Theory]
+        [InlineData("GetFriendsTrips")]
+        [InlineData("ShareTrip")]
+        private void CreateOperationPathItemAddsCustomAttributeValuesToPathExtension(string operationName)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.TripServiceModel;
+            ODataContext context = new(model);
+            context.Settings.CustomXMLAttributesMapping = new()
+            {
+                {
+                    "ags:IsHidden",
+                    "x-ms-isHidden"
+                },
+                {
+                    "WorkloadName",
+                    "x-ms-workloadName"
+                }
+            };
+            IEdmNavigationSource navigationSource = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(navigationSource); // guard
+            IEdmOperation edmOperation = model.SchemaElements.OfType<IEdmOperation>()
+                .FirstOrDefault(o => o.Name == operationName);
+            Assert.NotNull(edmOperation); // guard
+            ODataPath path = new(new ODataNavigationSourceSegment(navigationSource), new ODataOperationSegment(edmOperation));
+
+            // Act
+            OpenApiPathItem pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+            Assert.NotNull(pathItem.Extensions);
+
+            pathItem.Extensions.TryGetValue("x-ms-isHidden", out IOpenApiExtension isHiddenExtension);
+            string isHiddenValue = (isHiddenExtension as OpenApiString)?.Value;
+            Assert.Equal("true", isHiddenValue);
+
+            pathItem.Extensions.TryGetValue("x-ms-workloadName", out IOpenApiExtension isOwnerExtension);
+            string isOwnerValue = (isOwnerExtension as OpenApiString)?.Value;
+            Assert.Equal("People", isOwnerValue);
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/SingletonPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/SingletonPathItemHandlerTests.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Validation;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Properties;
@@ -134,9 +135,32 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             Assert.Equal(expected, pathItem.Operations.Select(e => e.Key));
         }
 
+        [Fact]
+        private void CreateSingletonPathItemAddsCustomAttributeValuesToPathExtension()
+        {
+            // Arrange
+            IEdmModel model = GetEdmModel(annotation: "");
+            ODataContext context = new(model);
+            context.Settings.CustomXMLAttributesMapping.Add("IsHidden", "x-ms-isHidden");
+            IEdmSingleton singleton = model.EntityContainer.FindSingleton("Me");
+            Assert.NotNull(singleton); // guard
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(singleton));
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+            Assert.NotNull(pathItem.Extensions);
+
+            pathItem.Extensions.TryGetValue("x-ms-isHidden", out var value);
+            string isHiddenValue = (value as OpenApiString)?.Value;
+            Assert.Equal("true", isHiddenValue);
+        }
+
         private IEdmModel GetEdmModel(string annotation)
         {
-            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" xmlns:ags=""http://aggregator.microsoft.com/internal"">
   <edmx:DataServices>
     <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
       <EntityType Name=""Customer"">
@@ -146,7 +170,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
       </EntityType>
       <EntityContainer Name =""Default"">
-         <Singleton Name=""Me"" Type=""NS.Customer"" />
+         <Singleton Name=""Me"" Type=""NS.Customer"" ags:IsHidden=""true""/>
       </EntityContainer>
       <Annotations Target=""NS.Default/Me"">
         {0}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/SingletonPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/SingletonPathItemHandlerTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Fact]
-        private void CreateSingletonPathItemAddsCustomAttributeValuesToPathExtension()
+        public void CreateSingletonPathItemAddsCustomAttributeValuesToPathExtensions()
         {
             // Arrange
             IEdmModel model = GetEdmModel(annotation: "");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -215,7 +215,7 @@
         <NavigationProperty Name="From" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
         <NavigationProperty Name="To" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
       </EntityType>
-      <EntityType Name="Employee" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+      <EntityType Name="Employee" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" ags:IsHidden="true" ags:WorkloadName="People">
         <Property Name="Cost" Type="Edm.Int64" Nullable="false" />
         <NavigationProperty Name="Peers" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" >
 			<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
-  <edmx:DataServices>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" xmlns:ags="http://aggregator.microsoft.com/internal">
+<edmx:DataServices>
     <Schema Namespace="Microsoft.OData.Service.Sample.TrippinInMemory.Models" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <ComplexType Name="InnerError">
         <Property Name="Date" Type="Edm.DateTimeOffset" />
@@ -266,7 +266,7 @@
         <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
       </Function>
-      <Function Name="GetFriendsTrips" IsBound="true">
+      <Function Name="GetFriendsTrips" IsBound="true" ags:IsHidden="true" ags:WorkloadName="People">
         <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
         <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" />
@@ -299,7 +299,7 @@
         <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager" />
         <Parameter Name="hire" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
       </Action>
-      <Action Name="ShareTrip" IsBound="true">
+      <Action Name="ShareTrip" IsBound="true" ags:IsHidden="true" ags:WorkloadName="People">
         <Annotation Term="Org.OData.Core.V1.Description" String="Details of the shared trip." />
         <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
         <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
@@ -379,8 +379,8 @@
         <FunctionImport Name="GetPersonWithMostFriends" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPersonWithMostFriends" EntitySet="People">
           <Annotation Term="Org.OData.Core.V1.Description" String="The person with most friends." />
         </FunctionImport>
-        <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetNearestAirport" EntitySet="Airports" />
-        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.Service.Sample.TrippinInMemory.Models.ResetDataSource">
+        <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetNearestAirport" EntitySet="Airports" ags:IsHidden="true"/>
+        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.Service.Sample.TrippinInMemory.Models.ResetDataSource" ags:IsHidden="true">
           <Annotation Term="Org.OData.Core.V1.Description" String="Resets the data source to default values." />
         </ActionImport>
       </EntityContainer>


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/192

This PR:
- Provides a means of reading custom attribute values from the CSDL through the setting `CustomXMLAttributesMapping`, which a client can use to provide a dictionary mapping of custom attribute names and extension names. The values of these custom attribute names will be extracted from the Edm model from an element if it contains the custom attribute. The values will then be mapped to the custom extension values provided in the dictionary and added to the relevant extensions object in the OpenAPI document.
- Tests have been added (and integration files updated) to validate the above.