### PR TITLE
Retrieves `RestrictedProperties` annotations annotated directly on navigations properties

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -403,7 +403,21 @@ namespace Microsoft.OpenApi.OData.Edm
             visitedNavigationProperties.Push(navPropFullyQualifiedName);
 
             // Check whether a collection-valued navigation property should be indexed by key value(s).
-            bool indexableByKey = restriction?.IndexableByKey ?? true;
+            bool indexableByKey = true;
+
+            if (restriction?.IndexableByKey != null)
+            {
+                indexableByKey = (bool)restriction.IndexableByKey;
+            }
+            else
+            {
+                // Find indexability annotation annotated directly via NavigationPropertyRestriction
+                IEdmVocabularyAnnotation indexabilityAnnotation = _model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(navigationProperty, CapabilitiesConstants.IndexableByKey).FirstOrDefault();
+                if (indexabilityAnnotation != null)
+                {
+                    indexableByKey = ((IEdmBooleanValue)indexabilityAnnotation.Value).Value;
+                }
+            }
 
             if (indexableByKey)
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
@@ -21,14 +21,14 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Delete;
+
         private DeleteRestrictionsType _deleteRestriction;
 
         /// <inheritdoc/>
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _deleteRestriction = Restriction?.DeleteRestrictions ??
-                Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions);
+            _deleteRestriction = GetRestrictionAnnotation(CapabilitiesConstants.DeleteRestrictions) as DeleteRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
@@ -6,7 +6,9 @@
 using System.Linq;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -19,14 +21,23 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Delete;
+        private DeleteRestrictionsType _deleteRestriction;
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _deleteRestriction = Restriction?.DeleteRestrictions ??
+                Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions);
+        }
 
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary and Description
             string placeHolder = "Delete navigation property " + NavigationProperty.Name + " for " + NavigationSource.Name;
-            operation.Summary = Restriction?.DeleteRestrictions?.Description ?? placeHolder;
-            operation.Description = Restriction?.DeleteRestrictions?.LongDescription;
+            operation.Summary = _deleteRestriction?.Description ?? placeHolder;
+            operation.Description = _deleteRestriction?.LongDescription;
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -58,12 +69,12 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.DeleteRestrictions == null)
+            if (_deleteRestriction == null)
             {
                 return;
             }
 
-            operation.Security = Context.CreateSecurityRequirements(Restriction.DeleteRestrictions.Permissions).ToList();
+            operation.Security = Context.CreateSecurityRequirements(_deleteRestriction.Permissions).ToList();
         }
 
         /// <inheritdoc/>
@@ -75,19 +86,19 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.DeleteRestrictions == null)
+            if (_deleteRestriction == null)
             {
                 return;
             }
 
-            if (Restriction.DeleteRestrictions.CustomHeaders != null)
+            if (_deleteRestriction.CustomHeaders != null)
             {
-                AppendCustomParameters(operation, Restriction.DeleteRestrictions.CustomHeaders, ParameterLocation.Header);
+                AppendCustomParameters(operation, _deleteRestriction.CustomHeaders, ParameterLocation.Header);
             }
 
-            if (Restriction.DeleteRestrictions.CustomQueryOptions != null)
+            if (_deleteRestriction.CustomQueryOptions != null)
             {
-                AppendCustomParameters(operation, Restriction.DeleteRestrictions.CustomQueryOptions, ParameterLocation.Query);
+                AppendCustomParameters(operation, _deleteRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
@@ -9,6 +9,7 @@ using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
@@ -23,15 +24,23 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Get;
+        private ReadRestrictionsType _readRestriction;
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _readRestriction = Restriction?.ReadRestrictions ??
+                Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty, CapabilitiesConstants.ReadRestrictions);
+        }
 
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary and Description
-            ReadRestrictionsType readRestriction = Restriction?.ReadRestrictions;
             string placeHolder = "Get " + NavigationProperty.Name + " from " + NavigationSource.Name;
-            operation.Summary = (LastSegmentIsKeySegment ? readRestriction?.ReadByKeyRestrictions?.Description : readRestriction?.Description) ?? placeHolder;    
-            operation.Description = (LastSegmentIsKeySegment ? readRestriction?.ReadByKeyRestrictions?.LongDescription : readRestriction?.LongDescription)
+            operation.Summary = (LastSegmentIsKeySegment ? _readRestriction?.ReadByKeyRestrictions?.Description : _readRestriction?.Description) ?? placeHolder;    
+            operation.Description = (LastSegmentIsKeySegment ? _readRestriction?.ReadByKeyRestrictions?.LongDescription : _readRestriction?.LongDescription)
                 ?? Context.Model.GetDescriptionAnnotation(NavigationProperty);
 
             // OperationId
