### PR TITLE
Adds `@odata.type` property and makes this a required property in schemas that have discriminator objects

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -109,5 +109,10 @@ namespace Microsoft.OpenApi.OData.Common
         /// Name used for reference update.
         /// </summary>
         public static string ReferenceUpdateSchemaName = "ReferenceUpdateSchema";
+
+        /// <summary>
+        /// The odata type name.
+        /// </summary>
+        public static string OdataType = "@odata.type";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Properties = new Dictionary<string, OpenApiSchema>
                     {
                         {"@odata.id", new OpenApiSchema { Type = "string", Nullable = false }},
-                        {"@odata.type", new OpenApiSchema { Type = "string", Nullable = true }},
+                        {Constants.OdataType, new OpenApiSchema { Type = "string", Nullable = true }},
                     }
                 };
             }
@@ -435,7 +435,6 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 // The discriminator object is added to structured types which have derived types.
                 OpenApiDiscriminator discriminator = null;
-                string discriminatorPropertyName = "@odata.type";
                 if (context.Settings.EnableDiscriminatorValue && derivedTypes.Any())
                 {
                     Dictionary<string, string> mapping = derivedTypes
@@ -450,7 +449,7 @@ namespace Microsoft.OpenApi.OData.Generator
 
                     discriminator = new OpenApiDiscriminator
                     {
-                        PropertyName = discriminatorPropertyName,
+                        PropertyName = Constants.OdataType,
                         Mapping = mapping
                     };
                 }
@@ -476,12 +475,12 @@ namespace Microsoft.OpenApi.OData.Generator
 
                 if (schema.Discriminator != null)
                 {
-                    schema.Properties.TryAdd(discriminatorPropertyName, new OpenApiSchema()
+                    schema.Properties.TryAdd(Constants.OdataType, new OpenApiSchema()
                     {
                         Type = "string"                        
                     });
-                    schema.Properties[discriminatorPropertyName].Default = new OpenApiString("#" + structuredType.FullTypeName());
-                    schema.Required.Add(discriminatorPropertyName);
+                    schema.Properties[Constants.OdataType].Default = new OpenApiString("#" + structuredType.FullTypeName());
+                    schema.Required.Add(Constants.OdataType);
                 }                
 
                 // It optionally can contain the field description,
@@ -570,7 +569,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 case EdmTypeKind.Complex:
                 case EdmTypeKind.Enum:
                     OpenApiObject obj = new OpenApiObject();
-                    obj["@odata.type"] = new OpenApiString(edmTypeReference.FullName());
+                    obj[Constants.OdataType] = new OpenApiString(edmTypeReference.FullName());
                     return obj;
 
                 case EdmTypeKind.Collection:

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -475,11 +475,15 @@ namespace Microsoft.OpenApi.OData.Generator
 
                 if (schema.Discriminator != null)
                 {
-                    schema.Properties.TryAdd(Constants.OdataType, new OpenApiSchema()
+                    if (!schema.Properties.TryAdd(Constants.OdataType, new OpenApiSchema()
                     {
-                        Type = "string"                        
-                    });
-                    schema.Properties[Constants.OdataType].Default = new OpenApiString("#" + structuredType.FullTypeName());
+                        Type = "string",
+                        Default = new OpenApiString("#" + structuredType.FullTypeName()),
+                    }))
+                    {
+                        throw new InvalidOperationException(
+                            $"Property {Constants.OdataType} is already present in schema {structuredType.FullTypeName()}; verify CSDL.");
+                    }
                     schema.Required.Add(Constants.OdataType);
                 }                
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -435,6 +435,7 @@ namespace Microsoft.OpenApi.OData.Generator
             {
                 // The discriminator object is added to structured types which have derived types.
                 OpenApiDiscriminator discriminator = null;
+                string discriminatorPropertyName = "@odata.type";
                 if (context.Settings.EnableDiscriminatorValue && derivedTypes.Any())
                 {
                     Dictionary<string, string> mapping = derivedTypes
@@ -449,13 +450,13 @@ namespace Microsoft.OpenApi.OData.Generator
 
                     discriminator = new OpenApiDiscriminator
                     {
-                        PropertyName = "@odata.type",
+                        PropertyName = discriminatorPropertyName,
                         Mapping = mapping
                     };
                 }
 
                 // A structured type without a base type is represented as a Schema Object of type object
-                OpenApiSchema schema = new OpenApiSchema
+                OpenApiSchema schema = new()
                 {
                     Title = (structuredType as IEdmSchemaElement)?.Name,
 
@@ -472,6 +473,16 @@ namespace Microsoft.OpenApi.OData.Generator
                     OneOf = null,
                     AnyOf = null
                 };
+
+                if (schema.Discriminator != null)
+                {
+                    schema.Properties.TryAdd(discriminatorPropertyName, new OpenApiSchema()
+                    {
+                        Type = "string"                        
+                    });
+                    schema.Properties[discriminatorPropertyName].Default = new OpenApiString("#" + structuredType.FullTypeName());
+                    schema.Required.Add(discriminatorPropertyName);
+                }                
 
                 // It optionally can contain the field description,
                 // whose value is the value of the unqualified annotation Core.Description of the structured type.

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.0.11-preview3</Version>
+    <Version>1.0.11-preview4</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -27,6 +27,7 @@
 - Fixes missing bound operations on some navigation property paths #201
 - Provides support for using success status code range 2XX #153
 - Adds discriminator object to complex types which have derived types #233
+- Adds @odata.type property and makes this a required property in schemas that have discriminator objects #243
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -106,6 +106,9 @@ namespace Microsoft.OpenApi.OData.Tests
     },
     {
       ""title"": ""directoryObject"",
+      ""required"": [
+        ""@odata.type""
+      ],
       ""type"": ""object"",
       ""properties"": {
         ""deletedDateTime"": {
@@ -113,6 +116,10 @@ namespace Microsoft.OpenApi.OData.Tests
           ""type"": ""string"",
           ""format"": ""date-time"",
           ""nullable"": true
+        },
+        ""@odata.type"": {
+          ""type"": ""string"",
+          ""default"": ""#microsoft.graph.directoryObject""
         }
       },
       ""discriminator"": {
@@ -163,11 +170,18 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.NotNull(json);
             Assert.Equal(@"{
   ""title"": ""userSet"",
+  ""required"": [
+    ""@odata.type""
+  ],
   ""type"": ""object"",
   ""properties"": {
     ""isBackup"": {
       ""type"": ""boolean"",
       ""nullable"": true
+    },
+    ""@odata.type"": {
+      ""type"": ""string"",
+      ""default"": ""#microsoft.graph.userSet""
     }
   },
   ""discriminator"": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/243

This PR does the following:

Given an example of this schema, which is a base type, which exposes the discriminator mappings as shown:

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/40403681/177202523-52d8b1cf-4986-430c-bd0c-2f10307133d5.png)

The following is accomplished:

1. Adds the @odata.type property in the properties' object
2. Marks the @odata.type property as required
3. In the @odata.type property, sets the default value to '#microsoft.graph.entity
4. Updates tests to validate the above.

After the above, the schema should appear as below:

![image](https://user-images.githubusercontent.com/40403681/177202853-d1ed5fe9-7598-4c31-8f03-96c087fcb5bb.png)
