### PR TITLE
Adds discriminator object to complex types which have derived types

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -374,7 +374,7 @@ namespace Microsoft.OpenApi.OData.Generator
         }
 
         private static OpenApiSchema CreateStructuredTypeSchema(this ODataContext context, IEdmStructuredType structuredType, bool processBase, bool processExample,
-            IEnumerable<IEdmEntityType> derivedTypes = null)
+            IEnumerable<IEdmStructuredType> derivedTypes = null)
         {
             Debug.Assert(context != null);
             Debug.Assert(structuredType != null);
@@ -387,7 +387,7 @@ namespace Microsoft.OpenApi.OData.Generator
 
             if (context.Settings.EnableDiscriminatorValue && derivedTypes == null)
             {
-                derivedTypes = context.Model.FindDirectlyDerivedTypes(structuredType).OfType<IEdmEntityType>();
+                derivedTypes = context.Model.FindDirectlyDerivedTypes(structuredType);
             }
 
             if (processBase && structuredType.BaseType != null)
@@ -435,8 +435,8 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 // The discriminator object is added to structured types which have derived types.
                 OpenApiDiscriminator discriminator = null;
-                if (context.Settings.EnableDiscriminatorValue && derivedTypes.Any() && structuredType.BaseType != null)
-                {         
+                if (context.Settings.EnableDiscriminatorValue && derivedTypes.Any())
+                {
                     Dictionary<string, string> mapping = derivedTypes
                         .ToDictionary(x => $"#{x.FullTypeName()}", x => new OpenApiSchema
                         {

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.0.11-preview2</Version>
+    <Version>1.0.11-preview3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -26,6 +26,7 @@
 - Add error ranges for OData actions when ErrorResponsesAsDefault is set to false #218
 - Fixes missing bound operations on some navigation property paths #201
 - Provides support for using success status code range 2XX #153
+- Adds discriminator object to complex types which have derived types #233
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Fact]
-        public void CreateStructuredTypeSchemaWithDiscriminatorValueEnabledReturnsCorrectSchema()
+        public void CreateStructuredTypeSchemaForEntityTypeWithDiscriminatorValueEnabledReturnsCorrectSchema()
         {
             // Arrange
             IEdmModel model = EdmModelHelper.GraphBetaModel;
@@ -139,6 +139,48 @@ namespace Microsoft.OpenApi.OData.Tests
       }
     }
   ]
+}".ChangeLineBreaks(), json);
+        }
+
+        [Fact]
+        public void CreateStructuredTypeSchemaForComplexTypeWithDiscriminatorValueEnabledReturnsCorrectSchema()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model, new OpenApiConvertSettings
+            {
+                EnableDiscriminatorValue = true,
+            });
+
+            IEdmComplexType complex = model.SchemaElements.OfType<IEdmComplexType>().First(t => t.Name == "userSet");
+            Assert.NotNull(complex); // Guard
+
+            // Act
+            var schema = context.CreateStructuredTypeSchema(complex);
+            string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            Assert.NotNull(json);
+            Assert.Equal(@"{
+  ""title"": ""userSet"",
+  ""type"": ""object"",
+  ""properties"": {
+    ""isBackup"": {
+      ""type"": ""boolean"",
+      ""nullable"": true
+    }
+  },
+  ""discriminator"": {
+    ""propertyName"": ""@odata.type"",
+    ""mapping"": {
+      ""#microsoft.graph.connectedOrganizationMembers"": ""#/components/schemas/microsoft.graph.connectedOrganizationMembers"",
+      ""#microsoft.graph.externalSponsors"": ""#/components/schemas/microsoft.graph.externalSponsors"",
+      ""#microsoft.graph.groupMembers"": ""#/components/schemas/microsoft.graph.groupMembers"",
+      ""#microsoft.graph.internalSponsors"": ""#/components/schemas/microsoft.graph.internalSponsors"",
+      ""#microsoft.graph.requestorManager"": ""#/components/schemas/microsoft.graph.requestorManager"",
+      ""#microsoft.graph.singleUser"": ""#/components/schemas/microsoft.graph.singleUser""
+    }
+  }
 }".ChangeLineBreaks(), json);
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/233

This PR: 
- Fixes the function that fetches the derived types of structured types and adds them to the discriminator object. The fix includes retrieving the derived types of complex properties and removing the condition that checks for base types before adding the discriminator object. Discriminator objects are not only required to be added to structured types which have base types. 
- Adds test to validate the above fix.
- Adds release note info.