@@ -226,18 +235,15 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.ReadRestrictions == null)
+            if (_readRestriction == null)
             {
                 return;
             }
 
-            ReadRestrictionsBase readBase = Restriction.ReadRestrictions;
-            if (LastSegmentIsKeySegment)
+            ReadRestrictionsBase readBase = _readRestriction;
+            if (LastSegmentIsKeySegment && _readRestriction.ReadByKeyRestrictions != null)
             {
-                if (Restriction.ReadRestrictions.ReadByKeyRestrictions != null)
-                {
-                    readBase = Restriction.ReadRestrictions.ReadByKeyRestrictions;
-                }
+                readBase = _readRestriction.ReadByKeyRestrictions;
             }
 
             operation.Security = Context.CreateSecurityRequirements(readBase.Permissions).ToList();
@@ -245,18 +251,15 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.ReadRestrictions == null)
+            if (_readRestriction == null)
             {
                 return;
             }
 
-            ReadRestrictionsBase readBase = Restriction.ReadRestrictions;
-            if (LastSegmentIsKeySegment)
+            ReadRestrictionsBase readBase = _readRestriction;
+            if (LastSegmentIsKeySegment && _readRestriction.ReadByKeyRestrictions != null)
             {
-                if (Restriction.ReadRestrictions.ReadByKeyRestrictions != null)
-                {
-                    readBase = Restriction.ReadRestrictions.ReadByKeyRestrictions;
-                }
+                readBase = _readRestriction.ReadByKeyRestrictions;
             }
 
             if (readBase.CustomHeaders != null)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
@@ -24,14 +24,14 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Get;
+
         private ReadRestrictionsType _readRestriction;
 
         /// <inheritdoc/>
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _readRestriction = Restriction?.ReadRestrictions ??
-                Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty, CapabilitiesConstants.ReadRestrictions);
+            _readRestriction = GetRestrictionAnnotation(CapabilitiesConstants.ReadRestrictions) as ReadRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -10,6 +10,7 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Vocabulary;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
@@ -153,6 +154,28 @@ namespace Microsoft.OpenApi.OData.Operation
             }
 
             return string.Join(".", items);
+        }
+
+        /// <summary>
+        /// Retrieves the CRUD restrictions annotations for the navigation property
+        /// in context, given a capability annotation term.
+        /// </summary>
+        /// <param name="annotationTerm">The fully qualified restriction annotation term.</param>
+        /// <returns>The restriction annotation, or null if not available.</returns>
+        protected IRecord GetRestrictionAnnotation(string annotationTerm)
+        {
+            return annotationTerm switch
+            {
+                CapabilitiesConstants.ReadRestrictions => Restriction?.ReadRestrictions ??
+                                        Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty, CapabilitiesConstants.ReadRestrictions),
+                CapabilitiesConstants.UpdateRestrictions => Restriction?.UpdateRestrictions ??
+                                        Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty, CapabilitiesConstants.UpdateRestrictions),
+                CapabilitiesConstants.InsertRestrictions => Restriction?.InsertRestrictions ??
+                                        Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty, CapabilitiesConstants.InsertRestrictions),
+                CapabilitiesConstants.DeleteRestrictions => Restriction?.DeleteRestrictions ??
+                                        Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions),
+                _ => null,
+            };
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
@@ -23,14 +23,14 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Post;
+
         private InsertRestrictionsType _insertRestriction;
 
         /// <inheritdoc/>
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _insertRestriction = Restriction?.InsertRestrictions ??
-                Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty, CapabilitiesConstants.InsertRestrictions);
+            _insertRestriction = GetRestrictionAnnotation(CapabilitiesConstants.InsertRestrictions) as InsertRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
@@ -8,7 +8,9 @@ using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -21,14 +23,23 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Post;
+        private InsertRestrictionsType _insertRestriction;
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _insertRestriction = Restriction?.InsertRestrictions ??
+                Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty, CapabilitiesConstants.InsertRestrictions);
+        }
 
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary and Description
             string placeHolder = "Create new navigation property to " + NavigationProperty.Name + " for " + NavigationSource.Name;
