### PR TITLE
Fixes reading restriction annotations for entity types defining navigation properties

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
@@ -18,39 +18,23 @@ namespace Microsoft.OpenApi.OData.PathItem
     {
         /// <inheritdoc/>
         protected override ODataPathKind HandleKind => ODataPathKind.Entity;
-        private IEdmEntityType _entityType;
-
-        protected override void Initialize(ODataContext context, ODataPath path)
-        {
-            base.Initialize(context, path);
-            _entityType = EntitySet.EntityType();            
-        }
 
         /// <inheritdoc/>
         protected override void SetOperations(OpenApiPathItem item)
         {
             ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet);
-            ReadRestrictionsType readEntity = Context.Model.GetRecord<ReadRestrictionsType>(_entityType);
-
-            bool isReadable = (read == null) || readEntity == null;
-
-            if (isReadable ||
+            if (read == null ||
                (read.ReadByKeyRestrictions == null && read.IsReadable) ||
-               (read.ReadByKeyRestrictions != null && read.ReadByKeyRestrictions.IsReadable) ||
-               readEntity.IsReadable)
+               (read.ReadByKeyRestrictions != null && read.ReadByKeyRestrictions.IsReadable))
             {
                 // If we don't have Read by key read restriction, we should check the set read restrction.
                 AddOperation(item, OperationType.Get);
             }
 
             UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet);
-            UpdateRestrictionsType updateEntity = Context.Model.GetRecord<UpdateRestrictionsType>(_entityType);
-            bool isUpdatable = (update != null) ? update.IsUpdatable : (updateEntity == null || updateEntity.IsUpdatable);
-            
-            if (isUpdatable)
+            if (update == null || update.IsUpdatable)
             {
-                if ((update?.IsUpdateMethodPut ?? false) ||
-                    (updateEntity?.IsUpdateMethodPut ?? false))
+                if (update != null && update.IsUpdateMethodPut)
                 {
                     AddOperation(item, OperationType.Put);
                 }
@@ -61,10 +45,7 @@ namespace Microsoft.OpenApi.OData.PathItem
             }
 
             DeleteRestrictionsType delete = Context.Model.GetRecord<DeleteRestrictionsType>(EntitySet);
-            DeleteRestrictionsType deleteEntity = Context.Model.GetRecord<DeleteRestrictionsType>(_entityType);
-            bool isDeletable = (delete != null) ? delete.IsDeletable : (deleteEntity == null || deleteEntity.IsDeletable);
-
-            if (isDeletable)
+            if (delete == null || delete.IsDeletable)
             {
                 AddOperation(item, OperationType.Delete);
             }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/EntityPathItemHandler.cs
@@ -18,23 +18,39 @@ namespace Microsoft.OpenApi.OData.PathItem
     {
         /// <inheritdoc/>
         protected override ODataPathKind HandleKind => ODataPathKind.Entity;
+        private IEdmEntityType _entityType;
+
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _entityType = EntitySet.EntityType();            
+        }
 
         /// <inheritdoc/>
         protected override void SetOperations(OpenApiPathItem item)
         {
             ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet);
-            if (read == null ||
+            ReadRestrictionsType readEntity = Context.Model.GetRecord<ReadRestrictionsType>(_entityType);
+
+            bool isReadable = (read == null) || readEntity == null;
+
+            if (isReadable ||
                (read.ReadByKeyRestrictions == null && read.IsReadable) ||
-               (read.ReadByKeyRestrictions != null && read.ReadByKeyRestrictions.IsReadable))
+               (read.ReadByKeyRestrictions != null && read.ReadByKeyRestrictions.IsReadable) ||
+               readEntity.IsReadable)
             {
                 // If we don't have Read by key read restriction, we should check the set read restrction.
                 AddOperation(item, OperationType.Get);
             }
 
             UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet);
-            if (update == null || update.IsUpdatable)
+            UpdateRestrictionsType updateEntity = Context.Model.GetRecord<UpdateRestrictionsType>(_entityType);
+            bool isUpdatable = (update != null) ? update.IsUpdatable : (updateEntity == null || updateEntity.IsUpdatable);
+            
+            if (isUpdatable)
             {
-                if (update != null && update.IsUpdateMethodPut)
+                if ((update?.IsUpdateMethodPut ?? false) ||
+                    (updateEntity?.IsUpdateMethodPut ?? false))
                 {
                     AddOperation(item, OperationType.Put);
                 }
@@ -45,7 +61,10 @@ namespace Microsoft.OpenApi.OData.PathItem
             }
 
             DeleteRestrictionsType delete = Context.Model.GetRecord<DeleteRestrictionsType>(EntitySet);
