### PR TITLE
Use convert setting to toggle between referencing `@odata.count` and `@odata.nextLink`

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,23 +15,13 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.1.0</Version>
+    <Version>1.2.0-preview1</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-- Fixes response schemas of actions and functions that return a collection to contain the nextLink property #231
-- Uses Computed annotation in the CSDL to declare property as ReadOnly #254
-- Fixes duplicated actions/functions request body/response schemas #241
-- Adds documentation links from Links annotations in CSDL to OpenAPI Operations #230
-- Sets explode property to false and the style property to form for OData query options #274
-- Aliases optional parameters of OData functions #259
-- Adds @odata.count parameter to collection responses #196
-- Appends OData query parameters to functions #251 #252
-- Replaces instances of anyOf to oneOf #245
-- Retrieves RestrictedProperties annotations annotated directly on navigations properties #249
-- Add x-ms-navigationProperty extension to navigation properties #278
+- Use convert setting to toggle between referencing @odata.count and @odata.nextLink #282
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -106,6 +106,11 @@ namespace Microsoft.OpenApi.OData
         public bool EnableCount { get; set; }
 
         /// <summary>
+        /// Gets/sets a value indicating whether or not to reference @odata.nextLink and @odata.count in responses
+        /// </summary>
+        public bool RefBaseCollectionPaginationCountResponse { get; set; } = true;
+
+        /// <summary>
         /// Gets/sets a value that specifies the name of the operation for retrieving the next page in a collection of entities.
         /// </summary>
         public string PageableOperationName { get; set; } = "listMore";
@@ -329,7 +334,8 @@ namespace Microsoft.OpenApi.OData
                 CustomHttpMethodLinkRelMapping = this.CustomHttpMethodLinkRelMapping,
                 AppendBoundOperationsOnDerivedTypeCastSegments = this.AppendBoundOperationsOnDerivedTypeCastSegments,
                 UseSuccessStatusCodeRange = this.UseSuccessStatusCodeRange,
-                EnableCount = this.EnableCount
+                EnableCount = this.EnableCount,
+                RefBaseCollectionPaginationCountResponse = this.RefBaseCollectionPaginationCountResponse
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -15,6 +15,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationPrope
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.get -> bool

--- a/src/OoasGui/MainForm.cs
+++ b/src/OoasGui/MainForm.cs
@@ -38,6 +38,7 @@ namespace OoasGui
         {
             InitializeComponent();
 
+            saveBtn.Enabled = false;
             jsonRadioBtn.Checked = true;
             v3RadioButton.Checked = true;
             fromFileRadioBtn.Checked = true;
@@ -181,6 +182,8 @@ namespace OoasGui
 
         private async Task Convert()
         {
+            saveBtn.Enabled = false;
+
             if (EdmModel == null)
             {
                 return;
@@ -198,6 +201,7 @@ namespace OoasGui
             });
 
             oasRichTextBox.Text = openApi;
+            saveBtn.Enabled = true;
         }
 
         private string FormatXml(string xml)
@@ -238,7 +242,7 @@ namespace OoasGui
                 {
                     await Task.Run(() =>
                     {
-                        _document.Serialize(fs, Version, Format);
+                        _document?.Serialize(fs, Version, Format);
                         fs.Flush();
                     });
                 }

--- a/src/OoasGui/MainForm.cs
+++ b/src/OoasGui/MainForm.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -31,6 +31,8 @@ namespace OoasGui
         private OpenApiConvertSettings Settings = new OpenApiConvertSettings();
 
         private IEdmModel EdmModel { get; set; }
+
+        private OpenApiDocument _document;
 
         public MainForm()
         {
@@ -187,9 +189,9 @@ namespace OoasGui
             string openApi = null;
             await Task.Run(() =>
             {
-                OpenApiDocument document = EdmModel.ConvertToOpenApi(Settings);
+                _document = EdmModel.ConvertToOpenApi(Settings);
                 MemoryStream stream = new MemoryStream();
-                document.Serialize(stream, Version, Format);
+                _document.Serialize(stream, Version, Format);
                 stream.Flush();
                 stream.Position = 0;
                 openApi = new StreamReader(stream).ReadToEnd();
@@ -227,7 +229,6 @@ namespace OoasGui
                 saveFileDialog.Filter = "YAML files (*.yaml)|*.yaml|All files (*.*)|*.*";
             }
 
-            saveFileDialog.FilterIndex = 2;
             saveFileDialog.RestoreDirectory = true;
 
             if (saveFileDialog.ShowDialog() == DialogResult.OK)
@@ -237,14 +238,13 @@ namespace OoasGui
                 {
                     await Task.Run(() =>
                     {
-                        OpenApiDocument document = EdmModel.ConvertToOpenApi(Settings);
-                        document.Serialize(fs, Version, Format);
+                        _document.Serialize(fs, Version, Format);
                         fs.Flush();
                     });
                 }
-            }
 
-            MessageBox.Show("Saved successful!");
+                MessageBox.Show("Saved successfully!");
+            }
         }
 
         private async void operationIdcheckBox_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/282

- Adds a new convert setting `RefBaseCollectionPaginationCountResponse` which can be used to toggle between referencing the `BaseCollectionPaginationCountResponse` which contains the schemas for `@odata.count` and/or `@odata.nextLink`. By default this defaults to `true`
- [Minor] Refactors the conversion and save processes in the `MainForm` to facilitate faster debugging and testing with the GUI tool.