-            operation.Summary = Restriction?.InsertRestrictions?.Description ?? placeHolder;
-            operation.Description = Restriction?.InsertRestrictions?.LongDescription;
+            operation.Summary = _insertRestriction?.Description ?? placeHolder;
+            operation.Description = _insertRestriction?.LongDescription;
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -131,29 +142,29 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.InsertRestrictions == null)
+            if (_insertRestriction == null)
             {
                 return;
             }
 
-            operation.Security = Context.CreateSecurityRequirements(Restriction.InsertRestrictions.Permissions).ToList();
+            operation.Security = Context.CreateSecurityRequirements(_insertRestriction.Permissions).ToList();
         }
 
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.InsertRestrictions == null)
+            if (_insertRestriction == null)
             {
                 return;
             }
 
-            if (Restriction.InsertRestrictions.CustomHeaders != null)
+            if (_insertRestriction.CustomHeaders != null)
             {
-                AppendCustomParameters(operation, Restriction.InsertRestrictions.CustomHeaders, ParameterLocation.Header);
+                AppendCustomParameters(operation, _insertRestriction.CustomHeaders, ParameterLocation.Header);
             }
 
-            if (Restriction.InsertRestrictions.CustomQueryOptions != null)
+            if (_insertRestriction.CustomQueryOptions != null)
             {
-                AppendCustomParameters(operation, Restriction.InsertRestrictions.CustomQueryOptions, ParameterLocation.Query);
+                AppendCustomParameters(operation, _insertRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -27,8 +27,7 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _updateRestriction = Restriction?.UpdateRestrictions ??
-                Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty, CapabilitiesConstants.UpdateRestrictions);
+            _updateRestriction = GetRestrictionAnnotation(CapabilitiesConstants.UpdateRestrictions) as UpdateRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -8,7 +8,9 @@ using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -19,13 +21,23 @@ namespace Microsoft.OpenApi.OData.Operation
     /// </summary>
     internal abstract class NavigationPropertyUpdateOperationHandler : NavigationPropertyOperationHandler
     {
+        private UpdateRestrictionsType _updateRestriction;
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _updateRestriction = Restriction?.UpdateRestrictions ??
+                Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty, CapabilitiesConstants.UpdateRestrictions);
+        }
+
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary and Description
             string placeHolder = "Update the navigation property " + NavigationProperty.Name + " in " + NavigationSource.Name;
-            operation.Summary = Restriction?.UpdateRestrictions?.Description ?? placeHolder;
-            operation.Description = Restriction?.UpdateRestrictions?.LongDescription;
+            operation.Summary = _updateRestriction?.Description ?? placeHolder;
+            operation.Description = _updateRestriction?.LongDescription;
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -67,29 +79,29 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.UpdateRestrictions == null)
+            if (_updateRestriction == null)
             {
                 return;
             }
 
-            operation.Security = Context.CreateSecurityRequirements(Restriction.UpdateRestrictions.Permissions).ToList();
+            operation.Security = Context.CreateSecurityRequirements(_updateRestriction.Permissions).ToList();
         }
 
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.UpdateRestrictions == null)
+            if (_updateRestriction == null)
             {
                 return;
             }
 
-            if (Restriction.UpdateRestrictions.CustomHeaders != null)
+            if (_updateRestriction.CustomHeaders != null)
             {
-                AppendCustomParameters(operation, Restriction.UpdateRestrictions.CustomHeaders, ParameterLocation.Header);
+                AppendCustomParameters(operation, _updateRestriction.CustomHeaders, ParameterLocation.Header);
             }
 
-            if (Restriction.UpdateRestrictions.CustomQueryOptions != null)
+            if (_updateRestriction.CustomQueryOptions != null)
             {
-                AppendCustomParameters(operation, Restriction.UpdateRestrictions.CustomQueryOptions, ParameterLocation.Query);
+                AppendCustomParameters(operation, _updateRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
@@ -26,8 +26,7 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _deleteRestriction = Restriction?.DeleteRestrictions ??
-                Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions);
+            _deleteRestriction = GetRestrictionAnnotation(CapabilitiesConstants.DeleteRestrictions) as DeleteRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
@@ -7,7 +7,9 @@ using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -18,14 +20,23 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Delete;
+        private DeleteRestrictionsType _deleteRestriction;
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _deleteRestriction = Restriction?.DeleteRestrictions ??
+                Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions);
+        }
 
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary and Description
             string placeHolder = "Delete ref of navigation property " + NavigationProperty.Name + " for " + NavigationSource.Name;
