### PR TITLE
Appends OData query parameters to functions

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -403,16 +403,17 @@ namespace Microsoft.OpenApi.OData.Edm
             visitedNavigationProperties.Push(navPropFullyQualifiedName);
 
             // Check whether a collection-valued navigation property should be indexed by key value(s).
+            // Find indexability annotation annotated directly via NavigationPropertyRestriction.
+            bool? annotatedIndexability = _model.GetBoolean(navigationProperty, CapabilitiesConstants.IndexableByKey);
             bool indexableByKey = true;
 
             if (restriction?.IndexableByKey != null)
             {
                 indexableByKey = (bool)restriction.IndexableByKey;
             }
-            else if (_model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(navigationProperty, CapabilitiesConstants.IndexableByKey).FirstOrDefault() is IEdmVocabularyAnnotation indexabilityAnnotation && indexabilityAnnotation.Value is IEdmBooleanValue booleanValue)
+            else if (annotatedIndexability != null)
             {
-                // Find indexability annotation annotated directly via NavigationPropertyRestriction
-                indexableByKey = booleanValue.Value;
+                indexableByKey = annotatedIndexability.Value;
             }
 
             if (indexableByKey)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -204,36 +204,29 @@ namespace Microsoft.OpenApi.OData.Operation
 
         private void AppendSystemQueryOptions(IEdmFunction function, OpenApiOperation operation)
         {
-            OpenApiParameter parameter;
-
             if (function.ReturnType.IsCollection())
             {
-                parameter = Context.CreateTop(function);
-                if (parameter != null)
+                if (Context.CreateTop(function) is OpenApiParameter parameter)
                 {
                     operation.Parameters.AppendParameter(parameter);
                 }
 
-                parameter = Context.CreateSkip(function);
-                if (parameter != null)
+                if (Context.CreateSkip(function) is OpenApiParameter parameter)
                 {
                     operation.Parameters.AppendParameter(parameter);
                 }
 
-                parameter = Context.CreateSearch(function);
-                if (parameter != null)
+                if (Context.CreateSearch(function) is OpenApiParameter parameter)
                 {
                     operation.Parameters.AppendParameter(parameter);
                 }
 
-                parameter = Context.CreateFilter(function);
-                if (parameter != null)
+                if (Context.CreateFilter(function) is OpenApiParameter parameter)
                 {
                     operation.Parameters.AppendParameter(parameter);
                 }
 
-                parameter = Context.CreateCount(function);
-                if (parameter != null)
+                if (Context.CreateCount(function) is OpenApiParameter parameter)
                 {
                     operation.Parameters.AppendParameter(parameter);
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -4,10 +4,8 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
 using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -1,11 +1,13 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
@@ -157,6 +159,8 @@ namespace Microsoft.OpenApi.OData.Operation
                         }
                     }
                 }
+
+                AppendSystemQueryOptions(function, operation);
             }
         }
 
