### PR TITLE
Set `explode = false` and `style = form` for OData query options

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -656,7 +656,9 @@ namespace Microsoft.OpenApi.OData.Generator
                     Type = "integer",
                     Minimum = 0,
                 },
-                Example = new OpenApiInteger(topExample)
+                Example = new OpenApiInteger(topExample),
+                Style = ParameterStyle.Form,
+                Explode = false
             };
         }
 
@@ -672,7 +674,9 @@ namespace Microsoft.OpenApi.OData.Generator
                 {
                     Type = "integer",
                     Minimum = 0,
-                }
+                },
+                Style = ParameterStyle.Form,
+                Explode = false
             };
         }
 
@@ -687,7 +691,9 @@ namespace Microsoft.OpenApi.OData.Generator
                 Schema = new OpenApiSchema
                 {
                     Type = "boolean"
-                }
+                },
+                Style = ParameterStyle.Form,
+                Explode = false
             };
         }
 
@@ -702,7 +708,9 @@ namespace Microsoft.OpenApi.OData.Generator
                 Schema = new OpenApiSchema
                 {
                     Type = "string"
-                }
+                },
+                Style = ParameterStyle.Form,
+                Explode = false
             };
         }
 
@@ -717,7 +725,9 @@ namespace Microsoft.OpenApi.OData.Generator
                 Schema = new OpenApiSchema
                 {
                     Type = "string"
-                }
+                },
+                Style = ParameterStyle.Form,
+                Explode = false
             };
         }
     }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -45,6 +45,90 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.Equal(5, parameters.Count);
             Assert.Equal(new[] { "top", "skip", "count", "filter", "search" },
                 parameters.Select(p => p.Key));
+            Assert.Collection(parameters,
+                item => // $top
+                {
+                    string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+                    string expected = $@"{{
+  ""name"": ""$top"",
+  ""in"": ""query"",
+  ""description"": ""Show only the first n items"",
+  ""style"": ""form"",
+  ""explode"": false,
+  ""schema"": {{
+    ""minimum"": 0,
+    ""type"": ""integer""
+  }},
+  ""example"": 50
+}}";
+
+                    Assert.Equal(expected.ChangeLineBreaks(), json);
+                },
+                item => // $skip
+                {
+                    string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+                    string expected = $@"{{
+  ""name"": ""$skip"",
+  ""in"": ""query"",
+  ""description"": ""Skip the first n items"",
+  ""style"": ""form"",
+  ""explode"": false,
+  ""schema"": {{
+    ""minimum"": 0,
+    ""type"": ""integer""
+  }}
+}}";
+
+                    Assert.Equal(expected.ChangeLineBreaks(), json);
+                },
+                item => // $count
+                {
+                    string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+                    string expected = $@"{{
+  ""name"": ""$count"",
+  ""in"": ""query"",
+  ""description"": ""Include count of items"",
+  ""style"": ""form"",
+  ""explode"": false,
+  ""schema"": {{
+    ""type"": ""boolean""
+  }}
+}}";
+
+                    Assert.Equal(expected.ChangeLineBreaks(), json);
+                },
+                item => // $filter
+                {
+                    string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+                    string expected = $@"{{
+  ""name"": ""$filter"",
+  ""in"": ""query"",
+  ""description"": ""Filter items by property values"",
+  ""style"": ""form"",
+  ""explode"": false,
+  ""schema"": {{
+    ""type"": ""string""
+  }}
+}}";
+
+                    Assert.Equal(expected.ChangeLineBreaks(), json);
+                },
+                item => // $search
+                {
+                    string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+                    string expected = $@"{{
+  ""name"": ""$search"",
+  ""in"": ""query"",
+  ""description"": ""Search items by search phrases"",
+  ""style"": ""form"",
+  ""explode"": false,
+  ""schema"": {{
+    ""type"": ""string""
+  }}
+}}";
+
+                    Assert.Equal(expected.ChangeLineBreaks(), json);
+                });
         }
 
         [Fact]
@@ -66,6 +150,8 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 @"name: $skip
 in: query
 description: Skip the first n items