-            operation.Summary = Restriction?.DeleteRestrictions?.Description ?? placeHolder;
-            operation.Description = Restriction?.DeleteRestrictions?.LongDescription;
+            operation.Summary = _deleteRestriction?.Description ?? placeHolder;
+            operation.Description = _deleteRestriction?.LongDescription;
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -70,12 +81,12 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.DeleteRestrictions == null)
+            if (_deleteRestriction == null)
             {
                 return;
             }
 
-            operation.Security = Context.CreateSecurityRequirements(Restriction.DeleteRestrictions.Permissions).ToList();
+            operation.Security = Context.CreateSecurityRequirements(_deleteRestriction.Permissions).ToList();
         }
 
         /// <inheritdoc/>
@@ -87,19 +98,19 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.DeleteRestrictions == null)
+            if (_deleteRestriction == null)
             {
                 return;
             }
 
-            if (Restriction.DeleteRestrictions.CustomHeaders != null)
+            if (_deleteRestriction.CustomHeaders != null)
             {
-                AppendCustomParameters(operation, Restriction.DeleteRestrictions.CustomHeaders, ParameterLocation.Header);
+                AppendCustomParameters(operation, _deleteRestriction.CustomHeaders, ParameterLocation.Header);
             }
 
-            if (Restriction.DeleteRestrictions.CustomQueryOptions != null)
+            if (_deleteRestriction.CustomQueryOptions != null)
             {
-                AppendCustomParameters(operation, Restriction.DeleteRestrictions.CustomQueryOptions, ParameterLocation.Query);
+                AppendCustomParameters(operation, _deleteRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefGetOperationHandler.cs
@@ -28,8 +28,7 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _readRestriction = Restriction?.ReadRestrictions ??
-                Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty, CapabilitiesConstants.ReadRestrictions);
+            _readRestriction = GetRestrictionAnnotation(CapabilitiesConstants.ReadRestrictions) as ReadRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -25,8 +25,7 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _insertRestriction = Restriction?.InsertRestrictions ??
-                Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty, CapabilitiesConstants.InsertRestrictions);
+            _insertRestriction = GetRestrictionAnnotation(CapabilitiesConstants.InsertRestrictions) as InsertRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -3,12 +3,12 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -19,14 +19,23 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Post;
+        private InsertRestrictionsType _insertRestriction;
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _insertRestriction = Restriction?.InsertRestrictions ??
+                Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty, CapabilitiesConstants.InsertRestrictions);
+        }
 
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary and Description
             string placeHolder = "Create new navigation property ref to " + NavigationProperty.Name + " for " + NavigationSource.Name;
-            operation.Summary = Restriction?.InsertRestrictions?.Description ?? placeHolder;
-            operation.Description = Restriction?.InsertRestrictions?.LongDescription;
+            operation.Summary = _insertRestriction?.Description ?? placeHolder;
+            operation.Description = _insertRestriction?.LongDescription;
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -70,29 +79,29 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.InsertRestrictions == null)
+            if (_insertRestriction == null)
             {
                 return;
             }
 
-            operation.Security = Context.CreateSecurityRequirements(Restriction.InsertRestrictions.Permissions).ToList();
+            operation.Security = Context.CreateSecurityRequirements(_insertRestriction.Permissions).ToList();
         }
 
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.InsertRestrictions == null)
+            if (_insertRestriction == null)
             {
                 return;
             }
 
-            if (Restriction.InsertRestrictions.CustomHeaders != null)
+            if (_insertRestriction.CustomHeaders != null)
             {
-                AppendCustomParameters(operation, Restriction.InsertRestrictions.CustomHeaders, ParameterLocation.Header);
+                AppendCustomParameters(operation, _insertRestriction.CustomHeaders, ParameterLocation.Header);
             }
 
