### PR TITLE
Adds `@odata.count` parameter to collection responses

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -106,16 +106,6 @@ namespace Microsoft.OpenApi.OData.Common
         public static string CollectionSchemaSuffix = "CollectionResponse";
 
         /// <summary>
-        /// Suffix used for the base collection pagination response schema.
-        /// </summary>
-        public static string BaseCollectionPaginationResponse = "BaseCollectionPaginationResponse";
-
-        /// <summary>
-        /// Suffix used for the base collection count response schema.
-        /// </summary>
-        public static string BaseCollectionCountResponse = "BaseCollectionCountResponse";
-
-        /// <summary>
         /// Suffix used for the base collection pagination response schema and count response schemas.
         /// </summary>
         public static string BaseCollectionPaginationCountResponse = "BaseCollectionPaginationCountResponse";

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -106,10 +106,14 @@ namespace Microsoft.OpenApi.OData.Common
         public static string CollectionSchemaSuffix = "CollectionResponse";
 
         /// <summary>
+        /// Suffix used for collection pagination response schemas.
+        /// </summary>
+        public static string CollectionPaginationResponse = "CollectionPaginationResponse";
+
+        /// <summary>
         /// Name used for reference update.
         /// </summary>
         public static string ReferenceUpdateSchemaName = "ReferenceUpdate";
-
 
         /// <summary>
         /// Name used for reference update.

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -116,6 +116,11 @@ namespace Microsoft.OpenApi.OData.Common
         public static string BaseCollectionCountResponse = "BaseCollectionCountResponse";
 
         /// <summary>
+        /// Suffix used for the base collection pagination response schema and count response schemas.
+        /// </summary>
+        public static string BaseCollectionPaginationCountResponse = "BaseCollectionPaginationCountResponse";
+
+        /// <summary>
         /// Name used for reference update.
         /// </summary>
         public static string ReferenceUpdateSchemaName = "ReferenceUpdate";
@@ -144,5 +149,15 @@ namespace Microsoft.OpenApi.OData.Common
         /// The odata id.
         /// </summary>
         public static string OdataId = "@odata.id";
+
+        /// <summary>
+        /// object type
+        /// </summary>
+        public static string ObjectType = "object";
+
+        /// <summary>
+        /// string type
+        /// </summary>
+        public static string StringType = "string";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -106,9 +106,14 @@ namespace Microsoft.OpenApi.OData.Common
         public static string CollectionSchemaSuffix = "CollectionResponse";
 
         /// <summary>
-        /// Suffix used for collection pagination response schemas.
+        /// Suffix used for the base collection pagination response schema.
         /// </summary>
-        public static string CollectionPaginationResponse = "CollectionPaginationResponse";
+        public static string BaseCollectionPaginationResponse = "BaseCollectionPaginationResponse";
+
+        /// <summary>
+        /// Suffix used for the base collection count response schema.
+        /// </summary>
+        public static string BaseCollectionCountResponse = "BaseCollectionCountResponse";
 
         /// <summary>
         /// Name used for reference update.

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -200,12 +200,8 @@ namespace Microsoft.OpenApi.OData.Generator
             };
             if (context.Settings.EnablePagination)
             {
-                properties.Add(
-                    "@odata.nextLink",
-                    new OpenApiSchema
-                    {
-                        Type = "string"
-                    });
+                properties.Add("@odata.nextLink", new OpenApiSchema { Type = "string" });
+                properties.Add("@odata.count", new OpenApiSchema { Type = "integer", Format = "int64" });
             }
 
             return new OpenApiSchema

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -120,13 +120,25 @@ namespace Microsoft.OpenApi.OData.Generator
 
             if (context.Settings.EnablePagination)
             {
-                schemas[Constants.CollectionPaginationResponse] = new()
+                schemas[Constants.BaseCollectionPaginationResponse] = new()
                 {
-                    Title = "Base collection response",
+                    Title = "Base collection pagination response",
                     Type = "object",
                     Properties = new Dictionary<string, OpenApiSchema>
                     {
-                        { "@odata.nextLink", new OpenApiSchema { Type = "string"} },
+                        { "@odata.nextLink", new OpenApiSchema { Type = "string"} }
+                    }
+                };
+            }
+
+            if (context.Settings.EnableCount)
+            {
+                schemas[Constants.BaseCollectionCountResponse] = new()
+                {
+                    Title = "Base collection count response",
+                    Type = "object",
+                    Properties = new Dictionary<string, OpenApiSchema>
+                    {
                         { "@odata.count", new OpenApiSchema { Type = "integer", Format = "int64" } }
                     }
                 };
@@ -219,22 +231,57 @@ namespace Microsoft.OpenApi.OData.Generator
                 Properties = properties
             };
 