+style: form
+explode: false
 schema:
   minimum: 0
   type: integer

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
@@ -49,83 +49,83 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
                 item => // $top
                 {
                     string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
-                    string expected = $@"{{
+                    string expected = @"{
   ""name"": ""$top"",
   ""in"": ""query"",
   ""description"": ""Show only the first n items"",
   ""style"": ""form"",
   ""explode"": false,
-  ""schema"": {{
+  ""schema"": {
     ""minimum"": 0,
     ""type"": ""integer""
-  }},
+  },
   ""example"": 50
-}}";
+}";
 
                     Assert.Equal(expected.ChangeLineBreaks(), json);
                 },
                 item => // $skip
                 {
                     string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
-                    string expected = $@"{{
+                    string expected = @"{
   ""name"": ""$skip"",
   ""in"": ""query"",
   ""description"": ""Skip the first n items"",
   ""style"": ""form"",
   ""explode"": false,
-  ""schema"": {{
+  ""schema"": {
     ""minimum"": 0,
     ""type"": ""integer""
-  }}
-}}";
+  }
+}";
 
                     Assert.Equal(expected.ChangeLineBreaks(), json);
                 },
                 item => // $count
                 {
                     string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
-                    string expected = $@"{{
+                    string expected = @"{
   ""name"": ""$count"",
   ""in"": ""query"",
   ""description"": ""Include count of items"",
   ""style"": ""form"",
   ""explode"": false,
-  ""schema"": {{
+  ""schema"": {
     ""type"": ""boolean""
-  }}
-}}";
+  }
+}";
 
                     Assert.Equal(expected.ChangeLineBreaks(), json);
                 },
                 item => // $filter
                 {
                     string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
-                    string expected = $@"{{
+                    string expected = @"{
   ""name"": ""$filter"",
   ""in"": ""query"",
   ""description"": ""Filter items by property values"",
   ""style"": ""form"",
   ""explode"": false,
-  ""schema"": {{
+  ""schema"": {
     ""type"": ""string""
-  }}
-}}";
+  }
+}";
 
                     Assert.Equal(expected.ChangeLineBreaks(), json);
                 },
                 item => // $search
                 {
                     string json = item.Value.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
-                    string expected = $@"{{
+                    string expected = @"{
   ""name"": ""$search"",
   ""in"": ""query"",
   ""description"": ""Search items by search phrases"",
   ""style"": ""form"",
   ""explode"": false,
-  ""schema"": {{
+  ""schema"": {
     ""type"": ""string""
-  }}
-}}";
+  }
+}";
 
                     Assert.Equal(expected.ChangeLineBreaks(), json);
                 });

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -1287,6 +1287,8 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -1297,6 +1299,8 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -1306,6 +1310,8 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "boolean"
         }
@@ -1314,6 +1320,8 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }
@@ -1322,6 +1330,8 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -850,6 +850,8 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -858,6 +860,8 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -865,18 +869,24 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
+      explode: false
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
+      explode: false
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
+      explode: false
       schema:
         type: string
   examples:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -130,6 +130,8 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -140,6 +142,8 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -149,6 +153,8 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "boolean"
         }
@@ -157,6 +163,8 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }
@@ -165,6 +173,8 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -86,6 +86,8 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -94,6 +96,8 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -101,18 +105,24 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
+      explode: false
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
+      explode: false
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
+      explode: false
       schema:
         type: string
   requestBodies:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -6732,6 +6732,8 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -6742,6 +6744,8 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -6751,6 +6755,8 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "boolean"
         }
@@ -6759,6 +6765,8 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }
@@ -6767,6 +6775,8 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -4851,6 +4851,8 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -4859,6 +4861,8 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -4866,18 +4870,24 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
+      explode: false
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
+      explode: false
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
+      explode: false
       schema:
         type: string
   examples:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -30395,6 +30395,8 @@
         "name": "$top",
         "in": "query",
         "description": "Show only the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -30405,6 +30407,8 @@
         "name": "$skip",
         "in": "query",
         "description": "Skip the first n items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "minimum": 0,
           "type": "integer"
@@ -30414,6 +30418,8 @@
         "name": "$count",
         "in": "query",
         "description": "Include count of items",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "boolean"
         }
@@ -30422,6 +30428,8 @@
         "name": "$filter",
         "in": "query",
         "description": "Filter items by property values",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }
@@ -30430,6 +30438,8 @@
         "name": "$search",
         "in": "query",
         "description": "Search items by search phrases",
+        "style": "form",
+        "explode": false,
         "schema": {
           "type": "string"
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -21204,6 +21204,8 @@ components:
       name: $top
       in: query
       description: Show only the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -21212,6 +21214,8 @@ components:
       name: $skip
       in: query
       description: Skip the first n items
+      style: form
+      explode: false
       schema:
         minimum: 0
         type: integer
@@ -21219,18 +21223,24 @@ components:
       name: $count
       in: query
       description: Include count of items
+      style: form
+      explode: false
       schema:
         type: boolean
     filter:
       name: $filter
       in: query
       description: Filter items by property values
+      style: form
+      explode: false
       schema:
         type: string
     search:
       name: $search
       in: query
       description: Search items by search phrases
+      style: form
+      explode: false
       schema:
         type: string
   examples:


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/274

This PR:
- Sets `explode = false` and `style = form` for the OData query options: `$top`, `$skip`, `$search`, `$filter`, `$count`
- Update tests to validate the above.
- Update integration test files.