@@ -196,6 +200,44 @@ namespace Microsoft.OpenApi.OData.Operation
             if (restriction.CustomQueryOptions != null)
             {
                 AppendCustomParameters(operation, restriction.CustomQueryOptions, ParameterLocation.Query);
+            }
+        }
+
+        private void AppendSystemQueryOptions(IEdmFunction function, OpenApiOperation operation)
+        {
+            OpenApiParameter parameter;
+
+            if (function.ReturnType.IsCollection())
+            {
+                parameter = Context.CreateTop(function);
+                if (parameter != null)
+                {
+                    operation.Parameters.AppendParameter(parameter);
+                }
+
+                parameter = Context.CreateSkip(function);
+                if (parameter != null)
+                {
+                    operation.Parameters.AppendParameter(parameter);
+                }
+
+                parameter = Context.CreateSearch(function);
+                if (parameter != null)
+                {
+                    operation.Parameters.AppendParameter(parameter);
+                }
+
+                parameter = Context.CreateFilter(function);
+                if (parameter != null)
+                {
+                    operation.Parameters.AppendParameter(parameter);
+                }
+
+                parameter = Context.CreateCount(function);
+                if (parameter != null)
+                {
+                    operation.Parameters.AppendParameter(parameter);
+                }
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
@@ -206,29 +207,49 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             if (function.ReturnType.IsCollection())
             {
-                if (Context.CreateTop(function) is OpenApiParameter parameter)
+                // $top
+                if (Context.CreateTop(function) is OpenApiParameter topParameter)
                 {
-                    operation.Parameters.AppendParameter(parameter);
+                    operation.Parameters.AppendParameter(topParameter);
                 }
 
-                if (Context.CreateSkip(function) is OpenApiParameter parameter)
+                // $skip
+                if (Context.CreateSkip(function) is OpenApiParameter skipParameter)
                 {
-                    operation.Parameters.AppendParameter(parameter);
+                    operation.Parameters.AppendParameter(skipParameter);
                 }
 
-                if (Context.CreateSearch(function) is OpenApiParameter parameter)
+                // $search
+                if (Context.CreateSearch(function) is OpenApiParameter searchParameter)
                 {
-                    operation.Parameters.AppendParameter(parameter);
+                    operation.Parameters.AppendParameter(searchParameter);
                 }
 
-                if (Context.CreateFilter(function) is OpenApiParameter parameter)
+                // $filter
+                if (Context.CreateFilter(function) is OpenApiParameter filterParameter)
                 {
-                    operation.Parameters.AppendParameter(parameter);
+                    operation.Parameters.AppendParameter(filterParameter);
                 }
 
-                if (Context.CreateCount(function) is OpenApiParameter parameter)
+                // $count
+                if (Context.CreateCount(function) is OpenApiParameter countParameter)
                 {
-                    operation.Parameters.AppendParameter(parameter);
+                    operation.Parameters.AppendParameter(countParameter);
+                }
+
+                if (function.ReturnType?.Definition?.AsElementType() is IEdmEntityType entityType)
+                {
+                    // $select
+                    if (Context.CreateSelect(function, entityType) is OpenApiParameter selectParameter)
+                    {
+                        operation.Parameters.AppendParameter(selectParameter);
+                    }
+
+                    // $orderby
+                    if (Context.CreateOrderBy(function, entityType) is OpenApiParameter orderbyParameter)
+                    {
+                        operation.Parameters.AppendParameter(orderbyParameter);
+                    }
                 }
             }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -139,8 +139,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal($"{entitySetName}.Functions", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(1, operation.Parameters.Count);
-            Assert.Equal(new string[] { "id" }, operation.Parameters.Select(p => p.Name));
+            Assert.Equal(6, operation.Parameters.Count); // id, top, skip, count, search, filter
+            Assert.Contains("id", operation.Parameters.Select(x => x.Name).FirstOrDefault());
 
             Assert.Null(operation.RequestBody);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -7386,6 +7386,21 @@
             "description": "Usage: userName='{userName}'",
             "required": true,
             "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
           }
         ],
         "responses": {
@@ -8757,6 +8772,21 @@
             "maximum": 2147483647,
             "minimum": -2147483648,
             "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
           }
         ],
         "responses": {
@@ -15124,6 +15154,21 @@
             "description": "Usage: userName='{userName}'",
             "required": true,
             "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
           }
         ],
         "responses": {
@@ -15725,6 +15770,21 @@
             "maximum": 2147483647,
             "minimum": -2147483648,
             "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
           }
         ],
         "responses": {
@@ -23462,6 +23522,21 @@
             "description": "Usage: userName='{userName}'",
             "required": true,
             "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
           }
         ],
         "responses": {
@@ -25035,6 +25110,21 @@
             "maximum": 2147483647,
             "minimum": -2147483648,
             "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -7401,6 +7401,53 @@
           },
           {
             "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8787,6 +8834,64 @@
           },
           {
             "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -15169,6 +15274,53 @@
           },
           {
             "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -15785,6 +15937,64 @@
           },
           {
             "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -23537,6 +23747,53 @@
           },
           {
             "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -25125,6 +25382,64 @@
           },
           {
             "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -5214,6 +5214,45 @@ paths:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
         - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
       responses:
         '200':
           description: Success
@@ -6197,6 +6236,56 @@ paths:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
         - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
       responses:
         '200':
           description: Success
@@ -10692,6 +10781,45 @@ paths:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
         - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
       responses:
         '200':
           description: Success
@@ -11122,6 +11250,56 @@ paths:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
         - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
       responses:
         '200':
           description: Success
@@ -16654,6 +16832,45 @@ paths:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
         - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
       responses:
         '200':
           description: Success
@@ -17788,6 +18005,56 @@ paths:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
         - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
       responses:
         '200':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -5209,6 +5209,11 @@ paths:
           description: 'Usage: userName=''{userName}'''
           required: true
           type: string
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
       responses:
         '200':
           description: Success
@@ -6187,6 +6192,11 @@ paths:
           maximum: 2147483647
           minimum: -2147483648
           x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
       responses:
         '200':
           description: Success
@@ -10677,6 +10687,11 @@ paths:
           description: 'Usage: userName=''{userName}'''
           required: true
           type: string
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
       responses:
         '200':
           description: Success
@@ -11102,6 +11117,11 @@ paths:
           maximum: 2147483647
           minimum: -2147483648
           x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
       responses:
         '200':
           description: Success
@@ -16629,6 +16649,11 @@ paths:
           description: 'Usage: userName=''{userName}'''
           required: true
           type: string
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
       responses:
         '200':
           description: Success
@@ -17758,6 +17783,11 @@ paths:
           maximum: 2147483647
           minimum: -2147483648
           x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
       responses:
         '200':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -8177,6 +8177,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
           }
         ],
         "responses": {
@@ -9676,6 +9691,21 @@
               "format": "int32"
             },
             "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
           }
         ],
         "responses": {
@@ -16856,6 +16886,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
           }
         ],
         "responses": {
@@ -17538,6 +17583,21 @@
               "format": "int32"
             },
             "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
           }
         ],
         "responses": {
@@ -26207,6 +26267,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
           }
         ],
         "responses": {
@@ -27968,6 +28043,21 @@
               "format": "int32"
             },
             "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -8192,6 +8192,63 @@
           },
           {
             "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "Description",
+                  "Description desc",
+                  "Tags",
+                  "Tags desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -9706,6 +9763,74 @@
           },
           {
             "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -16901,6 +17026,63 @@
           },
           {
             "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "Description",
+                  "Description desc",
+                  "Tags",
+                  "Tags desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -17598,6 +17780,74 @@
           },
           {
             "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -26282,6 +26532,63 @@
           },
           {
             "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "Description",
+                  "Description desc",
+                  "Tags",
+                  "Tags desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -28058,6 +28365,74 @@
           },
           {
             "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -5719,6 +5719,11 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
       responses:
         '200':
           description: Success
@@ -6774,6 +6779,11 @@ paths:
             type: integer
             format: int32
           x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
       responses:
         '200':
           description: Success
@@ -11765,6 +11775,11 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
       responses:
         '200':
           description: Success
@@ -12230,6 +12245,11 @@ paths:
             type: integer
             format: int32
           x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
       responses:
         '200':
           description: Success
@@ -18331,6 +18351,11 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
       responses:
         '200':
           description: Success
@@ -19567,6 +19592,11 @@ paths:
             type: integer
             format: int32
           x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
       responses:
         '200':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -5724,6 +5724,53 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - TripId desc
+                - ShareId
+                - ShareId desc
+                - Name
+                - Name desc
+                - Budget
+                - Budget desc
+                - Description
+                - Description desc
+                - Tags
+                - Tags desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+              type: string
       responses:
         '200':
           description: Success
@@ -6784,6 +6831,64 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
       responses:
         '200':
           description: Success
@@ -11780,6 +11885,53 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - TripId desc
+                - ShareId
+                - ShareId desc
+                - Name
+                - Name desc
+                - Budget
+                - Budget desc
+                - Description
+                - Description desc
+                - Tags
+                - Tags desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+              type: string
       responses:
         '200':
           description: Success
@@ -12250,6 +12402,64 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
       responses:
         '200':
           description: Success
@@ -18356,6 +18566,53 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - TripId desc
+                - ShareId
+                - ShareId desc
+                - Name
+                - Name desc
+                - Budget
+                - Budget desc
+                - Description
+                - Description desc
+                - Tags
+                - Tags desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+              type: string
       responses:
         '200':
           description: Success
@@ -19597,6 +19854,64 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
       responses:
         '200':
           description: Success


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/251
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/252

This PR: 
- Appends OData query parameters to functions: `$top`, `$skip`, `$filter`, `$search`, `$count`, `$select`, `$top`
- Update tests and integration files.
- Refactors the retrieval of `IndexableByKey` annotation.