### PR TITLE
Fixes missing bound operations on some navigation property paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -614,29 +614,16 @@ namespace Microsoft.OpenApi.OData.Edm
                 foreach (var bindingEntityType in allEntitiesForOperation)
                 {
                     // 1. Search for corresponding navigation source path
-                    if (AppendBoundOperationOnNavigationSourcePath(edmOperation, isCollection, bindingEntityType))
-                    {
-                        continue;
-                    }
+                    AppendBoundOperationOnNavigationSourcePath(edmOperation, isCollection, bindingEntityType);
 
                     // 2. Search for generated navigation property
-                    if (AppendBoundOperationOnNavigationPropertyPath(edmOperation, isCollection, bindingEntityType))
-                    {
-                        continue;
-                    }
+                    AppendBoundOperationOnNavigationPropertyPath(edmOperation, isCollection, bindingEntityType);
 
                     // 3. Search for derived
-                    if (AppendBoundOperationOnDerived(edmOperation, isCollection, bindingEntityType, convertSettings))
-                    {
-                        continue;
-                    }
+                    AppendBoundOperationOnDerived(edmOperation, isCollection, bindingEntityType, convertSettings);
 
                     // 4. Search for derived generated navigation property
-                    if (AppendBoundOperationOnDerivedNavigationPropertyPath(edmOperation, isCollection, bindingEntityType, convertSettings))
-                    {
-                        continue;
-                    }
-
+                    AppendBoundOperationOnDerivedNavigationPropertyPath(edmOperation, isCollection, bindingEntityType, convertSettings);
                 }
             }
         }
@@ -646,10 +633,8 @@ namespace Microsoft.OpenApi.OData.Edm
             ODataPathKind.DollarCount,
             ODataPathKind.ComplexProperty,
         };
-        private bool AppendBoundOperationOnNavigationSourcePath(IEdmOperation edmOperation, bool isCollection, IEdmEntityType bindingEntityType)
+        private void AppendBoundOperationOnNavigationSourcePath(IEdmOperation edmOperation, bool isCollection, IEdmEntityType bindingEntityType)
         {
-            bool found = false;
-
             if (_allNavigationSourcePaths.TryGetValue(bindingEntityType, out IList<ODataPath> value))
             {
                 bool isEscapedFunction = _model.IsUrlEscapeFunction(edmOperation);
@@ -676,19 +661,15 @@ namespace Microsoft.OpenApi.OData.Edm
                         ODataPath newPath = subPath.Clone();
                         newPath.Push(new ODataOperationSegment(edmOperation, isEscapedFunction));
                         AppendPath(newPath);
-                        found = true;
                     }
                 }
             }
-
-            return found;
         }
         private static readonly HashSet<ODataPathKind> _pathKindToSkipForNavigationProperties = new () {
             ODataPathKind.Ref,
         };
-        private bool AppendBoundOperationOnNavigationPropertyPath(IEdmOperation edmOperation, bool isCollection, IEdmEntityType bindingEntityType)
+        private void AppendBoundOperationOnNavigationPropertyPath(IEdmOperation edmOperation, bool isCollection, IEdmEntityType bindingEntityType)
         {
-            bool found = false;
             bool isEscapedFunction = _model.IsUrlEscapeFunction(edmOperation);
 
             if (_allNavigationPropertyPaths.TryGetValue(bindingEntityType, out IList<ODataPath> value))
@@ -727,21 +708,16 @@ namespace Microsoft.OpenApi.OData.Edm
                     ODataPath newPath = path.Clone();
                     newPath.Push(new ODataOperationSegment(edmOperation, isEscapedFunction));
                     AppendPath(newPath);
-                    found = true;
                 }
             }
-
-            return found;
         }
 
-        private bool AppendBoundOperationOnDerived(
+        private void AppendBoundOperationOnDerived(
             IEdmOperation edmOperation,
             bool isCollection,
             IEdmEntityType bindingEntityType,
             OpenApiConvertSettings convertSettings)
         {
-            bool found = false;
-
             bool isEscapedFunction = _model.IsUrlEscapeFunction(edmOperation);
             foreach (var baseType in bindingEntityType.FindAllBaseTypes())
             {
@@ -764,7 +740,6 @@ namespace Microsoft.OpenApi.OData.Edm
                                 ODataPath newPath = new ODataPath(new ODataNavigationSourceSegment(ns), new ODataTypeCastSegment(bindingEntityType),
                                     new ODataOperationSegment(edmOperation, isEscapedFunction));
                                 AppendPath(newPath);
-                                found = true;
                             }
                         }
                         else
@@ -774,7 +749,6 @@ namespace Microsoft.OpenApi.OData.Edm
                                 ODataPath newPath = new ODataPath(new ODataNavigationSourceSegment(ns), new ODataTypeCastSegment(bindingEntityType),
                                     new ODataOperationSegment(edmOperation, isEscapedFunction));
                                 AppendPath(newPath);
-                                found = true;
                             }
                             else
                             {
@@ -782,14 +756,11 @@ namespace Microsoft.OpenApi.OData.Edm
                                     new ODataTypeCastSegment(bindingEntityType),
                                     new ODataOperationSegment(edmOperation, isEscapedFunction));
                                 AppendPath(newPath);
-                                found = true;
                             }
                         }
                     }
                 }
             }
-
-            return found;
         }
 
         private bool HasUnsatisfiedDerivedTypeConstraint(
@@ -804,13 +775,12 @@ namespace Microsoft.OpenApi.OData.Edm
         private IEnumerable<string> GetDerivedTypeConstaintTypeNames(IEdmVocabularyAnnotatable annotatable) =>
             _model.GetCollection(annotatable, "Org.OData.Validation.V1.DerivedTypeConstraint") ?? Enumerable.Empty<string>();
 
-        private bool AppendBoundOperationOnDerivedNavigationPropertyPath(
+        private void AppendBoundOperationOnDerivedNavigationPropertyPath(
             IEdmOperation edmOperation,
             bool isCollection,
             IEdmEntityType bindingEntityType,
             OpenApiConvertSettings convertSettings)
         {
-            bool found = false;
             bool isEscapedFunction = _model.IsUrlEscapeFunction(edmOperation);
 
             foreach (var baseType in bindingEntityType.FindAllBaseTypes())
@@ -865,12 +835,9 @@ namespace Microsoft.OpenApi.OData.Edm
                         newPath.Push(new ODataTypeCastSegment(bindingEntityType));
                         newPath.Push(new ODataOperationSegment(edmOperation, isEscapedFunction));
                         AppendPath(newPath);
-                        found = true;
                     }
                 }
             }
-
-            return found;
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(14624, paths.Count());
+            Assert.Equal(16354, paths.Count());
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(14582, paths.Count());
+            Assert.Equal(15293, paths.Count());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/201

This PR:
- Removes the conditional expressions that prevent generation of bound operations for a given set of paths when the conditional expression that comes before this is `true`. This also necessitated refactoring of the target `private` method signatures and local variables.
- Updates the integration test results as a product of the above fix.
- With the above fix, the path `/users/{user-id}/followedSites/microsoft.graph.add` can now be generated:

![image](https://user-images.githubusercontent.com/40403681/171038463-2ab7243f-4488-4c6d-a4c0-d5bd96ded52f.png)
