### PR TITLE
Replaces instances of `anyOf` to `oneOf`

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -124,6 +124,11 @@ namespace Microsoft.OpenApi.OData.Common
         /// Name used for reference request PUT body.
         /// </summary>
         public static string ReferencePutRequestBodyName = "refPutBody";
+
+        /// <summary>
+        /// Name used to reference INF, -INF and NaN
+        /// </summary>
+        public static string ReferenceNumericName = "ReferenceNumeric";
         
         /// <summary>
         /// The odata type name.

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -154,5 +154,25 @@ namespace Microsoft.OpenApi.OData.Common
         /// string type
         /// </summary>
         public static string StringType = "string";
+
+        /// <summary>
+        /// integer type
+        /// </summary>
+        public static string IntegerType = "integer";
+
+        /// <summary>
+        /// number type
+        /// </summary>
+        public static string NumberType = "number";
+
+        /// <summary>
+        /// int64 format
+        /// </summary>
+        public static string Int64Format = "int64";
+
+        /// <summary>
+        /// decimal format
+        /// </summary>
+        public static string DecimalFormat = "decimal";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -110,7 +110,6 @@ namespace Microsoft.OpenApi.OData.Common
         /// </summary>
         public static string ReferenceUpdateSchemaName = "ReferenceUpdate";
 
-
         /// <summary>
         /// Name used for reference update.
         /// </summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -183,11 +183,13 @@ namespace Microsoft.OpenApi.OData.Generator
                         schema.Type = "number";
                         schema.Format = format;
                     }
+                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.Double: // double
+                    format = "double";
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number", Format = "double" },
+                        new OpenApiSchema { Type = "number", Format = format },
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {
@@ -199,11 +201,13 @@ namespace Microsoft.OpenApi.OData.Generator
                             }
                         }
                     };
+                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.Single: // single
+                    format = "float";
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number", Format = "float"},
+                        new OpenApiSchema { Type = "number", Format = format },
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {
@@ -215,6 +219,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             }
                         }
                     };
+                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.Guid: // guid
                     schema.Type = "string";
@@ -248,6 +253,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         schema.Type = "integer";
                         schema.Format = format;
                     }
+                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.SByte:
                     schema.Type = "integer";

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -169,7 +169,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 case EdmPrimitiveTypeKind.Decimal: // decimal
                     if (context.Settings.IEEE754Compatible)
                     {
-                        schema.AnyOf = new List<OpenApiSchema>
+                        schema.OneOf = new List<OpenApiSchema>
                         {
                             new OpenApiSchema { Type = "number" },
                             new OpenApiSchema { Type = "string" },
@@ -182,7 +182,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     schema.Format = "decimal";
                     break;
                 case EdmPrimitiveTypeKind.Double: // double
-                    schema.AnyOf = new List<OpenApiSchema>
+                    schema.OneOf = new List<OpenApiSchema>
                     {
                         new OpenApiSchema { Type = "number" },
                         new OpenApiSchema { Type = "string" },
@@ -199,7 +199,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     schema.Format = "double";
                     break;
                 case EdmPrimitiveTypeKind.Single: // single
-                    schema.AnyOf = new List<OpenApiSchema>
+                    schema.OneOf = new List<OpenApiSchema>
                     {
                         new OpenApiSchema { Type = "number" },
                         new OpenApiSchema { Type = "string" },
@@ -235,7 +235,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 case EdmPrimitiveTypeKind.Int64:
                     if (context.Settings.IEEE754Compatible)
                     {
-                        schema.AnyOf = new List<OpenApiSchema>
+                        schema.OneOf = new List<OpenApiSchema>
                         {
                             new OpenApiSchema { Type = "integer" },
                             new OpenApiSchema { Type = "string" }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -147,6 +147,8 @@ namespace Microsoft.OpenApi.OData.Generator
                 OneOf = null,
                 AnyOf = null
             };
+
+            string format;
             switch (primitiveType.PrimitiveKind)
             {
                 case EdmPrimitiveTypeKind.Binary: // binary
@@ -167,24 +169,25 @@ namespace Microsoft.OpenApi.OData.Generator
                     schema.Pattern = "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$";
                     break;
                 case EdmPrimitiveTypeKind.Decimal: // decimal
+                    format = "decimal";
                     if (context.Settings.IEEE754Compatible)
                     {
                         schema.OneOf = new List<OpenApiSchema>
                         {
-                            new OpenApiSchema { Type = "number" },
+                            new OpenApiSchema { Type = "number", Format = format },
                             new OpenApiSchema { Type = "string" },
                         };
                     }
                     else
                     {
                         schema.Type = "number";
+                        schema.Format = format;
                     }
-                    schema.Format = "decimal";
                     break;
                 case EdmPrimitiveTypeKind.Double: // double
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number" },
+                        new OpenApiSchema { Type = "number", Format = "double" },
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {
@@ -196,12 +199,11 @@ namespace Microsoft.OpenApi.OData.Generator
                             }
                         }
                     };
-                    schema.Format = "double";
                     break;
                 case EdmPrimitiveTypeKind.Single: // single
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number" },
+                        new OpenApiSchema { Type = "number", Format = "float"},
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {
@@ -213,7 +215,6 @@ namespace Microsoft.OpenApi.OData.Generator
                             }
                         }
                     };
-                    schema.Format = "float";
                     break;
                 case EdmPrimitiveTypeKind.Guid: // guid
                     schema.Type = "string";
@@ -233,20 +234,20 @@ namespace Microsoft.OpenApi.OData.Generator
                     schema.Maximum = Int32.MaxValue; // 2147483647
                     break;
                 case EdmPrimitiveTypeKind.Int64:
+                    format = "int64";
                     if (context.Settings.IEEE754Compatible)
                     {
                         schema.OneOf = new List<OpenApiSchema>
                         {
-                            new OpenApiSchema { Type = "integer" },
+                            new OpenApiSchema { Type = "integer", Format = format },
                             new OpenApiSchema { Type = "string" }
                         };
                     }
                     else
                     {
                         schema.Type = "integer";
+                        schema.Format = format;
                     }
-
-                    schema.Format = "int64";
                     break;
                 case EdmPrimitiveTypeKind.SByte:
                     schema.Type = "integer";

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -183,7 +183,6 @@ namespace Microsoft.OpenApi.OData.Generator
                         schema.Type = "number";
                         schema.Format = format;
                     }
-                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.Double: // double
                     format = "double";
@@ -201,7 +200,6 @@ namespace Microsoft.OpenApi.OData.Generator
                             }
                         }
                     };
-                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.Single: // single
                     format = "float";
@@ -219,7 +217,6 @@ namespace Microsoft.OpenApi.OData.Generator
                             }
                         }
                     };
-                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.Guid: // guid
                     schema.Type = "string";
@@ -253,7 +250,6 @@ namespace Microsoft.OpenApi.OData.Generator
                         schema.Type = "integer";
                         schema.Format = format;
                     }
-                    schema.Format = format;
                     break;
                 case EdmPrimitiveTypeKind.SByte:
                     schema.Type = "integer";

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -148,11 +148,10 @@ namespace Microsoft.OpenApi.OData.Generator
                 AnyOf = null
             };
 
-            string format;
             switch (primitiveType.PrimitiveKind)
             {
                 case EdmPrimitiveTypeKind.Binary: // binary
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     schema.Format = "base64url";
                     break;
                 case EdmPrimitiveTypeKind.Boolean: // boolean
@@ -160,35 +159,34 @@ namespace Microsoft.OpenApi.OData.Generator
                     schema.Default = new OpenApiBoolean(false);
                     break;
                 case EdmPrimitiveTypeKind.Byte: // byte
-                    schema.Type = "integer";
+                    schema.Type = Constants.IntegerType;
                     schema.Format = "uint8";
                     break;
                 case EdmPrimitiveTypeKind.DateTimeOffset: // datetime offset
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     schema.Format = "date-time";
                     schema.Pattern = "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$";
                     break;
                 case EdmPrimitiveTypeKind.Decimal: // decimal
-                    format = "decimal";
                     if (context.Settings.IEEE754Compatible)
                     {
                         schema.OneOf = new List<OpenApiSchema>
                         {
-                            new OpenApiSchema { Type = "number", Format = format },
-                            new OpenApiSchema { Type = "string" },
+                            new OpenApiSchema { Type = Constants.NumberType, Format = Constants.DecimalFormat },
+                            new OpenApiSchema { Type = Constants.StringType },
                         };
                     }
                     else
                     {
-                        schema.Type = "number";
-                        schema.Format = format;
+                        schema.Type = Constants.NumberType;
+                        schema.Format = Constants.DecimalFormat;
                     }
                     break;
                 case EdmPrimitiveTypeKind.Double: // double
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number", Format = "double" },
-                        new OpenApiSchema { Type = "string" },
+                        new OpenApiSchema { Type = Constants.NumberType, Format = "double" },
+                        new OpenApiSchema { Type = Constants.StringType },
                         new OpenApiSchema
                         {
                             UnresolvedReference = true,
@@ -203,8 +201,8 @@ namespace Microsoft.OpenApi.OData.Generator
                 case EdmPrimitiveTypeKind.Single: // single
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number", Format = "float" },
-                        new OpenApiSchema { Type = "string" },
+                        new OpenApiSchema { Type = Constants.NumberType, Format = "float" },
+                        new OpenApiSchema { Type = Constants.StringType },
                         new OpenApiSchema
                         {
                             UnresolvedReference = true,
@@ -217,63 +215,62 @@ namespace Microsoft.OpenApi.OData.Generator
                     };
                     break;
                 case EdmPrimitiveTypeKind.Guid: // guid
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     schema.Format = "uuid";
                     schema.Pattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
                     break;
                 case EdmPrimitiveTypeKind.Int16:
-                    schema.Type = "integer";
+                    schema.Type = Constants.IntegerType;
                     schema.Format = "int16";
                     schema.Minimum = Int16.MinValue; // -32768
                     schema.Maximum = Int16.MaxValue; // 32767
                     break;
                 case EdmPrimitiveTypeKind.Int32:
-                    schema.Type = "integer";
+                    schema.Type = Constants.IntegerType;
                     schema.Format = "int32";
                     schema.Minimum = Int32.MinValue; // -2147483648
                     schema.Maximum = Int32.MaxValue; // 2147483647
                     break;
                 case EdmPrimitiveTypeKind.Int64:
-                    format = "int64";
                     if (context.Settings.IEEE754Compatible)
                     {
                         schema.OneOf = new List<OpenApiSchema>
                         {
-                            new OpenApiSchema { Type = "integer", Format = format },
-                            new OpenApiSchema { Type = "string" }
+                            new OpenApiSchema { Type = Constants.IntegerType, Format = Constants.Int64Format },
+                            new OpenApiSchema { Type = Constants.StringType }
                         };
                     }
                     else
                     {
-                        schema.Type = "integer";
-                        schema.Format = format;
+                        schema.Type = Constants.IntegerType;
+                        schema.Format = Constants.Int64Format;
                     }
                     break;
                 case EdmPrimitiveTypeKind.SByte:
-                    schema.Type = "integer";
+                    schema.Type = Constants.IntegerType;
                     schema.Format = "int8";
                     schema.Minimum = SByte.MinValue; // -128
                     schema.Maximum = SByte.MaxValue; // 127
                     break;
                 case EdmPrimitiveTypeKind.String: // string
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     break;
                 case EdmPrimitiveTypeKind.Stream: // stream
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     schema.Format = "base64url";
                     break;
                 case EdmPrimitiveTypeKind.Duration: // duration
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     schema.Format = "duration";
                     schema.Pattern = "^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$";
                     break;
                 case EdmPrimitiveTypeKind.Date:
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     schema.Format = "date";
                     schema.Pattern = "^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$";
                     break;
                 case EdmPrimitiveTypeKind.TimeOfDay:
-                    schema.Type = "string";
+                    schema.Type = Constants.StringType;
                     schema.Format = "time";
                     schema.Pattern = "^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?$";
                     break;

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -185,10 +185,9 @@ namespace Microsoft.OpenApi.OData.Generator
                     }
                     break;
                 case EdmPrimitiveTypeKind.Double: // double
-                    format = "double";
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number", Format = format },
+                        new OpenApiSchema { Type = "number", Format = "double" },
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {
@@ -202,10 +201,9 @@ namespace Microsoft.OpenApi.OData.Generator
                     };
                     break;
                 case EdmPrimitiveTypeKind.Single: // single
-                    format = "float";
                     schema.OneOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema { Type = "number", Format = format },
+                        new OpenApiSchema { Type = "number", Format = "float" },
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -188,11 +188,11 @@ namespace Microsoft.OpenApi.OData.Generator
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {
-                            Enum = new List<IOpenApiAny>
+                            UnresolvedReference = true,
+                            Reference = new OpenApiReference
                             {
-                                new OpenApiString("-INF"),
-                                new OpenApiString("INF"),
-                                new OpenApiString("NaN")
+                                Type = ReferenceType.Schema,
+                                Id = Constants.ReferenceNumericName
                             }
                         }
                     };
@@ -205,11 +205,11 @@ namespace Microsoft.OpenApi.OData.Generator
                         new OpenApiSchema { Type = "string" },
                         new OpenApiSchema
                         {
-                            Enum = new List<IOpenApiAny>
+                            UnresolvedReference = true,
+                            Reference = new OpenApiReference
                             {
-                                new OpenApiString("-INF"),
-                                new OpenApiString("INF"),
-                                new OpenApiString("NaN")
+                                Type = ReferenceType.Schema,
+                                Id = Constants.ReferenceNumericName
                             }
                         }
                     };

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -589,23 +589,10 @@ namespace Microsoft.OpenApi.OData.Generator
                             string typeName = schema.Type ?? schema.Format;
                             if (typeName == null)
                             {
-                                List<OpenApiSchema> schemaList = new();
-                                if (schema.AnyOf != null)
-                                {
-                                    schemaList = schema.AnyOf.ToList();
-                                }
-
-                                if (schema.OneOf != null)
-                                {
-                                    schemaList = schemaList.Union(schema.OneOf).ToList();
-                                }
-
-                                if (schema.AllOf != null)
-                                {
-                                    schemaList = schemaList.Union(schema.AllOf).ToList();
-                                }
-
-                                typeName = schemaList?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Format))?.Format;                                
+                                (schema.AnyOf ?? Enumerable.Empty<OpenApiSchema>())
+                                .Union(schema.AllOf ?? Enumerable.Empty<OpenApiSchema>())
+                                .Union(schema.OneOf ?? Enumerable.Empty<OpenApiSchema>())
+                                .FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format;                                
                             }
 
                             return new OpenApiString(typeName);

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -118,6 +118,16 @@ namespace Microsoft.OpenApi.OData.Generator
                 AdditionalProperties = new OpenApiSchema { Type = "object" }
             };
 
