### PR TITLE
Enables configuring appending bound operations on derived types

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -673,7 +673,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         ((isCollection && subPath.Kind == ODataPathKind.EntitySet) ||
                             (!isCollection && !_oDataPathKindsToSkipForOperationsWhenSingle.Contains(subPath.Kind))))
                     {
-                        if (lastPathSegment is ODataTypeCastSegment && !convertSettings.AppendBoundOperationsOnDerivedTypes) continue;
+                        if (lastPathSegment is ODataTypeCastSegment && !convertSettings.AppendBoundOperationsOnDerivedTypeCastSegments) continue;
                         ODataPath newPath = subPath.Clone();
                         newPath.Push(new ODataOperationSegment(edmOperation, isEscapedFunction));
                         AppendPath(newPath);
@@ -741,7 +741,7 @@ namespace Microsoft.OpenApi.OData.Edm
             IEdmEntityType bindingEntityType,
             OpenApiConvertSettings convertSettings)
         {
-            if (!convertSettings.AppendBoundOperationsOnDerivedTypes) return false;
+            if (!convertSettings.AppendBoundOperationsOnDerivedTypeCastSegments) return false;
 
             bool found = false;
 
@@ -813,7 +813,7 @@ namespace Microsoft.OpenApi.OData.Edm
             IEdmEntityType bindingEntityType,
             OpenApiConvertSettings convertSettings)
         {
-            if (!convertSettings.AppendBoundOperationsOnDerivedTypes) return false;
+            if (!convertSettings.AppendBoundOperationsOnDerivedTypeCastSegments) return false;
 
             bool found = false;
             bool isEscapedFunction = _model.IsUrlEscapeFunction(edmOperation);

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -567,7 +567,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         {
                             RetrieveNavigationPropertyPaths(declaredNavigationProperty, null, castPath, convertSettings);
                         }
-                    }                        
+                    }
                 }
             }
         }
@@ -614,7 +614,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 foreach (var bindingEntityType in allEntitiesForOperation)
                 {
                     // 1. Search for corresponding navigation source path
-                    if (AppendBoundOperationOnNavigationSourcePath(edmOperation, isCollection, bindingEntityType))
+                    if (AppendBoundOperationOnNavigationSourcePath(edmOperation, isCollection, bindingEntityType, convertSettings))
                     {
                         continue;
                     }
@@ -646,7 +646,7 @@ namespace Microsoft.OpenApi.OData.Edm
             ODataPathKind.DollarCount,
             ODataPathKind.ComplexProperty,
         };