+            OpenApiSchema paginationSchema = new()
+            {
+                UnresolvedReference = true,
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = Constants.BaseCollectionPaginationResponse
+                }
+            };
+
+            OpenApiSchema countSchema = new()
+            {
+                UnresolvedReference = true,
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = Constants.BaseCollectionCountResponse
+                }
+            };
+
             OpenApiSchema colSchema;
-            if (context.Settings.EnablePagination)
+            if (context.Settings.EnablePagination && context.Settings.EnableCount)
             {
                 colSchema = new OpenApiSchema
                 {
                     AllOf = new List<OpenApiSchema>
                     {
-                        new OpenApiSchema
-                        {
-                            UnresolvedReference = true,
-                            Reference = new OpenApiReference
-                            {
-                                Type = ReferenceType.Schema,
-                                Id = Constants.CollectionPaginationResponse
-                            }
-                        },
+                        paginationSchema,
+                        countSchema,
+                        baseSchema
+                    }
+                };
+            }
+            else if (context.Settings.EnablePagination)
+            {
+                colSchema = new OpenApiSchema
+                {
+                    AllOf = new List<OpenApiSchema>
+                    {
+                        paginationSchema,
+                        baseSchema
+                    }
+                };
+            }
+            else if (context.Settings.EnableCount)
+            {
+                colSchema = new OpenApiSchema
+                {
+                    AllOf = new List<OpenApiSchema>
+                    {
+                        countSchema,
                         baseSchema
                     }
                 };

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -118,38 +118,16 @@ namespace Microsoft.OpenApi.OData.Generator
                 AdditionalProperties = new OpenApiSchema { Type = Constants.ObjectType }
             };
 
-            // @odata.nextLink
-            if (context.Settings.EnablePagination)
-            {
-                schemas[Constants.BaseCollectionPaginationResponse] = new()
-                {
-                    Title = "Base collection pagination response",
-                    Type = Constants.ObjectType
-                };
-                schemas[Constants.BaseCollectionPaginationResponse].Properties.Add(ODataConstants.OdataNextLink);
-            }
-
-            // @odata.count
-            if (context.Settings.EnableCount)
-            {
-                schemas[Constants.BaseCollectionCountResponse] = new()
-                {
-                    Title = "Base collection count response",
-                    Type = Constants.ObjectType
-                };
-                schemas[Constants.BaseCollectionCountResponse].Properties.Add(ODataConstants.OdataCount);
-            }
-
             // @odata.nextLink + @odata.count
-            if (context.Settings.EnablePagination && context.Settings.EnableCount)
+            if (context.Settings.EnablePagination || context.Settings.EnableCount)
             {
                 schemas[Constants.BaseCollectionPaginationCountResponse] = new()
                 {
                     Title = "Base collection pagination and count responses",
                     Type = Constants.ObjectType,                   
                 };
-                schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataCount);
-                schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataNextLink);
+                if (context.Settings.EnableCount) schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataCount);
+     if (context.Settings.EnablePagination) schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataNextLink);
             }
 
             return schemas;
@@ -239,27 +217,6 @@ namespace Microsoft.OpenApi.OData.Generator
                 Properties = properties
             };
 
-            // @odata.nextLink
-            OpenApiSchema paginationSchema = new()
-            {
-                UnresolvedReference = true,
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.Schema,
-                    Id = Constants.BaseCollectionPaginationResponse
-                }
-            };
-
-            // @odata.count
-            OpenApiSchema countSchema = new()
-            {
-                UnresolvedReference = true,
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.Schema,
-                    Id = Constants.BaseCollectionCountResponse
-                }
-            };
 
             // @odata.nextLink + @odata.count
             OpenApiSchema paginationCountSchema = new()