-            if (Restriction.InsertRestrictions.CustomQueryOptions != null)
+            if (_insertRestriction.CustomQueryOptions != null)
             {
-                AppendCustomParameters(operation, Restriction.InsertRestrictions.CustomQueryOptions, ParameterLocation.Query);
+                AppendCustomParameters(operation, _insertRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
@@ -25,8 +25,7 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            _updateRestriction = Restriction?.UpdateRestrictions ??
-                Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty, CapabilitiesConstants.UpdateRestrictions);
+            _updateRestriction = GetRestrictionAnnotation(CapabilitiesConstants.UpdateRestrictions) as UpdateRestrictionsType;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
@@ -3,11 +3,12 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -18,14 +19,23 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Patch;
+        private UpdateRestrictionsType _updateRestriction;
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+            _updateRestriction = Restriction?.UpdateRestrictions ??
+                Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty, CapabilitiesConstants.UpdateRestrictions);
+        }
 
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary and Description
             string placeHolder = "Update the ref of navigation property " + NavigationProperty.Name + " in " + NavigationSource.Name;
-            operation.Summary = Restriction?.UpdateRestrictions?.Description ?? placeHolder;
-            operation.Description = Restriction?.UpdateRestrictions?.LongDescription;
+            operation.Summary = _updateRestriction?.Description ?? placeHolder;
+            operation.Description = _updateRestriction?.LongDescription;
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -68,29 +78,29 @@ namespace Microsoft.OpenApi.OData.Operation
 
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.UpdateRestrictions == null)
+            if (_updateRestriction == null)
             {
                 return;
             }
 
-            operation.Security = Context.CreateSecurityRequirements(Restriction.UpdateRestrictions.Permissions).ToList();
+            operation.Security = Context.CreateSecurityRequirements(_updateRestriction.Permissions).ToList();
         }
 
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
-            if (Restriction == null || Restriction.UpdateRestrictions == null)
+            if (_updateRestriction == null)
             {
                 return;
             }
 
-            if (Restriction.UpdateRestrictions.CustomHeaders != null)
+            if (_updateRestriction.CustomHeaders != null)
             {
-                AppendCustomParameters(operation, Restriction.UpdateRestrictions.CustomHeaders, ParameterLocation.Header);
+                AppendCustomParameters(operation, _updateRestriction.CustomHeaders, ParameterLocation.Header);
             }
 