-            if (delete == null || delete.IsDeletable)
+            DeleteRestrictionsType deleteEntity = Context.Model.GetRecord<DeleteRestrictionsType>(_entityType);
+            bool isDeletable = (delete != null) ? delete.IsDeletable : (deleteEntity == null || deleteEntity.IsDeletable);
+
+            if (isDeletable)
             {
                 AddOperation(item, OperationType.Delete);
             }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -163,11 +163,16 @@ namespace Microsoft.OpenApi.OData.PathItem
 
             DeleteRestrictionsType delete = restriction?.DeleteRestrictions;
             DeleteRestrictionsType deleteEntity = Context.Model.GetRecord<DeleteRestrictionsType>(_entityType);
-            bool isDeletable = (delete?.IsDeletable ?? true) || (deleteEntity?.IsDeletable ?? true);
+            bool isDeletableDefault = delete == null && deleteEntity == null;
 
-            if (isDeletable)
+            if (isDeletableDefault ||
+               (delete?.IsDeletable ?? false) ||
+               (deleteEntity?.IsDeletable ?? false))
             {
-                AddOperation(item, OperationType.Delete);
+                if (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment)
+                {
+                    AddOperation(item, OperationType.Delete);
+                }
                 return;
             }
         }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -44,8 +44,10 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// </summary>
         protected bool LastSegmentIsRefSegment { get; private set; }
 
-		/// <inheritdoc/>
-		protected override void SetOperations(OpenApiPathItem item)
+        private IEdmEntityType _entityType;
+
+        /// <inheritdoc/>
+        protected override void SetOperations(OpenApiPathItem item)
         {
             IEdmEntitySet entitySet = NavigationSource as IEdmEntitySet;
             IEdmVocabularyAnnotatable target = entitySet;
@@ -78,12 +80,16 @@ namespace Microsoft.OpenApi.OData.PathItem
                 {
                     if (LastSegmentIsKeySegment)
                     {
-                        AddUpdateOperation(item, restriction);
+                        UpdateRestrictionsType updateEntity = Context.Model.GetRecord<UpdateRestrictionsType>(_entityType);
+                        if (updateEntity?.IsUpdatable ?? true)
+                        {
+                            AddUpdateOperation(item, restriction);
+                        }
                     }
                     else
                     {
                         InsertRestrictionsType insert = restriction?.InsertRestrictions;
-                        if (insert == null || insert.IsInsertable)
+                        if (insert?.IsInsertable ?? true)
                         {
                             AddOperation(item, OperationType.Post);
                         }
@@ -121,7 +127,8 @@ namespace Microsoft.OpenApi.OData.PathItem
                     }
                     else
                     {
-                        if (read.IsReadable)
+                        ReadRestrictionsType readEntity = Context.Model.GetRecord<ReadRestrictionsType>(_entityType);
+                        if (readEntity?.IsReadable ?? true)
                         {
                             AddOperation(item, OperationType.Get);
                         }
@@ -155,13 +162,12 @@ namespace Microsoft.OpenApi.OData.PathItem
             }
 
             DeleteRestrictionsType delete = restriction?.DeleteRestrictions;
-            if (delete == null || delete.IsDeletable)
-            {
-                if (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment)
-                {
-                    AddOperation(item, OperationType.Delete);
-                }
+            DeleteRestrictionsType deleteEntity = Context.Model.GetRecord<DeleteRestrictionsType>(_entityType);
+            bool isDeletable = (delete?.IsDeletable ?? true) || (deleteEntity?.IsDeletable ?? true);
 
+            if (isDeletable)
+            {
+                AddOperation(item, OperationType.Delete);
                 return;
             }
         }
@@ -193,6 +199,7 @@ namespace Microsoft.OpenApi.OData.PathItem
             LastSegmentIsKeySegment = path.LastSegment.Kind == ODataSegmentKind.Key;
             LastSegmentIsRefSegment = path.LastSegment.Kind == ODataSegmentKind.Ref;
             NavigationProperty = path.OfType<ODataNavigationPropertySegment>().Last().NavigationProperty;
+            _entityType = NavigationProperty.ToEntityType();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/220

This PR: 
- Fixes reading restriction annotations for entity types that define navigation properties.
- Adds a test to validate the above fix.