@@ -273,35 +230,13 @@ namespace Microsoft.OpenApi.OData.Generator
             };
 
             OpenApiSchema colSchema;
-            if (context.Settings.EnablePagination && context.Settings.EnableCount)
+            if (context.Settings.EnablePagination || context.Settings.EnableCount)
             {
                 colSchema = new OpenApiSchema
                 {
                     AllOf = new List<OpenApiSchema>
                     {
                         paginationCountSchema,
-                        baseSchema
-                    }
-                };
-            }
-            else if (context.Settings.EnablePagination)
-            {
-                colSchema = new OpenApiSchema
-                {
-                    AllOf = new List<OpenApiSchema>
-                    {
-                        paginationSchema,
-                        baseSchema
-                    }
-                };
-            }
-            else if (context.Settings.EnableCount)
-            {
-                colSchema = new OpenApiSchema
-                {
-                    AllOf = new List<OpenApiSchema>
-                    {
-                        countSchema,
                         baseSchema
                     }
                 };

--- a/src/Microsoft.OpenApi.OData.Reader/OData/ODataConstants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OData/ODataConstants.cs
@@ -3,11 +3,9 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.OpenApi.OData
 {
@@ -23,5 +21,15 @@ namespace Microsoft.OpenApi.OData
             "OData.Community.",
         };
 
+        /// <summary>
+        /// @odata.nextLink KeyValue pair
+        /// </summary>
+        public static KeyValuePair<string, OpenApiSchema> OdataNextLink = new("@odata.nextLink", new OpenApiSchema { Type = Constants.StringType, Nullable = true });
+
+        /// <summary>
+        /// @odata.count KeyValue pair
+        /// </summary>
+        public static KeyValuePair<string, OpenApiSchema> OdataCount = new("@odata.count", new OpenApiSchema { Type = "integer", Format = "int64", Nullable = true });
+        
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -101,6 +101,11 @@ namespace Microsoft.OpenApi.OData
         public bool EnablePagination { get; set; }
 
         /// <summary>
+        /// Gets/sets a value indicating whether or not to allow the count of a collection of entities.
+        /// </summary>
+        public bool EnableCount { get; set; }
+
+        /// <summary>
         /// Gets/sets a value that specifies the name of the operation for retrieving the next page in a collection of entities.
         /// </summary>
         public string PageableOperationName { get; set; } = "listMore";
@@ -323,7 +328,8 @@ namespace Microsoft.OpenApi.OData
                 CustomXMLAttributesMapping = this.CustomXMLAttributesMapping,
                 CustomHttpMethodLinkRelMapping = this.CustomHttpMethodLinkRelMapping,
                 AppendBoundOperationsOnDerivedTypeCastSegments = this.AppendBoundOperationsOnDerivedTypeCastSegments,
-                UseSuccessStatusCodeRange = this.UseSuccessStatusCodeRange
+                UseSuccessStatusCodeRange = this.UseSuccessStatusCodeRange,
+                EnableCount = this.EnableCount
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTyp
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -36,8 +36,8 @@ namespace Microsoft.OpenApi.OData.Tests
         }
 
         [Theory]
-        [InlineData(true, false, "BaseCollectionPaginationResponse")]
-        [InlineData(false, true, "BaseCollectionCountResponse")]
+        [InlineData(true, false, "BaseCollectionPaginationCountResponse")]
+        [InlineData(false, true, "BaseCollectionPaginationCountResponse")]
         [InlineData(true, true, "BaseCollectionPaginationCountResponse")]
         [InlineData(false, false)]
         public void CreatesCollectionResponseSchema(bool enablePagination, bool enableCount, string referenceId = null)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -57,6 +57,9 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Equal("Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight", flightCollectionResponse.Properties["value"].Items.Reference.Id);
             Assert.Equal("array", stringCollectionResponse.Properties["value"].Type);
             Assert.Equal("string", stringCollectionResponse.Properties["value"].Items.Type);