-            if (Restriction.UpdateRestrictions.CustomQueryOptions != null)
+            if (_updateRestriction.CustomQueryOptions != null)
             {
-                AppendCustomParameters(operation, Restriction.UpdateRestrictions.CustomQueryOptions, ParameterLocation.Query);
+                AppendCustomParameters(operation, _updateRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -44,7 +44,10 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// </summary>
         protected bool LastSegmentIsRefSegment { get; private set; }
 
-        private IEdmEntityType _entityType;
+        /// <summary>
+        /// The entity type targeted by the <see cref="NavigationProperty"/>
+        /// </summary>
+        private IEdmEntityType _navPropEntityType;
 
         /// <inheritdoc/>
         protected override void SetOperations(OpenApiPathItem item)
@@ -80,16 +83,26 @@ namespace Microsoft.OpenApi.OData.PathItem
                 {
                     if (LastSegmentIsKeySegment)
                     {
-                        UpdateRestrictionsType updateEntity = Context.Model.GetRecord<UpdateRestrictionsType>(_entityType);
-                        if (updateEntity?.IsUpdatable ?? true)
+                        UpdateRestrictionsType entityUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(_navPropEntityType);
+                        UpdateRestrictionsType navPropUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty);
+                        if ((entityUpdateRestriction?.IsUpdatable ?? true) ||
+                            (navPropUpdateRestriction?.IsUpdatable ?? true))
                         {
-                            AddUpdateOperation(item, restriction);
+                            UpdateRestrictionsType updateRestrictionType = entityUpdateRestriction ?? navPropUpdateRestriction;
+                            AddUpdateOperation(item, restriction, updateRestrictionType);
                         }
                     }
                     else
                     {
-                        InsertRestrictionsType insert = restriction?.InsertRestrictions;
-                        if (insert?.IsInsertable ?? true)
+                        InsertRestrictionsType insert = restriction?.InsertRestrictions ??
+                            Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty);
+                        InsertRestrictionsType entityInsertRestriction = Context.Model.GetRecord<InsertRestrictionsType>(_navPropEntityType);
+
+                        bool isInsertableDefault = insert == null && entityInsertRestriction == null;
+
+                        if (isInsertableDefault ||
+                           (entityInsertRestriction?.IsInsertable ?? false) ||
+                           (insert?.IsInsertable ?? false))
                         {
                             AddOperation(item, OperationType.Post);
                         }
@@ -106,8 +119,12 @@ namespace Microsoft.OpenApi.OData.PathItem
 
         private void AddGetOperation(OpenApiPathItem item, NavigationPropertyRestriction restriction)
         {
-            ReadRestrictionsType read = restriction?.ReadRestrictions;
-            if (read == null)
+            ReadRestrictionsType read = restriction?.ReadRestrictions ??
+                Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty);
+            ReadRestrictionsType entityReadRestriction = Context.Model.GetRecord<ReadRestrictionsType>(_navPropEntityType);
+            bool isReadableDefault = read == null && entityReadRestriction == null;
+
+            if (isReadableDefault)
             {
                 AddOperation(item, OperationType.Get);
                 return;
@@ -118,25 +135,16 @@ namespace Microsoft.OpenApi.OData.PathItem
                 // TODO: $ref also supports Get ?
                 if (LastSegmentIsKeySegment)
                 {
-                    if (read.ReadByKeyRestrictions != null && read.ReadByKeyRestrictions.Readable != null)
+                    if ((read?.ReadByKeyRestrictions?.IsReadable ?? false) ||
+                        (entityReadRestriction?.IsReadable ?? false))
                     {
-                        if (read.ReadByKeyRestrictions.Readable.Value)
-                        {
-                            AddOperation(item, OperationType.Get);
-                        }
-                    }
-                    else
-                    {
-                        ReadRestrictionsType readEntity = Context.Model.GetRecord<ReadRestrictionsType>(_entityType);
-                        if (readEntity?.IsReadable ?? true)
-                        {
-                            AddOperation(item, OperationType.Get);
-                        }
+                        AddOperation(item, OperationType.Get);
                     }
                 }
                 else
                 {
-                    if (read.IsReadable)
+                    if ((read?.IsReadable ?? false) ||
+                        (entityReadRestriction?.IsReadable ?? false))
                     {
                         AddOperation(item, OperationType.Get);
                     }
@@ -145,7 +153,8 @@ namespace Microsoft.OpenApi.OData.PathItem
             else
             {
                 Debug.Assert(LastSegmentIsKeySegment == false);
-                if (read.IsReadable)
+                if ((read?.IsReadable ?? false) ||
+                   (entityReadRestriction?.IsReadable ?? false))
                 {
                     AddOperation(item, OperationType.Get);
                 }
@@ -161,13 +170,14 @@ namespace Microsoft.OpenApi.OData.PathItem
                 return;
             }
 
-            DeleteRestrictionsType delete = restriction?.DeleteRestrictions;
-            DeleteRestrictionsType deleteEntity = Context.Model.GetRecord<DeleteRestrictionsType>(_entityType);
-            bool isDeletableDefault = delete == null && deleteEntity == null;
+            DeleteRestrictionsType delete = restriction?.DeleteRestrictions ??
+                Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty);
+            DeleteRestrictionsType entityDeleteRestriction = Context.Model.GetRecord<DeleteRestrictionsType>(_navPropEntityType);
+            bool isDeletableDefault = delete == null && entityDeleteRestriction == null;
 
             if (isDeletableDefault ||
-               (delete?.IsDeletable ?? false) ||
-               (deleteEntity?.IsDeletable ?? false))
+               (entityDeleteRestriction?.IsDeletable ?? false) ||
+               (delete?.IsDeletable ?? false))
             {
                 if (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment)
                 {
@@ -177,9 +187,9 @@ namespace Microsoft.OpenApi.OData.PathItem
             }
         }
 
-        private void AddUpdateOperation(OpenApiPathItem item, NavigationPropertyRestriction restriction)
+        private void AddUpdateOperation(OpenApiPathItem item, NavigationPropertyRestriction restriction, UpdateRestrictionsType updateRestrictionsType = null)
         {
-            UpdateRestrictionsType update = restriction?.UpdateRestrictions;
+            UpdateRestrictionsType update = restriction?.UpdateRestrictions ?? updateRestrictionsType;
             if (update == null || update.IsUpdatable)
             {
                 if (update != null && update.IsUpdateMethodPut)
@@ -204,7 +214,7 @@ namespace Microsoft.OpenApi.OData.PathItem
             LastSegmentIsKeySegment = path.LastSegment.Kind == ODataSegmentKind.Key;
             LastSegmentIsRefSegment = path.LastSegment.Kind == ODataSegmentKind.Ref;
             NavigationProperty = path.OfType<ODataNavigationPropertySegment>().Last().NavigationProperty;
-            _entityType = NavigationProperty.ToEntityType();
+            _navPropEntityType = NavigationProperty.ToEntityType();
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -94,15 +94,15 @@ namespace Microsoft.OpenApi.OData.PathItem
                     }
                     else
                     {
-                        InsertRestrictionsType insert = restriction?.InsertRestrictions ??
+                        InsertRestrictionsType navPropInsertRestriction = restriction?.InsertRestrictions ??
                             Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty);
                         InsertRestrictionsType entityInsertRestriction = Context.Model.GetRecord<InsertRestrictionsType>(_navPropEntityType);
 
-                        bool isInsertableDefault = insert == null && entityInsertRestriction == null;
+                        bool isInsertableDefault = navPropInsertRestriction == null && entityInsertRestriction == null;
 
                         if (isInsertableDefault ||
-                           (entityInsertRestriction?.IsInsertable ?? false) ||
-                           (insert?.IsInsertable ?? false))
+                           ((entityInsertRestriction?.IsInsertable ?? true) &&
+                           (navPropInsertRestriction?.IsInsertable ?? true)))
                         {
                             AddOperation(item, OperationType.Post);
                         }
@@ -119,10 +119,10 @@ namespace Microsoft.OpenApi.OData.PathItem
 
         private void AddGetOperation(OpenApiPathItem item, NavigationPropertyRestriction restriction)
         {
-            ReadRestrictionsType read = restriction?.ReadRestrictions ??
+            ReadRestrictionsType navPropReadRestriction = restriction?.ReadRestrictions ??
                 Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty);
             ReadRestrictionsType entityReadRestriction = Context.Model.GetRecord<ReadRestrictionsType>(_navPropEntityType);
-            bool isReadableDefault = read == null && entityReadRestriction == null;
+            bool isReadableDefault = navPropReadRestriction == null && entityReadRestriction == null;
 
             if (isReadableDefault)
             {
@@ -135,16 +135,16 @@ namespace Microsoft.OpenApi.OData.PathItem
                 // TODO: $ref also supports Get ?
                 if (LastSegmentIsKeySegment)
                 {
-                    if ((read?.ReadByKeyRestrictions?.IsReadable ?? false) ||
-                        (entityReadRestriction?.IsReadable ?? false))
+                    if ((navPropReadRestriction?.ReadByKeyRestrictions?.IsReadable ?? true) &&
+                        (entityReadRestriction?.IsReadable ?? true))
                     {
                         AddOperation(item, OperationType.Get);
                     }
                 }
                 else
                 {
-                    if ((read?.IsReadable ?? false) ||
-                        (entityReadRestriction?.IsReadable ?? false))
+                    if ((navPropReadRestriction?.IsReadable ?? true) &&
+                        (entityReadRestriction?.IsReadable ?? true))
                     {
                         AddOperation(item, OperationType.Get);
                     }
@@ -153,8 +153,8 @@ namespace Microsoft.OpenApi.OData.PathItem
             else
             {
                 Debug.Assert(LastSegmentIsKeySegment == false);
-                if ((read?.IsReadable ?? false) ||
-                   (entityReadRestriction?.IsReadable ?? false))
+                if ((navPropReadRestriction?.IsReadable ?? true) &&
+                   (entityReadRestriction?.IsReadable ?? true))
                 {
                     AddOperation(item, OperationType.Get);
                 }
@@ -170,14 +170,14 @@ namespace Microsoft.OpenApi.OData.PathItem
                 return;
             }
 
-            DeleteRestrictionsType delete = restriction?.DeleteRestrictions ??
+            DeleteRestrictionsType navPropDeleteRestriction = restriction?.DeleteRestrictions ??
                 Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty);
             DeleteRestrictionsType entityDeleteRestriction = Context.Model.GetRecord<DeleteRestrictionsType>(_navPropEntityType);
-            bool isDeletableDefault = delete == null && entityDeleteRestriction == null;
+            bool isDeletableDefault = navPropDeleteRestriction == null && entityDeleteRestriction == null;
 
             if (isDeletableDefault ||
-               (entityDeleteRestriction?.IsDeletable ?? false) ||
-               (delete?.IsDeletable ?? false))
+               ((entityDeleteRestriction?.IsDeletable ?? true) &&
+               (navPropDeleteRestriction?.IsDeletable ?? true)))
             {
                 if (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment)
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                         if ((entityUpdateRestriction?.IsUpdatable ?? true) &&
                             (navPropUpdateRestriction?.IsUpdatable ?? true))
                         {
-                            UpdateRestrictionsType updateRestrictionType = entityUpdateRestriction ?? navPropUpdateRestriction;
+                            UpdateRestrictionsType updateRestrictionType = navPropUpdateRestriction ?? entityUpdateRestriction;
                             AddUpdateOperation(item, restriction, updateRestrictionType);
                         }
                     }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                     {
                         UpdateRestrictionsType entityUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(_navPropEntityType);
                         UpdateRestrictionsType navPropUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty);
-                        if ((entityUpdateRestriction?.IsUpdatable ?? true) ||
+                        if ((entityUpdateRestriction?.IsUpdatable ?? true) &&
                             (navPropUpdateRestriction?.IsUpdatable ?? true))
                         {
                             UpdateRestrictionsType updateRestrictionType = entityUpdateRestriction ?? navPropUpdateRestriction;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" xmlns:ags="http://aggregator.microsoft.com/internal">
 <edmx:DataServices>
     <Schema Namespace="Microsoft.OData.Service.Sample.TrippinInMemory.Models" xmlns="http://docs.oasis-open.org/odata/ns/edm">
@@ -385,46 +385,36 @@
         </ActionImport>
       </EntityContainer>
       <Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person/Trips">
-        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-          <Record>
-            <PropertyValue Property="RestrictedProperties">
-              <Collection>
-                <Record>
-                  <PropertyValue Property="ReadRestrictions">
-                    <Record>
-                      <PropertyValue Property="LongDescription" String="Retrieve a list of trips." />
-                      <PropertyValue Property="Description" String="List trips." />
-                      <PropertyValue Property="ReadByKeyRestrictions">
-                        <Record>
-                          <PropertyValue Property="LongDescription" String="Retrieve the properties of a trip." />
-                          <PropertyValue Property="Description" String="Get a trip." />
-                        </Record>
-                      </PropertyValue>
-                    </Record>
-                  </PropertyValue>
-                  <PropertyValue Property="InsertRestrictions">
-                    <Record>
-                      <PropertyValue Property="LongDescription" String="Create a new trip." />
-                      <PropertyValue Property="Description" String="Create a trip." />                      
-                    </Record>
-                  </PropertyValue>
-                  <PropertyValue Property="UpdateRestrictions">
-                    <Record>
-                      <PropertyValue Property="LongDescription" String="Update an instance of a trip." />
-                      <PropertyValue Property="Description" String="Update a trip." />                      
-                    </Record>
-                  </PropertyValue>
-                  <PropertyValue Property="DeleteRestrictions">
-                    <Record>
-                      <PropertyValue Property="LongDescription" String="Delete an instance of a trip." />
-                      <PropertyValue Property="Description" String="Delete a trip." />                      
-                    </Record>
-                  </PropertyValue>
-                </Record>
-              </Collection>
-            </PropertyValue>
-          </Record>
-        </Annotation>
+		<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+		  <Record>
+			<PropertyValue Property="LongDescription" String="Retrieve a list of trips." />
+			<PropertyValue Property="Description" String="List trips." />
+			<PropertyValue Property="ReadByKeyRestrictions">
+			  <Record>
+				<PropertyValue Property="LongDescription" String="Retrieve the properties of a trip." />
+				<PropertyValue Property="Description" String="Get a trip." />
+			  </Record>
+			</PropertyValue>
+		  </Record>
+		</Annotation>
+		<Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+		  <Record>
+			<PropertyValue Property="LongDescription" String="Delete an instance of a trip." />
+			<PropertyValue Property="Description" String="Delete a trip." />
+		  </Record>
+		</Annotation>
+		<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+		  <Record>
+			<PropertyValue Property="LongDescription" String="Update an instance of a trip." />
+			<PropertyValue Property="Description" String="Update a trip." />
+		  </Record>
+		</Annotation>
+		<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+		  <Record>
+			<PropertyValue Property="LongDescription" String="Create a new trip." />
+			<PropertyValue Property="Description" String="Create a trip." />
+		  </Record>
+		</Annotation>		
       </Annotations>
     </Schema>
   </edmx:DataServices>


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/249

This PR:

- Retrieves `RestrictedProperties` annotations annotated directly on navigations properties. 
  If the entity type targeted by this navigation property also has `RestrictedProperties` annotations, this will take precedence first.
- Retrieves `IndexableByKey` annotation annotated directly on a navigation property. 
- Updates tests appropriately.