+            schemas[Constants.ReferenceNumericName] = new()
+            {
+                Enum = new List<IOpenApiAny>
+                {
+                    new OpenApiString("-INF"),
+                    new OpenApiString("INF"),
+                    new OpenApiString("NaN")
+                }
+            };
+
             return schemas;
         }
         internal static bool HasAnyNonContainedCollections(this ODataContext context)

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -586,16 +586,11 @@ namespace Microsoft.OpenApi.OData.Generator
                         }
                         else
                         {
-                            string typeName = schema.Type ?? schema.Format;
-                            if (typeName == null)
-                            {
+                            return new OpenApiString(schema.Type ?? schema.Format ??
                                 (schema.AnyOf ?? Enumerable.Empty<OpenApiSchema>())
                                 .Union(schema.AllOf ?? Enumerable.Empty<OpenApiSchema>())
                                 .Union(schema.OneOf ?? Enumerable.Empty<OpenApiSchema>())
-                                .FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format;                                
-                            }
-
-                            return new OpenApiString(typeName);
+                                .FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format);
                         }
                     }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -586,7 +586,29 @@ namespace Microsoft.OpenApi.OData.Generator
                         }
                         else
                         {
-                            return new OpenApiString(schema.Type ?? schema.Format);
+                            string typeName = schema.Type ?? schema.Format;
+                            if (typeName == null)
+                            {
+                                List<OpenApiSchema> schemaList = new();
+                                if (schema.AnyOf != null)
+                                {
+                                    schemaList = schema.AnyOf.ToList();
+                                }
+
+                                if (schema.OneOf != null)
+                                {
+                                    schemaList = schemaList.Union(schema.OneOf).ToList();
+                                }
+
+                                if (schema.AllOf != null)
+                                {
+                                    schemaList = schemaList.Union(schema.AllOf).ToList();
+                                }
+
+                                typeName = schemaList?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Format))?.Format;                                
+                            }
+
+                            return new OpenApiString(typeName);
                         }
                     }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -586,11 +586,11 @@ namespace Microsoft.OpenApi.OData.Generator
                         }
                         else
                         {
-                            return new OpenApiString(schema.Type ?? schema.Format ??
+                            return new OpenApiString(schema.Type ??
                                 (schema.AnyOf ?? Enumerable.Empty<OpenApiSchema>())
                                 .Union(schema.AllOf ?? Enumerable.Empty<OpenApiSchema>())
                                 .Union(schema.OneOf ?? Enumerable.Empty<OpenApiSchema>())
-                                .FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format);
+                                .FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format ?? schema.Format);
                         }
                     }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSpatialTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSpatialTypeSchemaGenerator.cs
@@ -214,7 +214,7 @@ namespace Microsoft.OpenApi.OData.Generator
             return new OpenApiSchema
             {
                 Type = "object",
-                AnyOf = new List<OpenApiSchema>
+                OneOf = new List<OpenApiSchema>
                 {
                     new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryPoint" } },
                     new OpenApiSchema { UnresolvedReference = true, Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = "Edm.GeometryLineString" } },

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -41,7 +41,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.10.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -41,7 +41,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.10.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/OoasGui/OoasGui.csproj
+++ b/src/OoasGui/OoasGui.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.2" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.3.2" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/OoasGui/OoasGui.csproj
+++ b/src/OoasGui/OoasGui.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.2" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
@@ -407,14 +407,14 @@ namespace Microsoft.OpenApi.OData.Tests
             if (IEEE754Compatible)
             {
                 Assert.Null(schema.Type);
-                Assert.NotNull(schema.AnyOf);
-                Assert.Equal(2, schema.AnyOf.Count);
-                Assert.Equal(new[] { "number", "string" }, schema.AnyOf.Select(a => a.Type));
+                Assert.NotNull(schema.OneOf);
+                Assert.Equal(2, schema.OneOf.Count);
+                Assert.Equal(new[] { "number", "string" }, schema.OneOf.Select(a => a.Type));
             }
             else
             {
                 Assert.Equal("number", schema.Type);
-                Assert.Null(schema.AnyOf);
+                Assert.Null(schema.OneOf);
             }
 
             Assert.Equal(isNullable, schema.Nullable);
@@ -445,9 +445,9 @@ namespace Microsoft.OpenApi.OData.Tests
             if (IEEE754Compatible)
             {
                 Assert.Null(schema.Type);
-                Assert.NotNull(schema.AnyOf);
-                Assert.Equal(2, schema.AnyOf.Count);
-                Assert.Equal(new[] { "integer", "string" }, schema.AnyOf.Select(a => a.Type));
+                Assert.NotNull(schema.OneOf);
+                Assert.Equal(2, schema.OneOf.Count);
+                Assert.Equal(new[] { "integer", "string" }, schema.OneOf.Select(a => a.Type));
             }
             else
             {
@@ -513,10 +513,10 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Equal("double", schema.Format);
             Assert.Equal(isNullable, schema.Nullable);
 
-            Assert.Null(schema.OneOf);
+            Assert.Null(schema.AnyOf);
 
-            Assert.NotNull(schema.AnyOf);
-            Assert.Equal(3, schema.AnyOf.Count);
+            Assert.NotNull(schema.OneOf);
+            Assert.Equal(3, schema.OneOf.Count);
         }
 
         [Theory]
@@ -539,10 +539,10 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Equal("float", schema.Format);
             Assert.Equal(isNullable, schema.Nullable);
 
-            Assert.Null(schema.OneOf);
+            Assert.Null(schema.AnyOf);
 
-            Assert.NotNull(schema.AnyOf);
-            Assert.Equal(3, schema.AnyOf.Count);
+            Assert.NotNull(schema.OneOf);
+            Assert.Equal(3, schema.OneOf.Count);
         }
         #endregion
     }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -510,7 +510,7 @@ namespace Microsoft.OpenApi.OData.Tests
             // & Assert
             Assert.Null(schema.Type);
 
-            Assert.Equal("double", schema.Format);
+            Assert.Equal("double", schema.OneOf.FirstOrDefault(x => !string.IsNullOrEmpty(x.Format))?.Format);
             Assert.Equal(isNullable, schema.Nullable);
 
             Assert.Null(schema.AnyOf);
@@ -536,7 +536,7 @@ namespace Microsoft.OpenApi.OData.Tests
             // & Assert
             Assert.Null(schema.Type);
 
-            Assert.Equal("float", schema.Format);
+            Assert.Equal("float", schema.OneOf.FirstOrDefault(x => !string.IsNullOrEmpty(x.Format))?.Format);
             Assert.Equal(isNullable, schema.Nullable);
 
             Assert.Null(schema.AnyOf);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 @"name: $skip
 in: query
 description: Skip the first n items
+style: form
 schema:
   minimum: 0
   type: integer
@@ -106,6 +107,7 @@ schema:
   ""in"": ""path"",
   ""description"": ""key: Customer-Id of Customer"",
   ""required"": true,