+            Assert.Equal("string", stringCollectionResponse.Properties["@odata.nextLink"].Type);            
+            Assert.Equal("integer", stringCollectionResponse.Properties["@odata.count"].Type);
+            Assert.Equal("int64", stringCollectionResponse.Properties["@odata.count"].Format);
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.OpenApi.OData.Tests
             IEdmModel model = EdmModelHelper.TripServiceModel;
             OpenApiConvertSettings settings = new()
             {
-                    EnableOperationId = true,
-                    EnablePagination = true,
+                EnableOperationId = true,
+                EnablePagination = true,
             };
             ODataContext context = new(model, settings);
 
@@ -52,14 +52,12 @@ namespace Microsoft.OpenApi.OData.Tests
 
             var flightCollectionResponse = schemas["Microsoft.OData.Service.Sample.TrippinInMemory.Models.FlightCollectionResponse"];
             var stringCollectionResponse = schemas["StringCollectionResponse"];
-
-            Assert.Equal("array", flightCollectionResponse.Properties["value"].Type);
-            Assert.Equal("Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight", flightCollectionResponse.Properties["value"].Items.Reference.Id);
-            Assert.Equal("array", stringCollectionResponse.Properties["value"].Type);
-            Assert.Equal("string", stringCollectionResponse.Properties["value"].Items.Type);
-            Assert.Equal("string", stringCollectionResponse.Properties["@odata.nextLink"].Type);            
-            Assert.Equal("integer", stringCollectionResponse.Properties["@odata.count"].Type);
-            Assert.Equal("int64", stringCollectionResponse.Properties["@odata.count"].Format);
+            Assert.Equal("array", flightCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Type);
+            Assert.Equal("Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight",
+                flightCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Items.Reference.Id);
+            Assert.Equal("array", stringCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Type);
+            Assert.Equal("string", stringCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Items.Type);
+            Assert.Equal("CollectionPaginationResponse", stringCollectionResponse.AllOf?.FirstOrDefault(x => x.Reference != null).Reference.Id);
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.OpenApi.OData.Tests
             {
                 EnableOperationId = true,
                 EnablePagination = true,
+                EnableCount = true
             };
             ODataContext context = new(model, settings);
 
@@ -55,9 +56,20 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Equal("array", flightCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Type);
             Assert.Equal("Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight",
                 flightCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Items.Reference.Id);
-            Assert.Equal("array", stringCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Type);
-            Assert.Equal("string", stringCollectionResponse.AllOf?.FirstOrDefault(x => x.Properties.Any())?.Properties["value"].Items.Type);
-            Assert.Equal("CollectionPaginationResponse", stringCollectionResponse.AllOf?.FirstOrDefault(x => x.Reference != null).Reference.Id);
+            
+            Assert.Collection(stringCollectionResponse.AllOf,
+                item =>
+                {
+                    Assert.Equal("BaseCollectionPaginationResponse", item.Reference.Id);
+                },
+                item =>
+                {
+                    Assert.Equal("BaseCollectionCountResponse", item.Reference.Id);
+                },
+                item =>
+                {
+                    Assert.Equal("array", item.Properties["value"].Type);
+                });
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/196

This PR:
- Adds an `@odata.count` as a pagination property for collection responses. Together with `@odata.nextLink` these are componentized and reused.
- Adds a new setting `Settings.EnableCount` which controls whether to set the `@odata.count`.
- When `Settings.EnablePagination` and `Settings.EnableCount` are enabled, these properties alongside the base properties of a type are appended to an `allOf` schema.
- Updates test.

When `Settings.EnablePagination = true` and `Settings.EnableCount = true` the new schema for collections would look like:

![image](https://user-images.githubusercontent.com/40403681/187777757-0688443a-a984-499a-aec0-7f4ee3eded85.png)

And the `BaseCollectionPaginationCountResponse` schema:

![image](https://user-images.githubusercontent.com/40403681/187777945-9fd03473-bc19-40c0-a416-d9bd1a311042.png)

And the `BaseCollectionCountResponse` schema:

![image](https://user-images.githubusercontent.com/40403681/187729073-21fb1895-b97c-49bb-9e9c-bee0f696b455.png)


