### PR TITLE
Include correct list of discriminator information

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -436,23 +436,26 @@ namespace Microsoft.OpenApi.OData.Generator
                 // The discriminator object is added to structured types which have derived types.
                 OpenApiDiscriminator discriminator = null;
                 if (context.Settings.EnableDiscriminatorValue && derivedTypes.Any() && structuredType.BaseType != null)
-                {
-                    string v3RefIdentifier = new OpenApiSchema
+                {                 
+                    Dictionary<string, string> mapping = new();
+                    foreach (var item in derivedTypes)
                     {
-                        Reference = new OpenApiReference
+                        string v3RefIdentifier = new OpenApiSchema
                         {
-                            Type = ReferenceType.Schema,
-                            Id = structuredType.FullTypeName()
-                        }
-                    }.Reference.ReferenceV3;
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = item.FullTypeName()
+                            }
+                        }.Reference.ReferenceV3;
+
+                        mapping.Add("#" + item.FullTypeName(), v3RefIdentifier);
+                    }
 
                     discriminator = new OpenApiDiscriminator
                     {
                         PropertyName = "@odata.type",
-                        Mapping = new Dictionary<string, string>
-                        {
-                            {"#" + structuredType.FullTypeName(), v3RefIdentifier }
-                        }
+                        Mapping = mapping
                     };
                 }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -436,21 +436,16 @@ namespace Microsoft.OpenApi.OData.Generator
                 // The discriminator object is added to structured types which have derived types.
                 OpenApiDiscriminator discriminator = null;
                 if (context.Settings.EnableDiscriminatorValue && derivedTypes.Any() && structuredType.BaseType != null)
-                {                 
-                    Dictionary<string, string> mapping = new();
-                    foreach (var item in derivedTypes)
-                    {
-                        string v3RefIdentifier = new OpenApiSchema
+                {         
+                    Dictionary<string, string> mapping = derivedTypes
+                        .ToDictionary(x => $"#{x.FullTypeName()}", x => new OpenApiSchema
                         {
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.Schema,
-                                Id = item.FullTypeName()
+                                Id = x.FullTypeName()
                             }
-                        }.Reference.ReferenceV3;
-
-                        mapping.Add("#" + item.FullTypeName(), v3RefIdentifier);
-                    }
+                        }.Reference.ReferenceV3);
 
                     discriminator = new OpenApiDiscriminator
                     {

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,27 +15,13 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.0.10-preview3</Version>
+    <Version>1.0.11-preview1</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-- Adds path items for properties of complex type. #176, #15
-- Describes errors on error response codes instead of default. #172, #165, #193
-- Fixes a bug where reference objects are not created correctly. #171
-- Adds support for enum values descriptions. #164
-- Declares path parameters on path item instead of operation. #159
-- Multiple fixes on navigation properties path items expansion. #151, #123
-- Multiple fixes for descriptions. #154
-- Fixes a bug where URL templates would be missing quotes for string parameters. #140
-- Fixes description of operations of primitive types. #126
-- Adds support for OData cast segments in path items generation. #123
-- Fixes the response descriptions for functions that return a collection. #122
-- Fixes structured and collection-valued parameters of functions. #203
-- Adds support for discriminator property in inheritance. #118
-- Sets deprecated for operations that are generated from deprecated types/singletons/entitysets/properties in the model. #113
-- Aligns target version to netframework2.0. #139
+- Adds list of all derived types for discriminator mapping #219
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -118,7 +118,23 @@ namespace Microsoft.OpenApi.OData.Tests
       ""discriminator"": {
         ""propertyName"": ""@odata.type"",
         ""mapping"": {
-          ""#microsoft.graph.directoryObject"": ""#/components/schemas/microsoft.graph.directoryObject""
+          ""#microsoft.graph.user"": ""#/components/schemas/microsoft.graph.user"",
+          ""#microsoft.graph.group"": ""#/components/schemas/microsoft.graph.group"",
+          ""#microsoft.graph.device"": ""#/components/schemas/microsoft.graph.device"",
+          ""#microsoft.graph.application"": ""#/components/schemas/microsoft.graph.application"",
+          ""#microsoft.graph.servicePrincipal"": ""#/components/schemas/microsoft.graph.servicePrincipal"",
+          ""#microsoft.graph.policyBase"": ""#/components/schemas/microsoft.graph.policyBase"",
+          ""#microsoft.graph.extensionProperty"": ""#/components/schemas/microsoft.graph.extensionProperty"",
+          ""#microsoft.graph.endpoint"": ""#/components/schemas/microsoft.graph.endpoint"",
+          ""#microsoft.graph.resourceSpecificPermissionGrant"": ""#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant"",
+          ""#microsoft.graph.administrativeUnit"": ""#/components/schemas/microsoft.graph.administrativeUnit"",
+          ""#microsoft.graph.contract"": ""#/components/schemas/microsoft.graph.contract"",
+          ""#microsoft.graph.directoryObjectPartnerReference"": ""#/components/schemas/microsoft.graph.directoryObjectPartnerReference"",
+          ""#microsoft.graph.directoryRole"": ""#/components/schemas/microsoft.graph.directoryRole"",
+          ""#microsoft.graph.directoryRoleTemplate"": ""#/components/schemas/microsoft.graph.directoryRoleTemplate"",
+          ""#microsoft.graph.directorySettingTemplate"": ""#/components/schemas/microsoft.graph.directorySettingTemplate"",
+          ""#microsoft.graph.organization"": ""#/components/schemas/microsoft.graph.organization"",
+          ""#microsoft.graph.orgContact"": ""#/components/schemas/microsoft.graph.orgContact""
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/219

Retrieve list of derived types for structured types and adds it to the mapping property of the discriminator object.