+  ""style"": ""simple"",
   ""schema"": {
     ""type"": ""string"",
     ""nullable"": true
@@ -120,6 +122,7 @@ schema:
   ""in"": ""path"",
   ""description"": ""key: Id of Customer"",
   ""required"": true,
+  ""style"": ""simple"",
   ""schema"": {
     ""type"": ""string"",
     ""nullable"": true
@@ -164,6 +167,7 @@ schema:
   ""in"": ""path"",
   ""description"": ""key: firstName of Customer"",
   ""required"": true,
+  ""style"": ""simple"",
   ""schema"": {
     ""type"": ""string"",
     ""nullable"": true
@@ -180,6 +184,7 @@ schema:
   ""in"": ""path"",
   ""description"": ""key: lastName of Customer"",
   ""required"": true,
+  ""style"": ""simple"",
   ""schema"": {
     ""type"": ""string"",
     ""nullable"": true
@@ -410,6 +415,7 @@ schema:
   ""in"": ""path"",
   ""description"": ""The URL-encoded JSON object"",
   ""required"": true,
+  ""style"": ""simple"",
   ""content"": {{
     ""application/json"": {{
       ""schema"": {{
@@ -427,6 +433,7 @@ schema:
   ""name"": ""resource"",
   ""in"": ""path"",
   ""required"": true,
+  ""style"": ""simple"",
   ""schema"": {{
     ""type"": ""string"",
     ""nullable"": true
@@ -437,6 +444,7 @@ schema:
             string expectedPayload3 = $@"{{
   ""name"": ""directoryScopeId"",
   ""in"": ""query"",
+  ""style"": ""form"",
   ""schema"": {{
     ""type"": ""string"",
     ""nullable"": true

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -405,7 +405,7 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Equal(1, declaredSchema.Properties.Count);
             var property = Assert.Single(declaredSchema.Properties);
             Assert.Equal("Price", property.Key);
-            Assert.Equal("decimal", property.Value.Format);
+            Assert.Equal("decimal", property.Value.OneOf.FirstOrDefault(x => !string.IsNullOrEmpty(x.Format))?.Format);
             Assert.NotNull(property.Value.OneOf);
             Assert.Equal(new string[] { "number", "string" }, property.Value.OneOf.Select(e => e.Type));
 
@@ -430,13 +430,13 @@ namespace Microsoft.OpenApi.OData.Tests
           ""multipleOf"": 1,
           ""oneOf"": [
             {
-              ""type"": ""number""
+              ""type"": ""number"",
+              ""format"": ""decimal""
             },
             {
               ""type"": ""string""
             }
-          ],
-          ""format"": ""decimal""
+          ]
         }
       },
       ""description"": ""Complex type 'Tree' description.""
@@ -915,7 +915,8 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Equal(@"{
   ""oneOf"": [
     {
-      ""type"": ""number""
+      ""type"": ""number"",
+      ""format"": ""double""
     },
     {
       ""type"": ""string""
@@ -924,7 +925,6 @@ namespace Microsoft.OpenApi.OData.Tests
       ""$ref"": ""#/components/schemas/ReferenceNumeric""
     }
   ],
-  ""format"": ""double"",
   ""default"": ""3.1415926535897931""
 }".ChangeLineBreaks(), json);
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -921,11 +921,7 @@ namespace Microsoft.OpenApi.OData.Tests
       ""type"": ""string""
     },
     {
-      ""enum"": [
-        ""-INF"",
-        ""INF"",
-        ""NaN""
-      ]
+      ""$ref"": ""#/components/schemas/ReferenceNumeric""
     }
   ],
   ""format"": ""double"",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -436,8 +436,7 @@ namespace Microsoft.OpenApi.OData.Tests
             {
               ""type"": ""string""
             }
-          ],
-          ""format"": ""decimal""
+          ]
         }
       },
       ""description"": ""Complex type 'Tree' description.""
@@ -926,7 +925,6 @@ namespace Microsoft.OpenApi.OData.Tests
       ""$ref"": ""#/components/schemas/ReferenceNumeric""
     }
   ],
-  ""format"": ""double"",
   ""default"": ""3.1415926535897931""
 }".ChangeLineBreaks(), json);
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -406,8 +406,8 @@ namespace Microsoft.OpenApi.OData.Tests
             var property = Assert.Single(declaredSchema.Properties);
             Assert.Equal("Price", property.Key);
             Assert.Equal("decimal", property.Value.Format);
-            Assert.NotNull(property.Value.AnyOf);
-            Assert.Equal(new string[] { "number", "string" }, property.Value.AnyOf.Select(e => e.Type));
+            Assert.NotNull(property.Value.OneOf);
+            Assert.Equal(new string[] { "number", "string" }, property.Value.OneOf.Select(e => e.Type));
 
             Assert.Equal("Complex type 'Tree' description.", declaredSchema.Description);
             Assert.Equal("Tree", declaredSchema.Title);
@@ -428,7 +428,7 @@ namespace Microsoft.OpenApi.OData.Tests
       ""properties"": {
         ""Price"": {
           ""multipleOf"": 1,
-          ""anyOf"": [
+          ""oneOf"": [
             {
               ""type"": ""number""
             },
@@ -913,7 +913,7 @@ namespace Microsoft.OpenApi.OData.Tests
             string json = schema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
 
             Assert.Equal(@"{
-  ""anyOf"": [
+  ""oneOf"": [
     {
       ""type"": ""number""
     },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -436,7 +436,8 @@ namespace Microsoft.OpenApi.OData.Tests
             {
               ""type"": ""string""
             }
-          ]
+          ],
+          ""format"": ""decimal""
         }
       },
       ""description"": ""Complex type 'Tree' description.""
@@ -925,6 +926,7 @@ namespace Microsoft.OpenApi.OData.Tests
       ""$ref"": ""#/components/schemas/ReferenceNumeric""
     }
   ],
+  ""format"": ""double"",
   ""default"": ""3.1415926535897931""
 }".ChangeLineBreaks(), json);
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSpatialTypeSchemaGeneratorTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSpatialTypeSchemaGeneratorTest.cs
@@ -222,7 +222,7 @@ namespace Microsoft.OpenApi.OData.Tests
             // Assert
             Assert.Equal(@"{
   ""type"": ""object"",
-  ""anyOf"": [
+  ""oneOf"": [
     {
       ""$ref"": ""#/components/schemas/Edm.GeometryPoint""
     },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
@@ -63,7 +63,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
@@ -63,7 +63,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionImportOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionImportOperationHandlerTests.cs
@@ -216,6 +216,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""odata-debug"",
       ""in"": ""query"",
       ""description"": ""Debug support for OData services"",
+      ""style"": ""form"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionImportOperationHandlerTests.cs
@@ -290,6 +290,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""myhead1"",
       ""in"": ""header"",
       ""required"": true,
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       }
@@ -302,6 +303,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""myhead2"",
       ""in"": ""header"",
       ""description"": ""This is the description for myhead2."",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       }
@@ -314,6 +316,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""myhead3"",
       ""in"": ""header"",
       ""description"": ""Documentation URL: https://foo.bar.com/myhead3"",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       }
@@ -326,6 +329,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""myhead4"",
       ""in"": ""header"",
       ""description"": ""This is the description for myhead4. Documentation URL: https://foo.bar.com/myhead4"",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
@@ -190,6 +190,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""odata-debug"",
       ""in"": ""query"",
       ""description"": ""Debug support for OData services"",
+      ""style"": ""form"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
@@ -202,6 +202,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""odata-debug"",
       ""in"": ""header"",
       ""description"": ""Debug support for OData services"",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
@@ -192,6 +192,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""odata-debug"",
       ""in"": ""header"",
       ""description"": ""Debug support for OData services"",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
@@ -202,6 +202,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""odata-debug"",
       ""in"": ""header"",
       ""description"": ""Debug support for OData services"",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonGetOperationHandlerTests.cs
@@ -227,6 +227,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""odata-debug"",
       ""in"": ""header"",
       ""description"": ""Debug support for OData services"",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonPatchOperationHandlerTests.cs
@@ -242,6 +242,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""in"": ""header"",
       ""description"": ""Description1"",
       ""required"": true,
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       },
@@ -256,6 +257,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""name"": ""HeadName2"",
       ""in"": ""header"",
       ""description"": ""Description2"",
+      ""style"": ""simple"",
       ""schema"": {
         ""type"": ""string""
       },
@@ -271,6 +273,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
       ""in"": ""query"",
       ""description"": ""Description3"",
       ""required"": true,
+      ""style"": ""form"",
       ""schema"": {
         ""type"": ""string""
       },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -1127,32 +1127,37 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean"
+      "type": "boolean",
+      "collectionFormat": "multi"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -1127,37 +1127,32 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean",
-      "collectionFormat": "multi"
+      "type": "boolean"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -1112,6 +1112,13 @@
       "additionalProperties": {
         "type": "object"
       }
+    },
+    "ReferenceNumeric": {
+      "enum": [
+        "-INF",
+        "INF",
+        "NaN"
+      ]
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -736,6 +736,11 @@ definitions:
         type: string
     additionalProperties:
       type: object
+  ReferenceNumeric:
+    enum:
+      - '-INF'
+      - INF
+      - NaN
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -748,32 +748,27 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
-    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
-    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
-    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -748,27 +748,32 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
+    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
+    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
+    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -1218,6 +1218,13 @@
         "additionalProperties": {
           "type": "object"
         }
+      },
+      "ReferenceNumeric": {
+        "enum": [
+          "-INF",
+          "INF",
+          "NaN"
+        ]
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -146,6 +146,7 @@
             "in": "path",
             "description": "key: Name of City",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -215,6 +216,7 @@
             "in": "path",
             "description": "key: Name of City",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -254,6 +256,7 @@
             "in": "path",
             "description": "key: Name of City",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -263,6 +266,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -429,6 +433,7 @@
             "in": "path",
             "description": "key: Name of CountryOrRegion",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -498,6 +503,7 @@
             "in": "path",
             "description": "key: Name of CountryOrRegion",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -537,6 +543,7 @@
             "in": "path",
             "description": "key: Name of CountryOrRegion",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -546,6 +553,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -814,6 +822,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -886,6 +895,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -925,6 +935,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -934,6 +945,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -1294,6 +1306,7 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -1304,6 +1317,7 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -1313,6 +1327,7 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
         "schema": {
           "type": "boolean"
         }
@@ -1321,6 +1336,7 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
         "schema": {
           "type": "string"
         }
@@ -1329,6 +1345,7 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -808,6 +808,11 @@ components:
           type: string
       additionalProperties:
         type: object
+    ReferenceNumeric:
+      enum:
+        - '-INF'
+        - INF
+        - NaN
   responses:
     error:
       description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -95,6 +95,7 @@ paths:
           in: path
           description: 'key: Name of City'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: City
@@ -142,6 +143,7 @@ paths:
           in: path
           description: 'key: Name of City'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: City
@@ -168,12 +170,14 @@ paths:
           in: path
           description: 'key: Name of City'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: City
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -281,6 +285,7 @@ paths:
           in: path
           description: 'key: Name of CountryOrRegion'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: CountryOrRegion
@@ -328,6 +333,7 @@ paths:
           in: path
           description: 'key: Name of CountryOrRegion'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: CountryOrRegion
@@ -354,12 +360,14 @@ paths:
           in: path
           description: 'key: Name of CountryOrRegion'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: CountryOrRegion
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -540,6 +548,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -590,6 +599,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -616,12 +626,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -855,6 +867,7 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -863,6 +876,7 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -870,18 +884,21 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
       schema:
         type: string
   examples:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -111,32 +111,37 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean"
+      "type": "boolean",
+      "collectionFormat": "multi"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -96,6 +96,13 @@
       "additionalProperties": {
         "type": "object"
       }
+    },
+    "ReferenceNumeric": {
+      "enum": [
+        "-INF",
+        "INF",
+        "NaN"
+      ]
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -111,37 +111,32 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean",
-      "collectionFormat": "multi"
+      "type": "boolean"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -77,27 +77,32 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
+    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
+    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
+    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -65,6 +65,11 @@ definitions:
         type: string
     additionalProperties:
       type: object
+  ReferenceNumeric:
+    enum:
+      - '-INF'
+      - INF
+      - NaN
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -77,32 +77,27 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
-    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
-    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
-    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -101,6 +101,13 @@
         "additionalProperties": {
           "type": "object"
         }
+      },
+      "ReferenceNumeric": {
+        "enum": [
+          "-INF",
+          "INF",
+          "NaN"
+        ]
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -137,6 +137,7 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -147,6 +148,7 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -156,6 +158,7 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
         "schema": {
           "type": "boolean"
         }
@@ -164,6 +167,7 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
         "schema": {
           "type": "string"
         }
@@ -172,6 +176,7 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -91,6 +91,7 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -99,6 +100,7 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -106,18 +108,21 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
       schema:
         type: string
   requestBodies:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -68,6 +68,11 @@ components:
           type: string
       additionalProperties:
         type: object
+    ReferenceNumeric:
+      enum:
+        - '-INF'
+        - INF
+        - NaN
   responses:
     error:
       description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -5827,6 +5827,13 @@
       "additionalProperties": {
         "type": "object"
       }
+    },
+    "ReferenceNumeric": {
+      "enum": [
+        "-INF",
+        "INF",
+        "NaN"
+      ]
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -5845,37 +5845,32 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean",
-      "collectionFormat": "multi"
+      "type": "boolean"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -789,7 +789,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -1626,7 +1627,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -3517,7 +3519,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -5842,32 +5845,37 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean"
+      "type": "boolean",
+      "collectionFormat": "multi"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -568,6 +568,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -1167,6 +1168,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -2536,6 +2538,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -4279,27 +4282,32 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
+    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
+    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
+    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -4267,6 +4267,11 @@ definitions:
         type: string
     additionalProperties:
       type: object
+  ReferenceNumeric:
+    enum:
+      - '-INF'
+      - INF
+      - NaN
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -4282,32 +4282,27 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
-    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
-    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
-    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -161,6 +161,7 @@
             "in": "path",
             "description": "key: Id of CategoryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -238,6 +239,7 @@
             "in": "path",
             "description": "key: Id of CategoryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -280,6 +282,7 @@
             "in": "path",
             "description": "key: Id of CategoryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -292,6 +295,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -487,6 +491,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -581,6 +586,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -623,6 +629,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -635,6 +642,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -665,6 +673,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -706,6 +715,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -857,6 +867,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -870,6 +881,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -882,6 +894,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -890,6 +903,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -917,6 +931,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -950,6 +965,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1046,6 +1062,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1079,6 +1096,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1173,6 +1191,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1214,6 +1233,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1226,6 +1246,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -1266,6 +1287,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1479,6 +1501,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1575,6 +1598,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1617,6 +1641,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1629,6 +1654,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -1659,6 +1685,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1789,6 +1816,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1802,6 +1830,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1814,6 +1843,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -1822,6 +1852,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -1848,6 +1879,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1861,6 +1893,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1955,6 +1988,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -1968,6 +2002,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2009,6 +2044,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2022,6 +2058,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2034,6 +2071,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -2074,6 +2112,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2087,6 +2126,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2117,6 +2157,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2150,6 +2191,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2232,6 +2274,7 @@
             "in": "path",
             "description": "key: Id of LibraryDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2455,6 +2498,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2553,6 +2597,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2595,6 +2640,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2607,6 +2653,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -2637,6 +2684,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2799,6 +2847,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2869,6 +2918,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2903,6 +2953,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -2915,6 +2966,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -2941,6 +2993,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3058,6 +3111,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3099,6 +3153,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3111,6 +3166,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -3151,6 +3207,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3180,6 +3237,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3296,6 +3354,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3337,6 +3396,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3349,6 +3409,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -3389,6 +3450,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3587,6 +3649,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3681,6 +3744,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3723,6 +3787,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3735,6 +3800,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -3765,6 +3831,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3806,6 +3873,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3957,6 +4025,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3970,6 +4039,7 @@
             "in": "path",
             "description": "key: Id of RevisionDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -3982,6 +4052,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -3990,6 +4061,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -4017,6 +4089,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -4050,6 +4123,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -4146,6 +4220,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -4179,6 +4254,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -4273,6 +4349,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -4314,6 +4391,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -4326,6 +4404,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -4366,6 +4445,7 @@
             "in": "path",
             "description": "key: Id of DocumentDto",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -6739,6 +6819,7 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -6749,6 +6830,7 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -6758,6 +6840,7 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
         "schema": {
           "type": "boolean"
         }
@@ -6766,6 +6849,7 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
         "schema": {
           "type": "string"
         }
@@ -6774,6 +6858,7 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -6583,6 +6583,13 @@
         "additionalProperties": {
           "type": "object"
         }
+      },
+      "ReferenceNumeric": {
+        "enum": [
+          "-INF",
+          "INF",
+          "NaN"
+        ]
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -4761,6 +4761,11 @@ components:
           type: string
       additionalProperties:
         type: object
+    ReferenceNumeric:
+      enum:
+        - '-INF'
+        - INF
+        - NaN
   responses:
     error:
       description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -110,6 +110,7 @@ paths:
           in: path
           description: 'key: Id of CategoryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -165,6 +166,7 @@ paths:
           in: path
           description: 'key: Id of CategoryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -194,6 +196,7 @@ paths:
           in: path
           description: 'key: Id of CategoryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -203,6 +206,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -339,6 +343,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -407,6 +412,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -436,6 +442,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -445,6 +452,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -465,6 +473,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -493,6 +502,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -609,6 +619,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -619,6 +630,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -628,11 +640,13 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -651,6 +665,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -674,6 +689,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -746,6 +762,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -769,6 +786,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -830,6 +848,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -858,6 +877,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -867,6 +887,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -893,6 +914,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1047,6 +1069,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1118,6 +1141,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1147,6 +1171,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1156,6 +1181,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -1176,6 +1202,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1271,6 +1298,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1281,6 +1309,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1290,11 +1319,13 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -1312,6 +1343,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1322,6 +1354,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1383,6 +1416,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1393,6 +1427,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1421,6 +1456,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1431,6 +1467,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1440,6 +1477,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -1466,6 +1504,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1476,6 +1515,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1497,6 +1537,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1520,6 +1561,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1578,6 +1620,7 @@ paths:
           in: path
           description: 'key: Id of LibraryDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1741,6 +1784,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1814,6 +1858,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1843,6 +1888,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -1852,6 +1898,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -1872,6 +1919,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2000,6 +2048,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2047,6 +2096,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2071,6 +2121,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2080,6 +2131,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -2097,6 +2149,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2181,6 +2234,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2209,6 +2263,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2218,6 +2273,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -2244,6 +2300,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2264,6 +2321,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2347,6 +2405,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2375,6 +2434,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2384,6 +2444,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -2410,6 +2471,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2549,6 +2611,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2617,6 +2680,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2646,6 +2710,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2655,6 +2720,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -2675,6 +2741,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2703,6 +2770,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2819,6 +2887,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2829,6 +2898,7 @@ paths:
           in: path
           description: 'key: Id of RevisionDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2838,11 +2908,13 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -2861,6 +2933,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2884,6 +2957,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2956,6 +3030,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -2979,6 +3054,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -3040,6 +3116,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -3068,6 +3145,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -3077,6 +3155,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -3103,6 +3182,7 @@ paths:
           in: path
           description: 'key: Id of DocumentDto'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -4856,6 +4936,7 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -4864,6 +4945,7 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -4871,18 +4953,21 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
       schema:
         type: string
   examples:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -724,7 +724,7 @@
         ],
         "summary": "Update the ref of navigation property EmergencyAuthority in Airports",
         "operationId": "Airports.UpdateRefEmergencyAuthority",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -737,7 +737,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -1665,12 +1665,12 @@
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
         "operationId": "Me.UpdateRefBestFriend",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -2820,12 +2820,12 @@
         ],
         "summary": "Create new navigation property ref to Peers for Me",
         "operationId": "Me.BestFriend.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -3607,12 +3607,12 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
         "operationId": "Me.BestFriend.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -5089,7 +5089,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for Me",
         "operationId": "Me.Friends.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -5102,7 +5102,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -5998,7 +5998,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
         "operationId": "Me.Friends.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -6011,7 +6011,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -6135,12 +6135,12 @@
         ],
         "summary": "Create new navigation property ref to Friends for Me",
         "operationId": "Me.CreateRefFriends",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -7308,12 +7308,12 @@
         ],
         "summary": "Create new navigation property ref to Peers for Me",
         "operationId": "Me.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -8243,12 +8243,12 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
         "operationId": "Me.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -9067,7 +9067,7 @@
         ],
         "summary": "Create new navigation property ref to PlanItems for Me",
         "operationId": "Me.Trips.CreateRefPlanItems",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -9083,7 +9083,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -9784,7 +9784,7 @@
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
         "operationId": "NewComePeople.UpdateRefBestFriend",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -9797,7 +9797,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -11148,7 +11148,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for NewComePeople",
         "operationId": "NewComePeople.BestFriend.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -11161,7 +11161,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -12056,7 +12056,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for NewComePeople",
         "operationId": "NewComePeople.BestFriend.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -12069,7 +12069,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -13570,7 +13570,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for NewComePeople",
         "operationId": "NewComePeople.Friends.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -13591,7 +13591,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -14493,7 +14493,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for NewComePeople",
         "operationId": "NewComePeople.Friends.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -14514,7 +14514,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -14635,7 +14635,7 @@
         ],
         "summary": "Create new navigation property ref to Friends for NewComePeople",
         "operationId": "NewComePeople.CreateRefFriends",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -14648,7 +14648,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -16032,7 +16032,7 @@
         ],
         "summary": "Create new navigation property ref to PlanItems for NewComePeople",
         "operationId": "NewComePeople.Trips.CreateRefPlanItems",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -16056,7 +16056,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -16845,7 +16845,7 @@
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
         "operationId": "People.UpdateRefBestFriend",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -16858,7 +16858,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -18210,7 +18210,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for People",
         "operationId": "People.BestFriend.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -18223,7 +18223,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -19119,7 +19119,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
         "operationId": "People.BestFriend.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -19132,7 +19132,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -20809,7 +20809,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for People",
         "operationId": "People.Friends.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -20830,7 +20830,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -21838,7 +21838,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
         "operationId": "People.Friends.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -21859,7 +21859,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -22001,7 +22001,7 @@
         ],
         "summary": "Create new navigation property ref to Friends for People",
         "operationId": "People.CreateRefFriends",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -22014,7 +22014,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -23358,7 +23358,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for People",
         "operationId": "People.CreateRefPeers",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -23371,7 +23371,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -24441,7 +24441,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
         "operationId": "People.CreateRefDirectReports",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -24454,7 +24454,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -25377,7 +25377,7 @@
         ],
         "summary": "Create new navigation property ref to PlanItems for People",
         "operationId": "People.Trips.CreateRefPlanItems",