-        private bool AppendBoundOperationOnNavigationSourcePath(IEdmOperation edmOperation, bool isCollection, IEdmEntityType bindingEntityType)
+        private bool AppendBoundOperationOnNavigationSourcePath(IEdmOperation edmOperation, bool isCollection, IEdmEntityType bindingEntityType, OpenApiConvertSettings convertSettings)
         {
             bool found = false;
 
@@ -673,6 +673,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         ((isCollection && subPath.Kind == ODataPathKind.EntitySet) ||
                             (!isCollection && !_oDataPathKindsToSkipForOperationsWhenSingle.Contains(subPath.Kind))))
                     {
+                        if (lastPathSegment is ODataTypeCastSegment && !convertSettings.AppendBoundOperationsOnDerivedTypes) continue;
                         ODataPath newPath = subPath.Clone();
                         newPath.Push(new ODataOperationSegment(edmOperation, isEscapedFunction));
                         AppendPath(newPath);
@@ -740,6 +741,8 @@ namespace Microsoft.OpenApi.OData.Edm
             IEdmEntityType bindingEntityType,
             OpenApiConvertSettings convertSettings)
         {
+            if (!convertSettings.AppendBoundOperationsOnDerivedTypes) return false;
+
             bool found = false;
 
             bool isEscapedFunction = _model.IsUrlEscapeFunction(edmOperation);
@@ -810,6 +813,8 @@ namespace Microsoft.OpenApi.OData.Edm
             IEdmEntityType bindingEntityType,
             OpenApiConvertSettings convertSettings)
         {
+            if (!convertSettings.AppendBoundOperationsOnDerivedTypes) return false;
+
             bool found = false;
             bool isEscapedFunction = _model.IsUrlEscapeFunction(edmOperation);
 

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -22,6 +22,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
 - Adds list of all derived types for discriminator mapping #219
+- Enables configuring appending bound operations on derived types #221
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -249,9 +249,9 @@ namespace Microsoft.OpenApi.OData
         public Dictionary<string, string> CustomXMLAttributesMapping { get; set; } = new();
 
         /// <summary>
-        /// Gets/sets a value indicating whether or not to append bound operations on derived property paths.
+        /// Gets/sets a value indicating whether or not to append bound operations on derived types.
         /// </summary>
-        public bool AppendBoundOperationsOnDerivedPaths { get; set; } = true;
+        public bool AppendBoundOperationsOnDerivedTypes { get; set; } = true;
 
         internal OpenApiConvertSettings Clone()
         {
@@ -294,7 +294,7 @@ namespace Microsoft.OpenApi.OData
                 RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths,
                 ExpandDerivedTypesNavigationProperties = this.ExpandDerivedTypesNavigationProperties,
                 CustomXMLAttributesMapping = this.CustomXMLAttributesMapping,
-                AppendBoundOperationsOnDerivedPaths = this.AppendBoundOperationsOnDerivedPaths
+                AppendBoundOperationsOnDerivedTypes = this.AppendBoundOperationsOnDerivedTypes
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -248,6 +248,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public Dictionary<string, string> CustomXMLAttributesMapping { get; set; } = new();
 
+        /// <summary>
+        /// Gets/sets a value indicating whether or not to append bound operations on derived property paths.
+        /// </summary>
+        public bool AppendBoundOperationsOnDerivedPaths { get; set; } = true;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -288,7 +293,8 @@ namespace Microsoft.OpenApi.OData
                 InnerErrorComplexTypeName = this.InnerErrorComplexTypeName,
                 RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths,
                 ExpandDerivedTypesNavigationProperties = this.ExpandDerivedTypesNavigationProperties,
-                CustomXMLAttributesMapping = this.CustomXMLAttributesMapping
+                CustomXMLAttributesMapping = this.CustomXMLAttributesMapping,
+                AppendBoundOperationsOnDerivedPaths = this.AppendBoundOperationsOnDerivedPaths
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -249,9 +249,9 @@ namespace Microsoft.OpenApi.OData
         public Dictionary<string, string> CustomXMLAttributesMapping { get; set; } = new();
 
         /// <summary>
-        /// Gets/sets a value indicating whether or not to append bound operations on derived types.
+        /// Gets/sets a value indicating whether or not to append bound operations on derived type cast segments.
         /// </summary>
-        public bool AppendBoundOperationsOnDerivedTypes { get; set; } = true;
+        public bool AppendBoundOperationsOnDerivedTypeCastSegments { get; set; } = false;
 
         internal OpenApiConvertSettings Clone()
         {
@@ -294,7 +294,7 @@ namespace Microsoft.OpenApi.OData
                 RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths,
                 ExpandDerivedTypesNavigationProperties = this.ExpandDerivedTypesNavigationProperties,
                 CustomXMLAttributesMapping = this.CustomXMLAttributesMapping,
-                AppendBoundOperationsOnDerivedTypes = this.AppendBoundOperationsOnDerivedTypes
+                AppendBoundOperationsOnDerivedTypeCastSegments = this.AppendBoundOperationsOnDerivedTypeCastSegments
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,8 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
-Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypes.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypes.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,8 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
-Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedPaths.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedPaths.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypes.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypes.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedPaths.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(14624, paths.Count());
+            Assert.Equal(13125, paths.Count());
         }
 
         [Fact]
@@ -63,7 +63,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var settings = new OpenApiConvertSettings
             {
                 RequireDerivedTypesConstraintForBoundOperations = true,
-                ExpandDerivedTypesNavigationProperties = false
+                ExpandDerivedTypesNavigationProperties = false,
+                AppendBoundOperationsOnDerivedTypeCastSegments = true
             };
 
             // Act
@@ -81,7 +82,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             IEdmModel model = GetInheritanceModel(string.Empty);
             ODataPathProvider provider = new ODataPathProvider();
             var settings = new OpenApiConvertSettings {
-              EnableDollarCountPath = false,
+                EnableDollarCountPath = false,
+                AppendBoundOperationsOnDerivedTypeCastSegments = true
             };
 
             // Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var settings = new OpenApiConvertSettings
             {
                 RequireDerivedTypesConstraintForBoundOperations = requireConstraint,
-                AppendBoundOperationsOnDerivedTypes = appendBoundOperationsOnDerivedTypes
+                AppendBoundOperationsOnDerivedTypeCastSegments = appendBoundOperationsOnDerivedTypes
             };
 
             // Act
@@ -171,7 +171,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var settings = new OpenApiConvertSettings
             {
                 RequireDerivedTypesConstraintForODataTypeCastSegments = requireConstraint,
-                AppendBoundOperationsOnDerivedTypes = appendBoundOperationsOnDerivedTypes
+                AppendBoundOperationsOnDerivedTypeCastSegments = appendBoundOperationsOnDerivedTypes
             };
 
             // Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -100,15 +100,26 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 </Annotation>";
 
         [Theory]
-        [InlineData(false, false, true, 3)]
-        [InlineData(false, false, false, 4)]
-        [InlineData(true, false, true, 7)]
-        [InlineData(true, false, false, 7)]
-        [InlineData(false, true, false, 5)]
-        [InlineData(false, true, true, 4)]
-        [InlineData(true, true, true, 8)]
-        [InlineData(true, true, false, 8)]
-        public void GetOperationPathsForModelWithDerivedTypesConstraint(bool addAnnotation, bool getNavPropModel, bool requireConstraint, int expectedCount)
+        [InlineData(false, false, true, true, 3)]
+        [InlineData(false, false, false, true, 4)]
+        [InlineData(false, false, false, false, 3)]
+        [InlineData(true, false, true, true, 7)]
+        [InlineData(true, false, true, false, 6)]
+        [InlineData(true, false, false, true, 7)]
+        [InlineData(true, false, false, false, 6)]
+        [InlineData(false, true, false, true, 5)]
+        [InlineData(false, true, false, false, 4)]
+        [InlineData(false, true, true, true, 4)]
+        [InlineData(true, true, true, true, 8)]
+        [InlineData(true, true, true, false, 7)]
+        [InlineData(true, true, false, true, 8)]
+        [InlineData(true, true, false, false, 7)]
+        public void GetOperationPathsForModelWithDerivedTypesConstraint(
+            bool addAnnotation,
+            bool getNavPropModel,
+            bool requireConstraint,
+            bool appendBoundOperationsOnDerivedTypes,
+            int expectedCount)
         {
             // Arrange
             var annotation = addAnnotation ? derivedTypeAnnotation : string.Empty;
@@ -116,7 +127,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             ODataPathProvider provider = new();
             var settings = new OpenApiConvertSettings
             {
-                RequireDerivedTypesConstraintForBoundOperations = requireConstraint
+                RequireDerivedTypesConstraintForBoundOperations = requireConstraint,
+                AppendBoundOperationsOnDerivedTypes = appendBoundOperationsOnDerivedTypes
             };
 
             // Act
@@ -130,15 +142,27 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
               Assert.Single(dollarCountPathsWithCastSegment);
         }
         [Theory]
-        [InlineData(false, false, true, 4)]
-        [InlineData(false, false, false, 7)]
-        [InlineData(true, false, true, 7)]
-        [InlineData(true, false, false, 7)]
-        [InlineData(false, true, false, 8)]
-        [InlineData(false, true, true, 5)]
-        [InlineData(true, true, true, 8)]
-        [InlineData(true, true, false, 8)]
-        public void GetTypeCastPathsForModelWithDerivedTypesConstraint(bool addAnnotation, bool getNavPropModel, bool requireConstraint, int expectedCount)
+        [InlineData(false, false, true, true, 4)]
+        [InlineData(false, false, true, false, 3)]
+        [InlineData(false, false, false, true, 7)]
+        [InlineData(false, false, false, false, 6)]
+        [InlineData(true, false, true, true, 7)]
+        [InlineData(true, false, true, false, 6)]
+        [InlineData(true, false, false, true, 7)]
+        [InlineData(false, true, false, true, 8)]
+        [InlineData(false, true, false, false, 7)]
+        [InlineData(false, true, true, true, 5)]
+        [InlineData(false, true, true, false, 4)]
+        [InlineData(true, true, true, true, 8)]
+        [InlineData(true, true, true, false, 7)]
+        [InlineData(true, true, false, true, 8)]
+        [InlineData(true, true, false, false, 7)]
+        public void GetTypeCastPathsForModelWithDerivedTypesConstraint(
+            bool addAnnotation,
+            bool getNavPropModel,
+            bool requireConstraint,
+            bool appendBoundOperationsOnDerivedTypes,
+            int expectedCount)
         {
             // Arrange
             var annotation = addAnnotation ? derivedTypeAnnotation : string.Empty;
@@ -146,7 +170,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             ODataPathProvider provider = new();
             var settings = new OpenApiConvertSettings
             {
-                RequireDerivedTypesConstraintForODataTypeCastSegments = requireConstraint
+                RequireDerivedTypesConstraintForODataTypeCastSegments = requireConstraint,
+                AppendBoundOperationsOnDerivedTypes = appendBoundOperationsOnDerivedTypes
             };
 
             // Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
@@ -211,6 +211,7 @@ namespace Microsoft.OpenApi.OData.Tests
                 OpenApiSpecVersion = specVersion,
                 AddSingleQuotesForStringParameters = true,
                 AddEnumDescriptionExtension = true,
+                AppendBoundOperationsOnDerivedTypeCastSegments = true
             };
             // Act
             string json = WriteEdmModelAsOpenApi(model, OpenApiFormat.Json, settings);
@@ -244,6 +245,7 @@ namespace Microsoft.OpenApi.OData.Tests
                 OpenApiSpecVersion = specVersion,
                 AddSingleQuotesForStringParameters = true,
                 AddEnumDescriptionExtension = true,
+                AppendBoundOperationsOnDerivedTypeCastSegments = true
             };
 
             // Act


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/221

This PR:
- Adds a new convert setting `AppendBoundOperationsOnDerivedTypes` that allows configuring whether or not to append bound operations on derived types. This is enabled by default - `true`.
- Updates the relevant tests to validate use of the above setting flag when generating paths for bound operations on derived types.