### PR TITLE
Use Computed annotation in the CSDL to declare property as ReadOnly

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -390,6 +390,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 OpenApiSchema propertySchema = context.CreatePropertySchema(property);
                 propertySchema.Description = context.Model.GetDescriptionAnnotation(property);
                 propertySchema.Extensions.AddCustomAtributesToExtensions(context, property);
+                propertySchema.ReadOnly = context.Model.GetBoolean(property, CoreConstants.Computed) ?? false;
                 properties.Add(property.Name, propertySchema);
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -390,7 +390,6 @@ namespace Microsoft.OpenApi.OData.Generator
                 OpenApiSchema propertySchema = context.CreatePropertySchema(property);
                 propertySchema.Description = context.Model.GetDescriptionAnnotation(property);
                 propertySchema.Extensions.AddCustomAtributesToExtensions(context, property);
-                propertySchema.ReadOnly = context.Model.GetBoolean(property, CoreConstants.Computed) ?? false;
                 properties.Add(property.Name, propertySchema);
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -16,6 +16,7 @@ using Microsoft.OpenApi.Exceptions;
 using System.Linq;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.OData.OpenApiExtensions;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 
 namespace Microsoft.OpenApi.OData.Generator
 {
@@ -362,6 +363,9 @@ namespace Microsoft.OpenApi.OData.Generator
             // The Schema Object for a property optionally can contain the field description,
             // whose value is the value of the unqualified annotation Core.Description of the property.
             schema.Description = context.Model.GetDescriptionAnnotation(property);
+
+            // Set property with Computed Annotation in CSDL to readonly
+            schema.ReadOnly = context.Model.GetBoolean(property, CoreConstants.Computed) ?? false;
 
             return schema;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -22,6 +22,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
 - Fixes response schemas of actions and functions that return a collection to contain the nextLink property #231
+- Use Computed annotation in the CSDL to declare property as ReadOnly #254
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -124,7 +125,7 @@ namespace Microsoft.OpenApi.OData.Operation
             if (EntitySet.EntityType().HasStream)
             {
                 IEnumerable<string> mediaTypes = Context.Model.GetCollection(EntitySet.EntityType(),
-                    CapabilitiesConstants.AcceptableMediaTypes);
+                    CoreConstants.AcceptableMediaTypes);
 
                 if (mediaTypes != null)
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
@@ -9,7 +9,6 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 using Microsoft.OpenApi.OData.Vocabulary.Core;
 using System.Collections.Generic;
 using System.Linq;
@@ -151,7 +150,7 @@ namespace Microsoft.OpenApi.OData.Operation
             if (annotatableElement != null)
             {
                 mediaTypes = Context.Model.GetCollection(annotatableElement,
-                    CapabilitiesConstants.AcceptableMediaTypes);
+                    CoreConstants.AcceptableMediaTypes);
             }
 
             if (mediaTypes != null)

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/CapabilitiesConstants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/CapabilitiesConstants.cs
@@ -94,10 +94,5 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// Org.OData.Capabilities.V1.KeyAsSegmentSupported
         /// </summary>
         public const string KeyAsSegmentSupported = "Org.OData.Capabilities.V1.KeyAsSegmentSupported";
-
-        /// <summary>
-        /// Org.OData.Core.V1.AcceptableMediaTypes
-        /// </summary>
-        public const string AcceptableMediaTypes = "Org.OData.Core.V1.AcceptableMediaTypes";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/CoreConstants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/CoreConstants.cs
@@ -21,6 +21,16 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Core
         public const string Revisions = "Org.OData.Core.V1.Revisions";
 
         /// <summary>
+        /// Org.OData.Core.V1.AcceptableMediaTypes
+        /// </summary>
+        public const string AcceptableMediaTypes = "Org.OData.Core.V1.AcceptableMediaTypes";
+
+        /// <summary>
+        /// Org.OData.Core.V1.Computed
+        /// </summary>
+        public const string Computed = "Org.OData.Core.V1.Computed";
+
+        /// <summary>
         /// External docs description.
         /// </summary>
         public const string ExternalDocsDescription = "Find more info here";

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -803,6 +803,46 @@ namespace Microsoft.OpenApi.OData.Tests
 }".ChangeLineBreaks(), json);
             }
         }
+
+        [Theory]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        public void CreatePropertySchemaWithComputedAnnotationReturnsCorrectSchema(OpenApiSpecVersion specVersion)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model);
+
+            context.Settings.OpenApiSpecVersion = specVersion;
+
+            IEdmEntityType entityType = model.SchemaElements.OfType<IEdmEntityType>().First(e => e.Name == "bookingAppointment");
+            IEdmProperty property = entityType.Properties().FirstOrDefault(x => x.Name == "duration");
+
+            // Act
+            var schema = context.CreatePropertySchema(property);
+            Assert.NotNull(schema);
+            string json = schema.SerializeAsJson(specVersion);
+
+            // Assert
+            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
+            {
+                Assert.Equal(@"{
+  ""format"": ""duration"",
+  ""pattern"": ""^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$"",
+  ""type"": ""string"",
+  ""readOnly"": true
+}".ChangeLineBreaks(), json);    
+            }
+            else
+            {
+                Assert.Equal(@"{
+  ""pattern"": ""^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$"",
+  ""type"": ""string"",
+  ""format"": ""duration"",
+  ""readOnly"": true
+}".ChangeLineBreaks(), json);
+            }
+        }
         #endregion
 
         #region BaseTypeToDerivedTypesSchema

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -10,7 +10,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Tests;
-using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 using System.Xml.Linq;
 using Xunit;
 
@@ -28,7 +28,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateEntitySetPostOperationReturnsCorrectOperation(bool enableOperationId, bool hasStream, bool useHTTPStatusCodeClass2XX)
         {
             // Arrange
-            string qualifiedName = CapabilitiesConstants.AcceptableMediaTypes;
+            string qualifiedName = CoreConstants.AcceptableMediaTypes;
             string annotation = $@"
             <Annotation Term=""{qualifiedName}"" >
               <Collection>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -7,7 +7,7 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 using System.Linq;
 using System.Xml.Linq;
 using Xunit;
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateMediaEntityGetOperationReturnsCorrectOperation(bool enableOperationId, bool useHTTPStatusCodeClass2XX)
         {
             // Arrange
-            string qualifiedName = CapabilitiesConstants.AcceptableMediaTypes;
+            string qualifiedName = CoreConstants.AcceptableMediaTypes;
             string annotation = $@"
             <Annotation Term=""{qualifiedName}"" >
               <Collection>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -6,7 +6,7 @@
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 using System.Linq;
 using Xunit;
 
@@ -22,7 +22,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateMediaEntityPutOperationReturnsCorrectOperation(bool enableOperationId)
         {
             // Arrange
-            string qualifiedName = CapabilitiesConstants.AcceptableMediaTypes;
+            string qualifiedName = CoreConstants.AcceptableMediaTypes;
             string annotation = $@"
             <Annotation Term=""{qualifiedName}"" >
               <Collection>


### PR DESCRIPTION
Fixes #254 

This PR
- Uses `Computed` annotation in the CSDL to declare property as `ReadOnly`