### PR TITLE
Fix error ranges for OData actions

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -208,8 +208,15 @@ namespace Microsoft.OpenApi.OData.Generator
                 responses.Add(Constants.StatusCode200, response);
             }
 
-            // Both action & function have the default response.
-            responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            if (context.Settings.ErrorResponsesAsDefault)
+            {
+                responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+            }
+            else
+            {
+                responses.Add(Constants.StatusCodeClass4XX, Constants.StatusCodeClass4XX.GetResponse());
+                responses.Add(Constants.StatusCodeClass5XX, Constants.StatusCodeClass5XX.GetResponse());
+            }
 
             return responses;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -24,6 +24,7 @@
 - Adds list of all derived types for discriminator mapping #219
 - Fixes reading restriction annotations for entity types defining navigation properties #220
 - Enables configuring appending bound operations on derived types #221
+- Add error ranges for OData actions when ErrorResponsesAsDefault is set to false #218
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiErrorSchemaGeneraratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiErrorSchemaGeneraratorTests.cs
@@ -9,7 +9,7 @@ using Microsoft.OpenApi.OData.Generator;
 using Xunit;
 
 namespace Microsoft.OpenApi.OData.Tests;
-public class OpenApiErrorSchemaGeneraratorTests
+public class OpenApiErrorSchemaGeneratorTests
 {
     [Fact]
     public void AddsEmptyInnerErrorWhenNoComplexTypeIsProvided()


### PR DESCRIPTION
Fixes (#218)

Add error ranges for OData actions if ErrorResponsesAsDefault is set to false.

<img width="650" alt="image" src="https://user-images.githubusercontent.com/25274795/171709026-249b7ff8-04ac-496b-8198-f0011f14be08.png">