-        "consumes": [],
+        "consumes": [ ],
         "parameters": [
           {
             "in": "path",
@@ -25401,7 +25401,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": { }
           }
         ],
         "responses": {
@@ -25792,7 +25792,7 @@
         "Gender": {
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
         },
-        "Age": {},
+        "Age": { },
         "Emails": {
           "type": "array",
           "items": {
@@ -25945,7 +25945,7 @@
         "Name": {
           "type": "string"
         },
-        "Budget": {},
+        "Budget": { },
         "Description": {
           "type": "string"
         },
@@ -26072,7 +26072,7 @@
           "title": "Employee",
           "type": "object",
           "properties": {
-            "Cost": {},
+            "Cost": { },
             "Peers": {
               "type": "array",
               "items": {
@@ -26092,7 +26092,7 @@
           "title": "Manager",
           "type": "object",
           "properties": {
-            "Budget": {},
+            "Budget": { },
             "BossOffice": {
               "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
             },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1167,14 +1167,12 @@
           {
             "in": "path",
             "name": "lat",
-            "required": true,
-            "format": "double"
+            "required": true
           },
           {
             "in": "path",
             "name": "lon",
-            "required": true,
-            "format": "double"
+            "required": true
           }
         ],
         "responses": {
@@ -25795,7 +25793,13 @@
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
         },
         "Age": {
-          "format": "int64"
+          "format": "int64",
+          "allOf": [
+            {
+              "format": "int64",
+              "type": "integer"
+            }
+          ]
         },
         "Emails": {
           "type": "array",
@@ -25950,7 +25954,13 @@
           "type": "string"
         },
         "Budget": {
-          "format": "float"
+          "format": "float",
+          "allOf": [
+            {
+              "format": "float",
+              "type": "number"
+            }
+          ]
         },
         "Description": {
           "type": "string"
@@ -26079,7 +26089,13 @@
           "type": "object",
           "properties": {
             "Cost": {
-              "format": "int64"
+              "format": "int64",
+              "allOf": [
+                {
+                  "format": "int64",
+                  "type": "integer"
+                }
+              ]
             },
             "Peers": {
               "type": "array",
@@ -26101,7 +26117,13 @@
           "type": "object",
           "properties": {
             "Budget": {
-              "format": "int64"
+              "format": "int64",
+              "allOf": [
+                {
+                  "format": "int64",
+                  "type": "integer"
+                }
+              ]
             },
             "BossOffice": {
               "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
@@ -26182,7 +26204,12 @@
       "$ref": "#/definitions/Edm.GeometryCollection"
     },
     "Edm.Geometry": {
-      "type": "object"
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Edm.GeometryPoint"
+        }
+      ]
     },
     "Edm.GeometryPoint": {
       "required": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1167,14 +1167,12 @@
           {
             "in": "path",
             "name": "lat",
-            "required": true,
-            "format": "double"
+            "required": true
           },
           {
             "in": "path",
             "name": "lon",
-            "required": true,
-            "format": "double"
+            "required": true
           }
         ],
         "responses": {
@@ -25794,9 +25792,7 @@
         "Gender": {
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
         },
-        "Age": {
-          "format": "int64"
-        },
+        "Age": {},
         "Emails": {
           "type": "array",
           "items": {
@@ -25949,9 +25945,7 @@
         "Name": {
           "type": "string"
         },
-        "Budget": {
-          "format": "float"
-        },
+        "Budget": {},
         "Description": {
           "type": "string"
         },
@@ -26078,9 +26072,7 @@
           "title": "Employee",
           "type": "object",
           "properties": {
-            "Cost": {
-              "format": "int64"
-            },
+            "Cost": {},
             "Peers": {
               "type": "array",
               "items": {
@@ -26100,9 +26092,7 @@
           "title": "Manager",
           "type": "object",
           "properties": {
-            "Budget": {
-              "format": "int64"
-            },
+            "Budget": {},
             "BossOffice": {
               "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
             },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -26585,6 +26585,13 @@
       "additionalProperties": {
         "type": "object"
       }
+    },
+    "ReferenceNumeric": {
+      "enum": [
+        "-INF",
+        "INF",
+        "NaN"
+      ]
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1167,12 +1167,14 @@
           {
             "in": "path",
             "name": "lat",
-            "required": true
+            "required": true,
+            "format": "double"
           },
           {
             "in": "path",
             "name": "lon",
-            "required": true
+            "required": true,
+            "format": "double"
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -27056,37 +27056,32 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0,
-      "collectionFormat": "multi"
+      "minimum": 0
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean",
-      "collectionFormat": "multi"
+      "type": "boolean"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string",
-      "collectionFormat": "multi"
+      "type": "string"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1167,12 +1167,14 @@
           {
             "in": "path",
             "name": "lat",
-            "required": true
+            "required": true,
+            "format": "double"
           },
           {
             "in": "path",
             "name": "lon",
-            "required": true
+            "required": true,
+            "format": "double"
           }
         ],
         "responses": {
@@ -25792,7 +25794,9 @@
         "Gender": {
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
         },
-        "Age": { },
+        "Age": {
+          "format": "int64"
+        },
         "Emails": {
           "type": "array",
           "items": {
@@ -25945,7 +25949,9 @@
         "Name": {
           "type": "string"
         },
-        "Budget": { },
+        "Budget": {
+          "format": "float"
+        },
         "Description": {
           "type": "string"
         },
@@ -26072,7 +26078,9 @@
           "title": "Employee",
           "type": "object",
           "properties": {
-            "Cost": { },
+            "Cost": {
+              "format": "int64"
+            },
             "Peers": {
               "type": "array",
               "items": {
@@ -26092,7 +26100,9 @@
           "title": "Manager",
           "type": "object",
           "properties": {
-            "Budget": { },
+            "Budget": {
+              "format": "int64"
+            },
             "BossOffice": {
               "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
             },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1167,12 +1167,14 @@
           {
             "in": "path",
             "name": "lat",
-            "required": true
+            "required": true,
+            "format": "double"
           },
           {
             "in": "path",
             "name": "lon",
-            "required": true
+            "required": true,
+            "format": "double"
           }
         ],
         "responses": {
@@ -25792,7 +25794,9 @@
         "Gender": {
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
         },
-        "Age": {},
+        "Age": {
+          "format": "int64"
+        },
         "Emails": {
           "type": "array",
           "items": {
@@ -25945,7 +25949,9 @@
         "Name": {
           "type": "string"
         },
-        "Budget": {},
+        "Budget": {
+          "format": "float"
+        },
         "Description": {
           "type": "string"
         },
@@ -26072,7 +26078,9 @@
           "title": "Employee",
           "type": "object",
           "properties": {
-            "Cost": {},
+            "Cost": {
+              "format": "int64"
+            },
             "Peers": {
               "type": "array",
               "items": {
@@ -26092,7 +26100,9 @@
           "title": "Manager",
           "type": "object",
           "properties": {
-            "Budget": {},
+            "Budget": {
+              "format": "int64"
+            },
             "BossOffice": {
               "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
             },
@@ -26575,13 +26585,6 @@
       "additionalProperties": {
         "type": "object"
       }
-    },
-    "ReferenceNumeric": {
-      "enum": [
-        "-INF",
-        "INF",
-        "NaN"
-      ]
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -724,7 +724,7 @@
         ],
         "summary": "Update the ref of navigation property EmergencyAuthority in Airports",
         "operationId": "Airports.UpdateRefEmergencyAuthority",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -737,7 +737,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -1665,12 +1665,12 @@
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
         "operationId": "Me.UpdateRefBestFriend",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -2820,12 +2820,12 @@
         ],
         "summary": "Create new navigation property ref to Peers for Me",
         "operationId": "Me.BestFriend.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -3607,12 +3607,12 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
         "operationId": "Me.BestFriend.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -5089,7 +5089,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for Me",
         "operationId": "Me.Friends.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -5102,7 +5102,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -5998,7 +5998,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
         "operationId": "Me.Friends.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -6011,7 +6011,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -6135,12 +6135,12 @@
         ],
         "summary": "Create new navigation property ref to Friends for Me",
         "operationId": "Me.CreateRefFriends",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -7308,12 +7308,12 @@
         ],
         "summary": "Create new navigation property ref to Peers for Me",
         "operationId": "Me.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -8243,12 +8243,12 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
         "operationId": "Me.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -9067,7 +9067,7 @@
         ],
         "summary": "Create new navigation property ref to PlanItems for Me",
         "operationId": "Me.Trips.CreateRefPlanItems",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -9083,7 +9083,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -9784,7 +9784,7 @@
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
         "operationId": "NewComePeople.UpdateRefBestFriend",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -9797,7 +9797,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -11148,7 +11148,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for NewComePeople",
         "operationId": "NewComePeople.BestFriend.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -11161,7 +11161,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -12056,7 +12056,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for NewComePeople",
         "operationId": "NewComePeople.BestFriend.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -12069,7 +12069,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -13570,7 +13570,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for NewComePeople",
         "operationId": "NewComePeople.Friends.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -13591,7 +13591,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -14493,7 +14493,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for NewComePeople",
         "operationId": "NewComePeople.Friends.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -14514,7 +14514,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -14635,7 +14635,7 @@
         ],
         "summary": "Create new navigation property ref to Friends for NewComePeople",
         "operationId": "NewComePeople.CreateRefFriends",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -14648,7 +14648,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -16032,7 +16032,7 @@
         ],
         "summary": "Create new navigation property ref to PlanItems for NewComePeople",
         "operationId": "NewComePeople.Trips.CreateRefPlanItems",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -16056,7 +16056,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -16845,7 +16845,7 @@
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
         "operationId": "People.UpdateRefBestFriend",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -16858,7 +16858,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -18210,7 +18210,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for People",
         "operationId": "People.BestFriend.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -18223,7 +18223,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -19119,7 +19119,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
         "operationId": "People.BestFriend.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -19132,7 +19132,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -20809,7 +20809,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for People",
         "operationId": "People.Friends.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -20830,7 +20830,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -21838,7 +21838,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
         "operationId": "People.Friends.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -21859,7 +21859,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -22001,7 +22001,7 @@
         ],
         "summary": "Create new navigation property ref to Friends for People",
         "operationId": "People.CreateRefFriends",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -22014,7 +22014,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -23358,7 +23358,7 @@
         ],
         "summary": "Create new navigation property ref to Peers for People",
         "operationId": "People.CreateRefPeers",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -23371,7 +23371,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -24441,7 +24441,7 @@
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
         "operationId": "People.CreateRefDirectReports",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -24454,7 +24454,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {
@@ -25377,7 +25377,7 @@
         ],
         "summary": "Create new navigation property ref to PlanItems for People",
         "operationId": "People.Trips.CreateRefPlanItems",
-        "consumes": [ ],
+        "consumes": [],
         "parameters": [
           {
             "in": "path",
@@ -25401,7 +25401,7 @@
           {
             "in": "body",
             "name": "body",
-            "schema": { }
+            "schema": {}
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -2279,7 +2279,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -3066,7 +3067,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -3776,7 +3778,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -4458,7 +4461,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -5367,7 +5371,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -6767,7 +6772,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -7764,7 +7770,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -9066,7 +9073,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -10652,7 +10660,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -11560,7 +11569,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -12377,7 +12387,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -13070,7 +13081,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -13993,7 +14005,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -16171,7 +16184,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -17849,7 +17863,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -18758,7 +18773,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -19582,7 +19598,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -20360,7 +20377,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -21389,7 +21407,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -22997,7 +23016,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -24142,7 +24162,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -25630,7 +25651,8 @@
             "in": "query",
             "name": "@id",
             "description": "Delete Uri",
-            "type": "string"
+            "type": "string",
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -27032,32 +27054,37 @@
       "name": "$top",
       "description": "Show only the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "skip": {
       "in": "query",
       "name": "$skip",
       "description": "Skip the first n items",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "collectionFormat": "multi"
     },
     "count": {
       "in": "query",
       "name": "$count",
       "description": "Include count of items",
-      "type": "boolean"
+      "type": "boolean",
+      "collectionFormat": "multi"
     },
     "filter": {
       "in": "query",
       "name": "$filter",
       "description": "Filter items by property values",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     },
     "search": {
       "in": "query",
       "name": "$search",
       "description": "Search items by search phrases",
-      "type": "string"
+      "type": "string",
+      "collectionFormat": "multi"
     }
   },
   "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1167,14 +1167,12 @@
           {
             "in": "path",
             "name": "lat",
-            "required": true,
-            "format": "double"
+            "required": true
           },
           {
             "in": "path",
             "name": "lon",
-            "required": true,
-            "format": "double"
+            "required": true
           }
         ],
         "responses": {
@@ -25794,9 +25792,7 @@
         "Gender": {
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
         },
-        "Age": {
-          "format": "int64"
-        },
+        "Age": {},
         "Emails": {
           "type": "array",
           "items": {
@@ -25949,9 +25945,7 @@
         "Name": {
           "type": "string"
         },
-        "Budget": {
-          "format": "float"
-        },
+        "Budget": {},
         "Description": {
           "type": "string"
         },
@@ -26078,9 +26072,7 @@
           "title": "Employee",
           "type": "object",
           "properties": {
-            "Cost": {
-              "format": "int64"
-            },
+            "Cost": {},
             "Peers": {
               "type": "array",
               "items": {
@@ -26100,9 +26092,7 @@
           "title": "Manager",
           "type": "object",
           "properties": {
-            "Budget": {
-              "format": "int64"
-            },
+            "Budget": {},
             "BossOffice": {
               "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
             },
@@ -26585,6 +26575,13 @@
       "additionalProperties": {
         "type": "object"
       }
+    },
+    "ReferenceNumeric": {
+      "enum": [
+        "-INF",
+        "INF",
+        "NaN"
+      ]
     }
   },
   "parameters": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -790,11 +790,9 @@ paths:
         - in: path
           name: lat
           required: true
-          format: double
         - in: path
           name: lon
           required: true
-          format: double
       responses:
         '200':
           description: Success
@@ -18304,8 +18302,7 @@ definitions:
         type: string
       Gender:
         $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'
-      Age:
-        format: int64
+      Age: { }
       Emails:
         type: array
         items:
@@ -18404,8 +18401,7 @@ definitions:
         type: string
       Name:
         type: string
-      Budget:
-        format: float
+      Budget: { }
       Description:
         type: string
       Tags:
@@ -18485,8 +18481,7 @@ definitions:
       - title: Employee
         type: object
         properties:
-          Cost:
-            format: int64
+          Cost: { }
           Peers:
             type: array
             items:
@@ -18497,8 +18492,7 @@ definitions:
       - title: Manager
         type: object
         properties:
-          Budget:
-            format: int64
+          Budget: { }
           BossOffice:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
           DirectReports:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -790,9 +790,11 @@ paths:
         - in: path
           name: lat
           required: true
+          format: double
         - in: path
           name: lon
           required: true
+          format: double
       responses:
         '200':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -790,9 +790,11 @@ paths:
         - in: path
           name: lat
           required: true
+          format: double
         - in: path
           name: lon
           required: true
+          format: double
       responses:
         '200':
           description: Success
@@ -18302,7 +18304,8 @@ definitions:
         type: string
       Gender:
         $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'
-      Age: { }
+      Age:
+        format: int64
       Emails:
         type: array
         items:
@@ -18401,7 +18404,8 @@ definitions:
         type: string
       Name:
         type: string
-      Budget: { }
+      Budget:
+        format: float
       Description:
         type: string
       Tags:
@@ -18481,7 +18485,8 @@ definitions:
       - title: Employee
         type: object
         properties:
-          Cost: { }
+          Cost:
+            format: int64
           Peers:
             type: array
             items:
@@ -18492,7 +18497,8 @@ definitions:
       - title: Manager
         type: object
         properties:
-          Budget: { }
+          Budget:
+            format: int64
           BossOffice:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
           DirectReports:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1577,6 +1577,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -2136,6 +2137,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -2637,6 +2639,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -3122,6 +3125,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -3772,6 +3776,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -4776,6 +4781,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -5483,6 +5489,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -6409,6 +6416,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -7531,6 +7539,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -8180,6 +8189,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -8760,6 +8770,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -9244,6 +9255,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -9893,6 +9905,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -11423,6 +11436,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -12617,6 +12631,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -13267,6 +13282,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -13853,6 +13869,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -14410,6 +14427,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -15150,6 +15168,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -16308,6 +16327,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -17125,6 +17145,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -18190,6 +18211,7 @@ paths:
           name: '@id'
           description: Delete Uri
           type: string
+          collectionFormat: multi
       responses:
         '204':
           description: Success
@@ -19141,27 +19163,32 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
+    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
+    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
+    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
+    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -790,11 +790,9 @@ paths:
         - in: path
           name: lat
           required: true
-          format: double
         - in: path
           name: lon
           required: true
-          format: double
       responses:
         '200':
           description: Success
@@ -18306,6 +18304,9 @@ definitions:
         $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'
       Age:
         format: int64
+        allOf:
+          - format: int64
+            type: integer
       Emails:
         type: array
         items:
@@ -18406,6 +18407,9 @@ definitions:
         type: string
       Budget:
         format: float
+        allOf:
+          - format: float
+            type: number
       Description:
         type: string
       Tags:
@@ -18487,6 +18491,9 @@ definitions:
         properties:
           Cost:
             format: int64
+            allOf:
+              - format: int64
+                type: integer
           Peers:
             type: array
             items:
@@ -18499,6 +18506,9 @@ definitions:
         properties:
           Budget:
             format: int64
+            allOf:
+              - format: int64
+                type: integer
           BossOffice:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
           DirectReports:
@@ -18552,6 +18562,8 @@ definitions:
     $ref: '#/definitions/Edm.GeometryCollection'
   Edm.Geometry:
     type: object
+    allOf:
+      - $ref: '#/definitions/Edm.GeometryPoint'
   Edm.GeometryPoint:
     required:
       - type

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -19165,32 +19165,27 @@ parameters:
     description: Show only the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   skip:
     in: query
     name: $skip
     description: Skip the first n items
     type: integer
     minimum: 0
-    collectionFormat: multi
   count:
     in: query
     name: $count
     description: Include count of items
     type: boolean
-    collectionFormat: multi
   filter:
     in: query
     name: $filter
     description: Filter items by property values
     type: string
-    collectionFormat: multi
   search:
     in: query
     name: $search
     description: Search items by search phrases
     type: string
-    collectionFormat: multi
 responses:
   error:
     description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -18820,6 +18820,11 @@ definitions:
         type: string
     additionalProperties:
       type: object
+  ReferenceNumeric:
+    enum:
+      - '-INF'
+      - INF
+      - NaN
 parameters:
   top:
     in: query

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -149,6 +149,7 @@
             "in": "path",
             "description": "key: AirlineCode of Airline",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -219,6 +220,7 @@
             "in": "path",
             "description": "key: AirlineCode of Airline",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -258,6 +260,7 @@
             "in": "path",
             "description": "key: AirlineCode of Airline",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -267,6 +270,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -442,6 +446,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -514,6 +519,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -553,6 +559,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -562,6 +569,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -588,6 +596,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -657,6 +666,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -699,6 +709,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -788,6 +799,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -823,6 +835,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -854,6 +867,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -863,6 +877,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -889,6 +904,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -983,6 +999,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1021,6 +1038,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1030,6 +1048,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -1070,6 +1089,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1100,6 +1120,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1127,6 +1148,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1153,6 +1175,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1219,6 +1242,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1260,6 +1284,7 @@
             "in": "path",
             "description": "key: IcaoCode of Airport",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -1304,6 +1329,7 @@
             "name": "lat",
             "in": "path",
             "required": true,
+            "style": "simple",
             "schema": {
               "oneOf": [
                 {
@@ -1323,6 +1349,7 @@
             "name": "lon",
             "in": "path",
             "required": true,
+            "style": "simple",
             "schema": {
               "oneOf": [
                 {
@@ -1652,6 +1679,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -1914,6 +1942,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -2070,6 +2099,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -2528,6 +2558,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2537,6 +2568,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -2545,6 +2577,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -2578,6 +2611,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2679,6 +2713,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2724,6 +2759,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2733,6 +2769,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -2780,6 +2817,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2817,6 +2855,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2851,6 +2890,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2884,6 +2924,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -2957,6 +2998,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3005,6 +3047,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3390,6 +3433,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3399,6 +3443,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -3407,6 +3452,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -3440,6 +3486,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3541,6 +3588,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3586,6 +3634,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3595,6 +3644,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -3642,6 +3692,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3679,6 +3730,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3713,6 +3765,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3746,6 +3799,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3819,6 +3873,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -3867,6 +3922,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4164,6 +4220,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4173,6 +4230,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -4181,6 +4239,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -4214,6 +4273,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4315,6 +4375,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4360,6 +4421,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4369,6 +4431,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -4416,6 +4479,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4453,6 +4517,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4487,6 +4552,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4520,6 +4586,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4593,6 +4660,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4641,6 +4709,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4678,6 +4747,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4772,6 +4842,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4917,6 +4988,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4927,6 +4999,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4936,6 +5009,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -4944,6 +5018,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -4977,6 +5052,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -4987,6 +5063,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5088,6 +5165,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5098,6 +5176,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5143,6 +5222,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5153,6 +5233,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5162,6 +5243,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -5209,6 +5291,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5219,6 +5302,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5256,6 +5340,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5266,6 +5351,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5300,6 +5386,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5310,6 +5397,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5343,6 +5431,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5353,6 +5442,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5426,6 +5516,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5436,6 +5527,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5484,6 +5576,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5494,6 +5587,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5528,6 +5622,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5565,6 +5660,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5653,6 +5749,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5694,6 +5791,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5788,6 +5886,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5933,6 +6032,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5943,6 +6043,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -5952,6 +6053,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -5960,6 +6062,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -5993,6 +6096,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6003,6 +6107,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6104,6 +6209,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6114,6 +6220,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6159,6 +6266,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6169,6 +6277,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6178,6 +6287,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -6225,6 +6335,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6235,6 +6346,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6272,6 +6384,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6282,6 +6395,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6316,6 +6430,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6326,6 +6441,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6359,6 +6475,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6369,6 +6486,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6442,6 +6560,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6452,6 +6571,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6500,6 +6620,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6510,6 +6631,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6544,6 +6666,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6581,6 +6704,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -6669,6 +6793,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7482,6 +7607,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7491,6 +7617,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -7499,6 +7626,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -7532,6 +7660,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7633,6 +7762,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7678,6 +7808,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7687,6 +7818,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -7734,6 +7866,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7771,6 +7904,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7805,6 +7939,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7838,6 +7973,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7911,6 +8047,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -7959,6 +8096,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8166,6 +8304,7 @@
             "in": "path",
             "description": "Usage: userName='{userName}'",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -8590,6 +8729,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8599,6 +8739,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -8607,6 +8748,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -8640,6 +8782,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8741,6 +8884,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8786,6 +8930,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8795,6 +8940,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -8842,6 +8988,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8879,6 +9026,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8913,6 +9061,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -8946,6 +9095,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -9019,6 +9169,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -9067,6 +9218,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -9333,6 +9485,7 @@
             "in": "path",
             "description": "Usage: lastName='{lastName}'",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -9545,6 +9698,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -9634,6 +9788,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -9684,6 +9839,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -9696,6 +9852,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -9733,6 +9890,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -9881,6 +10039,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -10001,6 +10160,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -10014,6 +10174,7 @@
             "in": "path",
             "description": "key: PlanItemId of PlanItem",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -10026,6 +10187,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -10034,6 +10196,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -10068,6 +10231,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -10108,6 +10272,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -10187,6 +10352,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -10410,6 +10576,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10495,6 +10662,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10534,6 +10702,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10543,6 +10712,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -10569,6 +10739,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10663,6 +10834,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10701,6 +10873,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10710,6 +10883,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -10750,6 +10924,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10780,6 +10955,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10807,6 +10983,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10838,6 +11015,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10934,6 +11112,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -10977,6 +11156,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11015,6 +11195,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11024,6 +11205,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -11057,6 +11239,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11158,6 +11341,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11203,6 +11387,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11212,6 +11397,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -11259,6 +11445,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11296,6 +11483,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11330,6 +11518,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11363,6 +11552,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11436,6 +11626,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11484,6 +11675,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11521,6 +11713,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11615,6 +11808,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11759,6 +11953,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11769,6 +11964,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11778,6 +11974,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -11786,6 +11983,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -11819,6 +12017,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11829,6 +12028,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11930,6 +12130,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11940,6 +12141,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11985,6 +12187,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -11995,6 +12198,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12004,6 +12208,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -12051,6 +12256,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12061,6 +12267,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12098,6 +12305,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12108,6 +12316,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12142,6 +12351,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12152,6 +12362,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12185,6 +12396,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12195,6 +12407,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12268,6 +12481,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12278,6 +12492,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12326,6 +12541,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12336,6 +12552,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12370,6 +12587,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12407,6 +12625,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12495,6 +12714,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12536,6 +12756,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12630,6 +12851,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12774,6 +12996,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12784,6 +13007,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12793,6 +13017,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -12801,6 +13026,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -12834,6 +13060,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12844,6 +13071,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12945,6 +13173,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -12955,6 +13184,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13000,6 +13230,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13010,6 +13241,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13019,6 +13251,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -13066,6 +13299,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13076,6 +13310,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13113,6 +13348,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13123,6 +13359,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13157,6 +13394,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13167,6 +13405,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13200,6 +13439,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13210,6 +13450,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13283,6 +13524,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13293,6 +13535,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13341,6 +13584,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13351,6 +13595,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13385,6 +13630,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13422,6 +13668,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13510,6 +13757,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13551,6 +13799,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13685,6 +13934,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13695,6 +13945,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13704,6 +13955,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -13712,6 +13964,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -13738,6 +13991,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13748,6 +14002,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13842,6 +14097,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13852,6 +14108,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13890,6 +14147,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13900,6 +14158,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13909,6 +14168,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -13949,6 +14209,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13959,6 +14220,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13989,6 +14251,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -13999,6 +14262,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14026,6 +14290,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14036,6 +14301,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14062,6 +14328,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14072,6 +14339,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14138,6 +14406,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14148,6 +14417,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14189,6 +14459,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14199,6 +14470,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14229,6 +14501,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14239,6 +14512,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14326,6 +14600,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14336,6 +14611,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14473,6 +14749,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14483,6 +14760,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14493,6 +14771,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14502,6 +14781,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -14510,6 +14790,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -14536,6 +14817,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14546,6 +14828,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14556,6 +14839,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14650,6 +14934,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14660,6 +14945,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14670,6 +14956,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14708,6 +14995,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14718,6 +15006,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14728,6 +15017,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14737,6 +15027,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -14777,6 +15068,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14787,6 +15079,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14797,6 +15090,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14827,6 +15121,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14837,6 +15132,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14847,6 +15143,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14874,6 +15171,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14884,6 +15182,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14894,6 +15193,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14920,6 +15220,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14930,6 +15231,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -14940,6 +15242,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15006,6 +15309,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15016,6 +15320,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15026,6 +15331,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15067,6 +15373,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15077,6 +15384,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15087,6 +15395,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15114,6 +15423,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15124,6 +15434,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15154,6 +15465,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15164,6 +15476,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15245,6 +15558,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15255,6 +15569,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15289,6 +15604,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15299,6 +15615,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15386,6 +15703,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15396,6 +15714,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15533,6 +15852,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15543,6 +15863,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15553,6 +15874,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15562,6 +15884,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -15570,6 +15893,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -15596,6 +15920,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15606,6 +15931,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15616,6 +15942,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15710,6 +16037,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15720,6 +16048,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15730,6 +16059,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15768,6 +16098,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15778,6 +16109,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15788,6 +16120,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15797,6 +16130,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -15837,6 +16171,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15847,6 +16182,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15857,6 +16193,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15887,6 +16224,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15897,6 +16235,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15907,6 +16246,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15934,6 +16274,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15944,6 +16285,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15954,6 +16296,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15980,6 +16323,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -15990,6 +16334,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16000,6 +16345,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16066,6 +16412,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16076,6 +16423,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16086,6 +16434,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16127,6 +16476,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16137,6 +16487,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16147,6 +16498,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16174,6 +16526,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16184,6 +16537,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16214,6 +16568,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16224,6 +16579,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16305,6 +16661,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16315,6 +16672,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16346,6 +16704,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16376,6 +16735,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16457,6 +16817,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16491,6 +16852,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16621,6 +16983,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16651,6 +17014,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16781,6 +17145,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16807,6 +17172,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16873,6 +17239,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16914,6 +17281,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16944,6 +17312,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -16990,6 +17359,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17000,6 +17370,7 @@
             "in": "path",
             "description": "Usage: userName='{userName}'",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -17133,6 +17504,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17211,6 +17583,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17267,6 +17640,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17320,6 +17694,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17330,6 +17705,7 @@
             "in": "path",
             "description": "Usage: lastName='{lastName}'",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -17374,6 +17750,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17493,6 +17870,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17543,6 +17921,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17553,6 +17932,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -17635,6 +18015,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17645,6 +18026,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -17688,6 +18070,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17698,6 +18081,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -17710,6 +18094,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -17740,6 +18125,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17750,6 +18136,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -17891,6 +18278,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -17901,6 +18289,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -18014,6 +18403,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18024,6 +18414,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -18037,6 +18428,7 @@
             "in": "path",
             "description": "key: PlanItemId of PlanItem",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -18049,6 +18441,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -18057,6 +18450,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -18084,6 +18478,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18094,6 +18489,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -18127,6 +18523,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18137,6 +18534,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -18209,6 +18607,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18219,6 +18618,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -18253,6 +18653,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18469,6 +18870,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18561,6 +18963,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18607,6 +19010,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18616,6 +19020,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -18649,6 +19054,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18750,6 +19156,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18795,6 +19202,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18804,6 +19212,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -18851,6 +19260,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18888,6 +19298,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18922,6 +19333,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -18960,6 +19372,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19056,6 +19469,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19099,6 +19513,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19137,6 +19552,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19146,6 +19562,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -19179,6 +19596,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19280,6 +19698,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19325,6 +19744,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19334,6 +19754,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -19381,6 +19802,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19418,6 +19840,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19452,6 +19875,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19485,6 +19909,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19558,6 +19983,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19606,6 +20032,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19643,6 +20070,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19737,6 +20165,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19882,6 +20311,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19892,6 +20322,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19901,6 +20332,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -19909,6 +20341,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -19942,6 +20375,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -19952,6 +20386,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20053,6 +20488,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20063,6 +20499,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20108,6 +20545,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20118,6 +20556,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20127,6 +20566,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -20174,6 +20614,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20184,6 +20625,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20221,6 +20663,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20231,6 +20674,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20265,6 +20709,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20275,6 +20720,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20308,6 +20754,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20318,6 +20765,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20391,6 +20839,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20401,6 +20850,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20449,6 +20899,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20459,6 +20910,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20493,6 +20945,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20530,6 +20983,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20618,6 +21072,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20659,6 +21114,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20753,6 +21209,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20898,6 +21355,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20908,6 +21366,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20917,6 +21376,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -20925,6 +21385,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -20958,6 +21419,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -20968,6 +21430,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21069,6 +21532,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21079,6 +21543,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21124,6 +21589,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21134,6 +21600,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21143,6 +21610,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -21190,6 +21658,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21200,6 +21669,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21237,6 +21707,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21247,6 +21718,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21281,6 +21753,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21291,6 +21764,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21324,6 +21798,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21334,6 +21809,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21407,6 +21883,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21417,6 +21894,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21465,6 +21943,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21475,6 +21954,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21509,6 +21989,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21546,6 +22027,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21634,6 +22116,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21675,6 +22158,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21816,6 +22300,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21826,6 +22311,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21835,6 +22321,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -21843,6 +22330,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -21876,6 +22364,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21886,6 +22375,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21987,6 +22477,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -21997,6 +22488,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22042,6 +22534,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22052,6 +22545,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22061,6 +22555,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -22108,6 +22603,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22118,6 +22614,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22155,6 +22652,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22165,6 +22663,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22199,6 +22698,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22209,6 +22709,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22242,6 +22743,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22252,6 +22754,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22325,6 +22828,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22335,6 +22839,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22383,6 +22888,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22393,6 +22899,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22430,6 +22937,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22440,6 +22948,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22534,6 +23043,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22544,6 +23054,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22689,6 +23200,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22699,6 +23211,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22709,6 +23222,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22718,6 +23232,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -22726,6 +23241,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -22759,6 +23275,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22769,6 +23286,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22779,6 +23297,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22880,6 +23399,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22890,6 +23410,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22900,6 +23421,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22945,6 +23467,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22955,6 +23478,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22965,6 +23489,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -22974,6 +23499,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -23021,6 +23547,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23031,6 +23558,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23041,6 +23569,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23078,6 +23607,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23088,6 +23618,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23098,6 +23629,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23132,6 +23664,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23142,6 +23675,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23152,6 +23686,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23185,6 +23720,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23195,6 +23731,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23205,6 +23742,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23278,6 +23816,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23288,6 +23827,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23298,6 +23838,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23346,6 +23887,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23356,6 +23898,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23366,6 +23909,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23400,6 +23944,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23410,6 +23955,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23447,6 +23993,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23457,6 +24004,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23545,6 +24093,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23555,6 +24104,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23596,6 +24146,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23606,6 +24157,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23700,6 +24252,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23710,6 +24263,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23855,6 +24409,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23865,6 +24420,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23875,6 +24431,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23884,6 +24441,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -23892,6 +24450,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -23925,6 +24484,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23935,6 +24495,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -23945,6 +24506,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24046,6 +24608,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24056,6 +24619,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24066,6 +24630,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24111,6 +24676,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24121,6 +24687,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24131,6 +24698,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24140,6 +24708,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -24187,6 +24756,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24197,6 +24767,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24207,6 +24778,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24244,6 +24816,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24254,6 +24827,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24264,6 +24838,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24298,6 +24873,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24308,6 +24884,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24318,6 +24895,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24351,6 +24929,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24361,6 +24940,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24371,6 +24951,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24444,6 +25025,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24454,6 +25036,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24464,6 +25047,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24512,6 +25096,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24522,6 +25107,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24532,6 +25118,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24566,6 +25153,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24576,6 +25164,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24613,6 +25202,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24623,6 +25213,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24711,6 +25302,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24721,6 +25313,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24759,6 +25352,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24796,6 +25390,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24884,6 +25479,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -24925,6 +25521,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25062,6 +25659,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25099,6 +25697,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25236,6 +25835,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25269,6 +25869,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25342,6 +25943,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25390,6 +25992,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25427,6 +26030,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25521,6 +26125,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25666,6 +26271,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25676,6 +26282,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25685,6 +26292,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -25693,6 +26301,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -25726,6 +26335,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25736,6 +26346,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25837,6 +26448,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25847,6 +26459,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25892,6 +26505,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25902,6 +26516,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25911,6 +26526,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -25958,6 +26574,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -25968,6 +26585,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26005,6 +26623,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26015,6 +26634,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26049,6 +26669,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26059,6 +26680,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26092,6 +26714,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26102,6 +26725,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26175,6 +26799,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26185,6 +26810,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26233,6 +26859,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26243,6 +26870,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26277,6 +26905,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26314,6 +26943,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26402,6 +27032,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26443,6 +27074,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26496,6 +27128,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26506,6 +27139,7 @@
             "in": "path",
             "description": "Usage: userName='{userName}'",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -26639,6 +27273,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26723,6 +27358,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26817,6 +27453,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26962,6 +27599,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26972,6 +27610,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -26981,6 +27620,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -26989,6 +27629,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -27022,6 +27663,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27032,6 +27674,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27133,6 +27776,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27143,6 +27787,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27188,6 +27833,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27198,6 +27844,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27207,6 +27854,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -27254,6 +27902,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27264,6 +27913,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27301,6 +27951,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27311,6 +27962,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27345,6 +27997,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27355,6 +28008,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27388,6 +28042,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27398,6 +28053,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27471,6 +28127,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27481,6 +28138,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27529,6 +28187,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27539,6 +28198,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27573,6 +28233,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27610,6 +28271,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27698,6 +28360,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27740,6 +28403,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27803,6 +28467,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27863,6 +28528,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -27873,6 +28539,7 @@
             "in": "path",
             "description": "Usage: lastName='{lastName}'",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -27924,6 +28591,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28050,6 +28718,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28107,6 +28776,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28117,6 +28787,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28206,6 +28877,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28216,6 +28888,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28266,6 +28939,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28276,6 +28950,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28288,6 +28963,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -28325,6 +29001,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28335,6 +29012,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28483,6 +29161,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28493,6 +29172,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28613,6 +29293,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28623,6 +29304,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28636,6 +29318,7 @@
             "in": "path",
             "description": "key: PlanItemId of PlanItem",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28648,6 +29331,7 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
+            "style": "simple",
             "schema": {
               "type": "string"
             }
@@ -28656,6 +29340,7 @@
             "name": "@id",
             "in": "query",
             "description": "Delete Uri",
+            "style": "form",
             "schema": {
               "type": "string"
             }
@@ -28690,6 +29375,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28700,6 +29386,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28740,6 +29427,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28750,6 +29438,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28829,6 +29518,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -28839,6 +29529,7 @@
             "in": "path",
             "description": "key: TripId of Trip",
             "required": true,
+            "style": "simple",
             "schema": {
               "maximum": 2147483647,
               "minimum": -2147483648,
@@ -28880,6 +29571,7 @@
             "in": "path",
             "description": "key: UserName of Person",
             "required": true,
+            "style": "simple",
             "schema": {
               "type": "string"
             },
@@ -30390,6 +31082,7 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -30400,6 +31093,7 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -30409,6 +31103,7 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
         "schema": {
           "type": "boolean"
         }
@@ -30417,6 +31112,7 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
         "schema": {
           "type": "string"
         }
@@ -30425,6 +31121,7 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1307,7 +1307,8 @@
             "schema": {
               "oneOf": [
                 {
-                  "type": "number"
+                  "type": "number",
+                  "format": "double"
                 },
                 {
                   "type": "string"
@@ -1315,8 +1316,7 @@
                 {
                   "$ref": "#/components/schemas/ReferenceNumeric"
                 }
-              ],
-              "format": "double"
+              ]
             }
           },
           {
@@ -1326,7 +1326,8 @@
             "schema": {
               "oneOf": [
                 {
-                  "type": "number"
+                  "type": "number",
+                  "format": "double"
                 },
                 {
                   "type": "string"
@@ -1334,8 +1335,7 @@
                 {
                   "$ref": "#/components/schemas/ReferenceNumeric"
                 }
-              ],
-              "format": "double"
+              ]
             }
           }
         ],
@@ -28811,13 +28811,13 @@
           "Age": {
             "oneOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               {
                 "type": "string"
               }
             ],
-            "format": "int64",
             "nullable": true
           },
           "Emails": {
@@ -29035,7 +29035,8 @@
           "Budget": {
             "oneOf": [
               {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               },
               {
                 "type": "string"
@@ -29043,8 +29044,7 @@
               {
                 "$ref": "#/components/schemas/ReferenceNumeric"
               }
-            ],
-            "format": "float"
+            ]
           },
           "Description": {
             "type": "string",
@@ -29213,13 +29213,13 @@
               "Cost": {
                 "oneOf": [
                   {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   {
                     "type": "string"
                   }
-                ],
-                "format": "int64"
+                ]
               },
               "Peers": {
                 "type": "array",
@@ -29243,13 +29243,13 @@
               "Budget": {
                 "oneOf": [
                   {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   {
                     "type": "string"
                   }
-                ],
-                "format": "int64"
+                ]
               },
               "BossOffice": {
                 "anyOf": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1305,7 +1305,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "number"
                 },
@@ -1313,11 +1313,7 @@
                   "type": "string"
                 },
                 {
-                  "enum": [
-                    "-INF",
-                    "INF",
-                    "NaN"
-                  ]
+                  "$ref": "#/components/schemas/ReferenceNumeric"
                 }
               ],
               "format": "double"
@@ -1328,7 +1324,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "number"
                 },
@@ -1336,11 +1332,7 @@
                   "type": "string"
                 },
                 {
-                  "enum": [
-                    "-INF",
-                    "INF",
-                    "NaN"
-                  ]
+                  "$ref": "#/components/schemas/ReferenceNumeric"
                 }
               ],
               "format": "double"
@@ -28817,7 +28809,7 @@
             "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
           },
           "Age": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "integer"
               },
@@ -29041,7 +29033,7 @@
             "nullable": true
           },
           "Budget": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "number"
               },
@@ -29049,11 +29041,7 @@
                 "type": "string"
               },
               {
-                "enum": [
-                  "-INF",
-                  "INF",
-                  "NaN"
-                ]
+                "$ref": "#/components/schemas/ReferenceNumeric"
               }
             ],
             "format": "float"
@@ -29223,7 +29211,7 @@
             "type": "object",
             "properties": {
               "Cost": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "integer"
                   },
@@ -29253,7 +29241,7 @@
             "type": "object",
             "properties": {
               "Budget": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "integer"
                   },
@@ -29351,7 +29339,7 @@
       },
       "Edm.Geometry": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
             "$ref": "#/components/schemas/Edm.GeometryPoint"
           },
@@ -29781,6 +29769,13 @@
         "additionalProperties": {
           "type": "object"
         }
+      },
+      "ReferenceNumeric": {
+        "enum": [
+          "-INF",
+          "INF",
+          "NaN"
+        ]
       }
     },
     "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1316,7 +1316,8 @@
                 {
                   "$ref": "#/components/schemas/ReferenceNumeric"
                 }
-              ]
+              ],
+              "format": "double"
             }
           },
           {
@@ -1335,7 +1336,8 @@
                 {
                   "$ref": "#/components/schemas/ReferenceNumeric"
                 }
-              ]
+              ],
+              "format": "double"
             }
           }
         ],
@@ -28818,6 +28820,7 @@
                 "type": "string"
               }
             ],
+            "format": "int64",
             "nullable": true
           },
           "Emails": {
@@ -29044,7 +29047,8 @@
               {
                 "$ref": "#/components/schemas/ReferenceNumeric"
               }
-            ]
+            ],
+            "format": "float"
           },
           "Description": {
             "type": "string",
@@ -29219,7 +29223,8 @@
                   {
                     "type": "string"
                   }
-                ]
+                ],
+                "format": "int64"
               },
               "Peers": {
                 "type": "array",
@@ -29249,7 +29254,8 @@
                   {
                     "type": "string"
                   }
-                ]
+                ],
+                "format": "int64"
               },
               "BossOffice": {
                 "anyOf": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1316,8 +1316,7 @@
                 {
                   "$ref": "#/components/schemas/ReferenceNumeric"
                 }
-              ],
-              "format": "double"
+              ]
             }
           },
           {
@@ -1336,8 +1335,7 @@
                 {
                   "$ref": "#/components/schemas/ReferenceNumeric"
                 }
-              ],
-              "format": "double"
+              ]
             }
           }
         ],
@@ -28820,7 +28818,6 @@
                 "type": "string"
               }
             ],
-            "format": "int64",
             "nullable": true
           },
           "Emails": {
@@ -29047,8 +29044,7 @@
               {
                 "$ref": "#/components/schemas/ReferenceNumeric"
               }
-            ],
-            "format": "float"
+            ]
           },
           "Description": {
             "type": "string",
@@ -29223,8 +29219,7 @@
                   {
                     "type": "string"
                   }
-                ],
-                "format": "int64"
+                ]
               },
               "Peers": {
                 "type": "array",
@@ -29254,8 +29249,7 @@
                   {
                     "type": "string"
                   }
-                ],
-                "format": "int64"
+                ]
               },
               "BossOffice": {
                 "anyOf": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -882,6 +882,7 @@ paths:
                 format: double
               - type: string
               - $ref: '#/components/schemas/ReferenceNumeric'
+            format: double
         - name: lon
           in: path
           required: true
@@ -891,6 +892,7 @@ paths:
                 format: double
               - type: string
               - $ref: '#/components/schemas/ReferenceNumeric'
+            format: double
       responses:
         '200':
           description: Success
@@ -20171,6 +20173,7 @@ components:
             - type: integer
               format: int64
             - type: string
+          format: int64
           nullable: true
         Emails:
           type: array
@@ -20306,6 +20309,7 @@ components:
               format: float
             - type: string
             - $ref: '#/components/schemas/ReferenceNumeric'
+          format: float
         Description:
           type: string
           nullable: true
@@ -20408,6 +20412,7 @@ components:
                 - type: integer
                   format: int64
                 - type: string
+              format: int64
             Peers:
               type: array
               items:
@@ -20423,6 +20428,7 @@ components:
                 - type: integer
                   format: int64
                 - type: string
+              format: int64
             BossOffice:
               anyOf:
                 - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -879,18 +879,18 @@ paths:
           schema:
             oneOf:
               - type: number
+                format: double
               - type: string
               - $ref: '#/components/schemas/ReferenceNumeric'
-            format: double
         - name: lon
           in: path
           required: true
           schema:
             oneOf:
               - type: number
+                format: double
               - type: string
               - $ref: '#/components/schemas/ReferenceNumeric'
-            format: double
       responses:
         '200':
           description: Success
@@ -20169,8 +20169,8 @@ components:
         Age:
           oneOf:
             - type: integer
+              format: int64
             - type: string
-          format: int64
           nullable: true
         Emails:
           type: array
@@ -20303,9 +20303,9 @@ components:
         Budget:
           oneOf:
             - type: number
+              format: float
             - type: string
             - $ref: '#/components/schemas/ReferenceNumeric'
-          format: float
         Description:
           type: string
           nullable: true
@@ -20406,8 +20406,8 @@ components:
             Cost:
               oneOf:
                 - type: integer
+                  format: int64
                 - type: string
-              format: int64
             Peers:
               type: array
               items:
@@ -20421,8 +20421,8 @@ components:
             Budget:
               oneOf:
                 - type: integer
+                  format: int64
                 - type: string
-              format: int64
             BossOffice:
               anyOf:
                 - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -882,7 +882,6 @@ paths:
                 format: double
               - type: string
               - $ref: '#/components/schemas/ReferenceNumeric'
-            format: double
         - name: lon
           in: path
           required: true
@@ -892,7 +891,6 @@ paths:
                 format: double
               - type: string
               - $ref: '#/components/schemas/ReferenceNumeric'
-            format: double
       responses:
         '200':
           description: Success
@@ -20173,7 +20171,6 @@ components:
             - type: integer
               format: int64
             - type: string
-          format: int64
           nullable: true
         Emails:
           type: array
@@ -20309,7 +20306,6 @@ components:
               format: float
             - type: string
             - $ref: '#/components/schemas/ReferenceNumeric'
-          format: float
         Description:
           type: string
           nullable: true
@@ -20412,7 +20408,6 @@ components:
                 - type: integer
                   format: int64
                 - type: string
-              format: int64
             Peers:
               type: array
               items:
@@ -20428,7 +20423,6 @@ components:
                 - type: integer
                   format: int64
                 - type: string
-              format: int64
             BossOffice:
               anyOf:
                 - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -877,25 +877,19 @@ paths:
           in: path
           required: true
           schema:
-            anyOf:
+            oneOf:
               - type: number
               - type: string
-              - enum:
-                  - '-INF'
-                  - INF
-                  - NaN
+              - $ref: '#/components/schemas/ReferenceNumeric'
             format: double
         - name: lon
           in: path
           required: true
           schema:
-            anyOf:
+            oneOf:
               - type: number
               - type: string
-              - enum:
-                  - '-INF'
-                  - INF
-                  - NaN
+              - $ref: '#/components/schemas/ReferenceNumeric'
             format: double
       responses:
         '200':
@@ -20173,7 +20167,7 @@ components:
         Gender:
           $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'
         Age:
-          anyOf:
+          oneOf:
             - type: integer
             - type: string
           format: int64
@@ -20307,13 +20301,10 @@ components:
           type: string
           nullable: true
         Budget:
-          anyOf:
+          oneOf:
             - type: number
             - type: string
-            - enum:
-                - '-INF'
-                - INF
-                - NaN
+            - $ref: '#/components/schemas/ReferenceNumeric'
           format: float
         Description:
           type: string
@@ -20413,7 +20404,7 @@ components:
           type: object
           properties:
             Cost:
-              anyOf:
+              oneOf:
                 - type: integer
                 - type: string
               format: int64
@@ -20428,7 +20419,7 @@ components:
           type: object
           properties:
             Budget:
-              anyOf:
+              oneOf:
                 - type: integer
                 - type: string
               format: int64
@@ -20488,7 +20479,7 @@ components:
       $ref: '#/components/schemas/Edm.GeometryCollection'
     Edm.Geometry:
       type: object
-      anyOf:
+      oneOf:
         - $ref: '#/components/schemas/Edm.GeometryPoint'
         - $ref: '#/components/schemas/Edm.GeometryLineString'
         - $ref: '#/components/schemas/Edm.GeometryPolygon'
@@ -20769,6 +20760,11 @@ components:
           type: string
       additionalProperties:
         type: object
+    ReferenceNumeric:
+      enum:
+        - '-INF'
+        - INF
+        - NaN
   responses:
     error:
       description: error

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -98,6 +98,7 @@ paths:
           in: path
           description: 'key: AirlineCode of Airline'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airline
@@ -146,6 +147,7 @@ paths:
           in: path
           description: 'key: AirlineCode of Airline'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airline
@@ -172,12 +174,14 @@ paths:
           in: path
           description: 'key: AirlineCode of Airline'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airline
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -294,6 +298,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -344,6 +349,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -370,12 +376,14 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -393,6 +401,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -441,6 +450,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -469,6 +479,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -535,6 +546,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -558,6 +570,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -579,12 +592,14 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -602,6 +617,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -663,6 +679,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -688,12 +705,14 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -720,6 +739,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -740,6 +760,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -758,6 +779,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -775,6 +797,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -820,6 +843,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -847,6 +871,7 @@ paths:
           in: path
           description: 'key: IcaoCode of Airport'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Airport
@@ -876,6 +901,7 @@ paths:
         - name: lat
           in: path
           required: true
+          style: simple
           schema:
             oneOf:
               - type: number
@@ -885,6 +911,7 @@ paths:
         - name: lon
           in: path
           required: true
+          style: simple
           schema:
             oneOf:
               - type: number
@@ -1104,6 +1131,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -1294,6 +1322,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -1399,6 +1428,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -1731,17 +1761,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -1765,6 +1798,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -1832,6 +1866,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -1863,12 +1898,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -1901,6 +1938,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -1927,6 +1965,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -1951,6 +1990,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -1974,6 +2014,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2025,6 +2066,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2058,6 +2100,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2341,17 +2384,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -2375,6 +2421,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2442,6 +2489,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2473,12 +2521,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -2511,6 +2561,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2537,6 +2588,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2561,6 +2613,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2584,6 +2637,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2635,6 +2689,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2668,6 +2723,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2885,17 +2941,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -2919,6 +2978,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -2986,6 +3046,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3017,12 +3078,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -3055,6 +3118,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3081,6 +3145,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3105,6 +3170,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3128,6 +3194,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3179,6 +3246,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3212,6 +3280,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3238,6 +3307,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3308,6 +3378,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3416,6 +3487,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3423,17 +3495,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -3457,6 +3532,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3464,6 +3540,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3531,6 +3608,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3538,6 +3616,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3569,6 +3648,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3576,12 +3656,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -3614,6 +3696,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3621,6 +3704,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3647,6 +3731,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3654,6 +3739,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3678,6 +3764,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3685,6 +3772,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3708,6 +3796,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3715,6 +3804,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3766,6 +3856,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3773,6 +3864,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3806,6 +3898,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3813,6 +3906,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3837,6 +3931,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3863,6 +3958,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3926,6 +4022,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -3955,6 +4052,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4025,6 +4123,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4133,6 +4232,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4140,17 +4240,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -4174,6 +4277,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4181,6 +4285,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4248,6 +4353,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4255,6 +4361,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4286,6 +4393,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4293,12 +4401,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -4331,6 +4441,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4338,6 +4449,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4364,6 +4476,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4371,6 +4484,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4395,6 +4509,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4402,6 +4517,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4425,6 +4541,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4432,6 +4549,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4483,6 +4601,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4490,6 +4609,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4523,6 +4643,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4530,6 +4651,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4554,6 +4676,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4580,6 +4703,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -4643,6 +4767,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5239,17 +5364,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -5273,6 +5401,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5340,6 +5469,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5371,12 +5501,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -5409,6 +5541,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5435,6 +5568,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5459,6 +5593,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5482,6 +5617,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5533,6 +5669,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5566,6 +5703,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -5711,6 +5849,7 @@ paths:
           in: path
           description: 'Usage: userName=''{userName}'''
           required: true
+          style: simple
           schema:
             type: string
         - $ref: '#/components/parameters/top'
@@ -6013,17 +6152,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -6047,6 +6189,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6114,6 +6257,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6145,12 +6289,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -6183,6 +6329,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6209,6 +6356,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6233,6 +6381,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6256,6 +6405,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6307,6 +6457,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6340,6 +6491,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -6527,6 +6679,7 @@ paths:
           in: path
           description: 'Usage: lastName=''{lastName}'''
           required: true
+          style: simple
           schema:
             type: string
       responses:
@@ -6677,6 +6830,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -6743,6 +6897,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -6779,6 +6934,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -6788,6 +6944,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -6814,6 +6971,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -6920,6 +7078,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -7004,6 +7163,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -7014,6 +7174,7 @@ paths:
           in: path
           description: 'key: PlanItemId of PlanItem'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -7023,11 +7184,13 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -7052,6 +7215,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -7081,6 +7245,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -7135,6 +7300,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -7296,6 +7462,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7359,6 +7526,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7385,12 +7553,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -7408,6 +7578,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7469,6 +7640,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7494,12 +7666,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -7526,6 +7700,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7546,6 +7721,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7564,6 +7740,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7585,6 +7762,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7657,6 +7835,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7687,6 +7866,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7714,12 +7894,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -7743,6 +7925,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7810,6 +7993,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7841,12 +8025,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -7879,6 +8065,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7905,6 +8092,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7929,6 +8117,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -7952,6 +8141,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8003,6 +8193,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8036,6 +8227,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8062,6 +8254,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8132,6 +8325,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8239,6 +8433,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8246,17 +8441,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -8280,6 +8478,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8287,6 +8486,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8354,6 +8554,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8361,6 +8562,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8392,6 +8594,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8399,12 +8602,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -8437,6 +8642,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8444,6 +8650,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8470,6 +8677,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8477,6 +8685,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8501,6 +8710,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8508,6 +8718,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8531,6 +8742,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8538,6 +8750,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8589,6 +8802,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8596,6 +8810,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8629,6 +8844,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8636,6 +8852,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8660,6 +8877,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8686,6 +8904,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8749,6 +8968,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8778,6 +8998,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8848,6 +9069,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8955,6 +9177,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -8962,17 +9185,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -8996,6 +9222,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9003,6 +9230,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9070,6 +9298,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9077,6 +9306,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9108,6 +9338,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9115,12 +9346,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -9153,6 +9386,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9160,6 +9394,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9186,6 +9421,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9193,6 +9429,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9217,6 +9454,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9224,6 +9462,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9247,6 +9486,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9254,6 +9494,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9305,6 +9546,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9312,6 +9554,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9345,6 +9588,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9352,6 +9596,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9376,6 +9621,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9402,6 +9648,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9465,6 +9712,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9494,6 +9742,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9593,6 +9842,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9600,17 +9850,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -9628,6 +9881,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9635,6 +9889,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9696,6 +9951,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9703,6 +9959,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9728,6 +9985,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9735,12 +9993,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -9767,6 +10027,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9774,6 +10035,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9794,6 +10056,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9801,6 +10064,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9819,6 +10083,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9826,6 +10091,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9843,6 +10109,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9850,6 +10117,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9895,6 +10163,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9902,6 +10171,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9929,6 +10199,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9936,6 +10207,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9956,6 +10228,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -9963,6 +10236,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10027,6 +10301,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10034,6 +10309,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10135,6 +10411,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10142,6 +10419,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10149,17 +10427,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -10177,6 +10458,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10184,6 +10466,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10191,6 +10474,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10252,6 +10536,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10259,6 +10544,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10266,6 +10552,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10291,6 +10578,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10298,6 +10586,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10305,12 +10594,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -10337,6 +10628,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10344,6 +10636,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10351,6 +10644,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10371,6 +10665,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10378,6 +10673,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10385,6 +10681,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10403,6 +10700,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10410,6 +10708,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10417,6 +10716,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10434,6 +10734,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10441,6 +10742,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10448,6 +10750,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10493,6 +10796,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10500,6 +10804,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10507,6 +10812,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10534,6 +10840,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10541,6 +10848,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10548,6 +10856,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10566,6 +10875,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10573,6 +10883,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10593,6 +10904,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10600,6 +10912,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10657,6 +10970,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10664,6 +10978,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10687,6 +11002,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10694,6 +11010,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10758,6 +11075,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10765,6 +11083,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10866,6 +11185,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10873,6 +11193,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10880,17 +11201,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -10908,6 +11232,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10915,6 +11240,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10922,6 +11248,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10983,6 +11310,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10990,6 +11318,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -10997,6 +11326,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11022,6 +11352,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11029,6 +11360,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11036,12 +11368,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -11068,6 +11402,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11075,6 +11410,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11082,6 +11418,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11102,6 +11439,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11109,6 +11447,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11116,6 +11455,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11134,6 +11474,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11141,6 +11482,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11148,6 +11490,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11165,6 +11508,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11172,6 +11516,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11179,6 +11524,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11224,6 +11570,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11231,6 +11578,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11238,6 +11586,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11265,6 +11614,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11272,6 +11622,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11279,6 +11630,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11297,6 +11649,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11304,6 +11657,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11324,6 +11678,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11331,6 +11686,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11388,6 +11744,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11395,6 +11752,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11416,6 +11774,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11436,6 +11795,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11493,6 +11853,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11516,6 +11877,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11612,6 +11974,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11632,6 +11995,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11728,6 +12092,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11745,6 +12110,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11790,6 +12156,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11817,6 +12184,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11837,6 +12205,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11865,6 +12234,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -11872,6 +12242,7 @@ paths:
           in: path
           description: 'Usage: userName=''{userName}'''
           required: true
+          style: simple
           schema:
             type: string
         - $ref: '#/components/parameters/top'
@@ -11963,6 +12334,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12013,6 +12385,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12048,6 +12421,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12084,6 +12458,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12091,6 +12466,7 @@ paths:
           in: path
           description: 'Usage: lastName=''{lastName}'''
           required: true
+          style: simple
           schema:
             type: string
       responses:
@@ -12120,6 +12496,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12205,6 +12582,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12238,6 +12616,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12245,6 +12624,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12305,6 +12685,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12312,6 +12693,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12342,6 +12724,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12349,6 +12732,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12358,6 +12742,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -12378,6 +12763,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12385,6 +12771,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12485,6 +12872,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12492,6 +12880,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12570,6 +12959,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12577,6 +12967,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12587,6 +12978,7 @@ paths:
           in: path
           description: 'key: PlanItemId of PlanItem'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12596,11 +12988,13 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -12619,6 +13013,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12626,6 +13021,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12649,6 +13045,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12656,6 +13053,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12704,6 +13102,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12711,6 +13110,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -12735,6 +13135,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12890,6 +13291,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12959,6 +13361,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -12991,12 +13394,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -13020,6 +13425,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13087,6 +13493,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13118,12 +13525,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -13156,6 +13565,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13182,6 +13592,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13206,6 +13617,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13233,6 +13645,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13305,6 +13718,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13335,6 +13749,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13362,12 +13777,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -13391,6 +13808,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13458,6 +13876,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13489,12 +13908,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -13527,6 +13948,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13553,6 +13975,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13577,6 +14000,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13600,6 +14024,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13651,6 +14076,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13684,6 +14110,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13710,6 +14137,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13780,6 +14208,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13888,6 +14317,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13895,17 +14325,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -13929,6 +14362,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -13936,6 +14370,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14003,6 +14438,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14010,6 +14446,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14041,6 +14478,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14048,12 +14486,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -14086,6 +14526,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14093,6 +14534,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14119,6 +14561,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14126,6 +14569,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14150,6 +14594,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14157,6 +14602,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14180,6 +14626,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14187,6 +14634,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14238,6 +14686,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14245,6 +14694,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14278,6 +14728,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14285,6 +14736,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14309,6 +14761,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14335,6 +14788,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14398,6 +14852,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14427,6 +14882,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14497,6 +14953,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14605,6 +15062,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14612,17 +15070,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -14646,6 +15107,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14653,6 +15115,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14720,6 +15183,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14727,6 +15191,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14758,6 +15223,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14765,12 +15231,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -14803,6 +15271,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14810,6 +15279,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14836,6 +15306,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14843,6 +15314,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14867,6 +15339,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14874,6 +15347,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14897,6 +15371,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14904,6 +15379,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14955,6 +15431,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14962,6 +15439,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -14995,6 +15473,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15002,6 +15481,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15026,6 +15506,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15052,6 +15533,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15115,6 +15597,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15144,6 +15627,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15249,6 +15733,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15256,17 +15741,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -15290,6 +15778,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15297,6 +15786,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15364,6 +15854,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15371,6 +15862,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15402,6 +15894,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15409,12 +15902,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -15447,6 +15942,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15454,6 +15950,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15480,6 +15977,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15487,6 +15985,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15511,6 +16010,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15518,6 +16018,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15541,6 +16042,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15548,6 +16050,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15599,6 +16102,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15606,6 +16110,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15639,6 +16144,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15646,6 +16152,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15672,6 +16179,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15679,6 +16187,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15749,6 +16258,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15756,6 +16266,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15864,6 +16375,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15871,6 +16383,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15878,17 +16391,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -15912,6 +16428,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15919,6 +16436,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15926,6 +16444,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -15993,6 +16512,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16000,6 +16520,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16007,6 +16528,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16038,6 +16560,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16045,6 +16568,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16052,12 +16576,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -16090,6 +16616,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16097,6 +16624,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16104,6 +16632,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16130,6 +16659,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16137,6 +16667,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16144,6 +16675,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16168,6 +16700,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16175,6 +16708,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16182,6 +16716,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16205,6 +16740,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16212,6 +16748,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16219,6 +16756,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16270,6 +16808,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16277,6 +16816,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16284,6 +16824,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16317,6 +16858,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16324,6 +16866,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16331,6 +16874,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16355,6 +16899,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16362,6 +16907,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16388,6 +16934,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16395,6 +16942,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16458,6 +17006,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16465,6 +17014,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16494,6 +17044,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16501,6 +17052,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16571,6 +17123,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16578,6 +17131,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16686,6 +17240,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16693,6 +17248,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16700,17 +17256,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -16734,6 +17293,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16741,6 +17301,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16748,6 +17309,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16815,6 +17377,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16822,6 +17385,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16829,6 +17393,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16860,6 +17425,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16867,6 +17433,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16874,12 +17441,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -16912,6 +17481,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16919,6 +17489,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16926,6 +17497,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16952,6 +17524,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16959,6 +17532,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16966,6 +17540,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16990,6 +17565,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -16997,6 +17573,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17004,6 +17581,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17027,6 +17605,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17034,6 +17613,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17041,6 +17621,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17092,6 +17673,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17099,6 +17681,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17106,6 +17689,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17139,6 +17723,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17146,6 +17731,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17153,6 +17739,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17177,6 +17764,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17184,6 +17772,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17210,6 +17799,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17217,6 +17807,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17280,6 +17871,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17287,6 +17879,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17314,6 +17907,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17340,6 +17934,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17403,6 +17998,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17432,6 +18028,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17534,6 +18131,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17560,6 +18158,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17662,6 +18261,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17685,6 +18285,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17736,6 +18337,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17769,6 +18371,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17795,6 +18398,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17865,6 +18469,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17973,6 +18578,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -17980,17 +18586,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -18014,6 +18623,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18021,6 +18631,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18088,6 +18699,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18095,6 +18707,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18126,6 +18739,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18133,12 +18747,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -18171,6 +18787,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18178,6 +18795,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18204,6 +18822,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18211,6 +18830,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18235,6 +18855,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18242,6 +18863,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18265,6 +18887,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18272,6 +18895,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18323,6 +18947,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18330,6 +18955,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18363,6 +18989,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18370,6 +18997,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18394,6 +19022,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18420,6 +19049,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18483,6 +19113,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18512,6 +19143,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18546,6 +19178,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18553,6 +19186,7 @@ paths:
           in: path
           description: 'Usage: userName=''{userName}'''
           required: true
+          style: simple
           schema:
             type: string
         - $ref: '#/components/parameters/top'
@@ -18644,6 +19278,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18699,6 +19334,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18769,6 +19405,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18877,6 +19514,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18884,17 +19522,20 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -18918,6 +19559,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18925,6 +19567,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18992,6 +19635,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -18999,6 +19643,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19030,6 +19675,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19037,12 +19683,14 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       requestBody:
@@ -19075,6 +19723,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19082,6 +19731,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19108,6 +19758,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19115,6 +19766,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19139,6 +19791,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19146,6 +19799,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19169,6 +19823,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19176,6 +19831,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19227,6 +19883,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19234,6 +19891,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19267,6 +19925,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19274,6 +19933,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19298,6 +19958,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19324,6 +19985,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19387,6 +20049,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19417,6 +20080,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19458,6 +20122,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19500,6 +20165,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19507,6 +20173,7 @@ paths:
           in: path
           description: 'Usage: lastName=''{lastName}'''
           required: true
+          style: simple
           schema:
             type: string
       responses:
@@ -19542,6 +20209,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19633,6 +20301,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19672,6 +20341,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19679,6 +20349,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -19745,6 +20416,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19752,6 +20424,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -19788,6 +20461,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19795,6 +20469,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -19804,6 +20479,7 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
       responses:
@@ -19830,6 +20506,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19837,6 +20514,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -19943,6 +20621,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -19950,6 +20629,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -20034,6 +20714,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -20041,6 +20722,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -20051,6 +20733,7 @@ paths:
           in: path
           description: 'key: PlanItemId of PlanItem'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -20060,11 +20743,13 @@ paths:
         - name: If-Match
           in: header
           description: ETag
+          style: simple
           schema:
             type: string
         - name: '@id'
           in: query
           description: Delete Uri
+          style: form
           schema:
             type: string
       responses:
@@ -20089,6 +20774,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -20096,6 +20782,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -20125,6 +20812,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -20132,6 +20820,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -20186,6 +20875,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -20193,6 +20883,7 @@ paths:
           in: path
           description: 'key: TripId of Trip'
           required: true
+          style: simple
           schema:
             maximum: 2147483647
             minimum: -2147483648
@@ -20223,6 +20914,7 @@ paths:
           in: path
           description: 'key: UserName of Person'
           required: true
+          style: simple
           schema:
             type: string
           x-ms-docs-key-type: Person
@@ -21200,6 +21892,7 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -21208,6 +21901,7 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
       schema:
         minimum: 0
         type: integer
@@ -21215,18 +21909,21 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
       schema:
         type: string
   examples:

--- a/tool/UpdateDocs/UpdateDocs.csproj
+++ b/tool/UpdateDocs/UpdateDocs.csproj
@@ -13,6 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.2" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.3.2" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/tool/UpdateDocs/UpdateDocs.csproj
+++ b/tool/UpdateDocs/UpdateDocs.csproj
@@ -13,6 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.2" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.4.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/245

This PR: 
- Replaces `anyOf` to `oneOf` for geometric points.
- Replaces instances of `anyOf` to `oneOf` for `Decimal`, `Double`, `Single` and `Int64` `EdmPrimitiveTypeKind`.
- Updates unit and integration tests.
- Make components for floating point numbers.
