### PR TITLE
Generate `odata.nextLink` and `odata.deltaLink` properties on delta functions response schemas

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -116,6 +116,11 @@ namespace Microsoft.OpenApi.OData.Common
         public static string BaseCollectionPaginationCountResponse = "BaseCollectionPaginationCountResponse";
 
         /// <summary>
+        /// Suffix used for the base delta function response schemas.
+        /// </summary>
+        public static string BaseDeltaFunctionResponse = "BaseDeltaFunctionResponse";
+
+        /// <summary>
         /// Name used for reference update.
         /// </summary>
         public static string ReferenceUpdateSchemaName = "ReferenceUpdate";

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmOperationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmOperationExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.OData.Edm;
+
+namespace Microsoft.OpenApi.OData.Edm
+{
+    /// <summary>
+    /// Extension methods for <see cref="IEdmOperation"/>
+    /// </summary>
+    internal static class EdmOperationExtensions
+    {
+        /// <summary>
+        /// Checks whether the EDM is a delta function
+        /// </summary>
+        /// <param name="operation">The EDM operation.</param>
+        /// <returns></returns>
+        public static bool IsDeltaFunction(this IEdmOperation operation)
+        {
+            if (operation.IsFunction() && operation.Name == "delta")
+                return true;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmOperationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmOperationExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OData.Edm;
+using System;
+using Microsoft.OData.Edm;
 
 namespace Microsoft.OpenApi.OData.Edm
 {

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmOperationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmOperationExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <returns></returns>
         public static bool IsDeltaFunction(this IEdmOperation operation)
         {
-            if (operation.IsFunction() && operation.Name == "delta")
+            if (operation.IsFunction() && "delta".Equals(operation.Name, StringComparison.OrdinalIgnoreCase))
                 return true;
             return false;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmTypeExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmTypeExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenApi.OData.Edm
     public static class EdmTypeExtensions
     {
         /// <summary>
-        /// Determines wether a path parameter should be wrapped in quotes based on the type of the parameter.
+        /// Determines whether a path parameter should be wrapped in quotes based on the type of the parameter.
         /// </summary>
         /// <param name="edmType">The type of the parameter.</param>
         /// <param name="settings">The conversion settings.</param>

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -147,7 +147,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 }
 
                 // @odata.nextLink + @odata.deltaLink
-                if (context.Model.SchemaElements.OfType<IEdmFunction>().Any(x => x.IsDeltaFunction()))
+                if (context.Model.SchemaElements.OfType<IEdmFunction>().Any(static x => x.IsDeltaFunction()))
                 {
                     schemas[Constants.BaseDeltaFunctionResponse] = new()
                     {

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -129,20 +129,34 @@ namespace Microsoft.OpenApi.OData.Generator
                 }
             };
 
-            // @odata.nextLink + @odata.count
-            if ((context.Settings.EnablePagination || context.Settings.EnableCount) &&
-                context.Settings.RefBaseCollectionPaginationCountResponse)
+            if (context.Settings.EnableODataAnnotationReferencesForResponses)
             {
-                schemas[Constants.BaseCollectionPaginationCountResponse] = new()
+                // @odata.nextLink + @odata.count
+                if (context.Settings.EnablePagination || context.Settings.EnableCount)
                 {
-                    Title = "Base collection pagination and count responses",
-                    Type = Constants.ObjectType,                   
-                };
+                    schemas[Constants.BaseCollectionPaginationCountResponse] = new()
+                    {
+                        Title = "Base collection pagination and count responses",
+                        Type = Constants.ObjectType,
+                    };
 
-                if (context.Settings.EnableCount)
-                    schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataCount);
-                if (context.Settings.EnablePagination)
-                    schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataNextLink);
+                    if (context.Settings.EnableCount)
+                        schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataCount);
+                    if (context.Settings.EnablePagination)
+                        schemas[Constants.BaseCollectionPaginationCountResponse].Properties.Add(ODataConstants.OdataNextLink);
+                }
+
+                // @odata.nextLink + @odata.deltaLink
+                if (context.Model.SchemaElements.OfType<IEdmFunction>().Any(x => x.IsDeltaFunction()))
+                {
+                    schemas[Constants.BaseDeltaFunctionResponse] = new()
+                    {
+                        Title = "Base delta function response",
+                        Type = Constants.ObjectType
+                    };
+                    schemas[Constants.BaseDeltaFunctionResponse].Properties.Add(ODataConstants.OdataNextLink);
+                    schemas[Constants.BaseDeltaFunctionResponse].Properties.Add(ODataConstants.OdataDeltaLink);
+                }
             }
 
             return schemas;
@@ -232,10 +246,10 @@ namespace Microsoft.OpenApi.OData.Generator
                 Properties = properties
             };
 
-            OpenApiSchema colSchema;
+            OpenApiSchema collectionSchema;
             if (context.Settings.EnablePagination || context.Settings.EnableCount)
             {
-                if (context.Settings.RefBaseCollectionPaginationCountResponse)
+                if (context.Settings.EnableODataAnnotationReferencesForResponses)
                 {
                     // @odata.nextLink + @odata.count
                     OpenApiSchema paginationCountSchema = new()
@@ -248,7 +262,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         }
                     };
 
-                    colSchema = new OpenApiSchema
+                    collectionSchema = new OpenApiSchema
                     {
                         AllOf = new List<OpenApiSchema>
                         {
@@ -265,17 +279,17 @@ namespace Microsoft.OpenApi.OData.Generator
                     if (context.Settings.EnableCount)
                         baseSchema.Properties.Add(ODataConstants.OdataCount);
 
-                    colSchema = baseSchema;
+                    collectionSchema = baseSchema;
                 }               
             }
             else
             {
-                colSchema = baseSchema;
+                collectionSchema = baseSchema;
             }
 
-            colSchema.Title = $"Collection of {typeName}";
-            colSchema.Type = Constants.ObjectType;
-            return colSchema;
+            collectionSchema.Title = $"Collection of {typeName}";
+            collectionSchema.Type = Constants.ObjectType;
+            return collectionSchema;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -26,6 +26,7 @@
 - Set assembly version used for conversion in OpenApiInfo object #208
 - Add support for alternate keys parameters #120
 - Adds create and update operations to non-containment navigation properties when restrictions annotations are explicitly set to true #265
+- Generate odata.nextLink and odata.deltaLink properties on delta functions response schemas #285
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.2.0-preview3</Version>
+    <Version>1.2.0-preview4</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>

--- a/src/Microsoft.OpenApi.OData.Reader/OData/ODataConstants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OData/ODataConstants.cs
@@ -30,6 +30,10 @@ namespace Microsoft.OpenApi.OData
         /// @odata.count KeyValue pair
         /// </summary>
         public static KeyValuePair<string, OpenApiSchema> OdataCount = new("@odata.count", new OpenApiSchema { Type = "integer", Format = "int64", Nullable = true });
-        
+
+        /// <summary>
+        /// @odata.deltaLink KeyValue pair
+        /// </summary>
+        public static KeyValuePair<string, OpenApiSchema> OdataDeltaLink = new("@odata.deltaLink", new OpenApiSchema { Type = Constants.StringType, Nullable = true });
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -106,9 +106,9 @@ namespace Microsoft.OpenApi.OData
         public bool EnableCount { get; set; }
 
         /// <summary>
-        /// Gets/sets a value indicating whether or not to reference @odata.nextLink and @odata.count in responses
+        /// Gets/sets a value indicating whether or not to reference @odata.nextLink, @odata.deltaLink and @odata.count in responses
         /// </summary>
-        public bool RefBaseCollectionPaginationCountResponse { get; set; } = true;
+        public bool EnableODataAnnotationReferencesForResponses { get; set; } = true;
 
         /// <summary>
         /// Gets/sets a value that specifies the name of the operation for retrieving the next page in a collection of entities.
@@ -342,7 +342,7 @@ namespace Microsoft.OpenApi.OData
                 UseSuccessStatusCodeRange = this.UseSuccessStatusCodeRange,
                 EnableCount = this.EnableCount,
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
-                RefBaseCollectionPaginationCountResponse = this.RefBaseCollectionPaginationCountResponse
+                EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -17,6 +17,8 @@ namespace Microsoft.OpenApi.OData
     /// </summary>
     public class OpenApiConvertSettings
     {
+        private bool _enableODataAnnotationReferencesForResponses = true;
+
         /// <summary>
         /// Gets/sets the service root.
         /// </summary>
@@ -106,9 +108,20 @@ namespace Microsoft.OpenApi.OData
         public bool EnableCount { get; set; }
 
         /// <summary>
+        /// Gets/sets a value indicating whether or not to reference @odata.nextLink and @odata.count in responses
+        /// </summary>
+        [Obsolete("Deprecated in favor of EnableODataAnnotationReferencesForResponses. " +
+            "When both are provided, EnableODataAnnotationReferencesForResponses takes precedence.")]
+        public bool RefBaseCollectionPaginationCountResponse { get; set; } = true;
+
+        /// <summary>
         /// Gets/sets a value indicating whether or not to reference @odata.nextLink, @odata.deltaLink and @odata.count in responses
         /// </summary>
-        public bool EnableODataAnnotationReferencesForResponses { get; set; } = true;
+        public bool EnableODataAnnotationReferencesForResponses 
+        {
+            get => _enableODataAnnotationReferencesForResponses;
+            set => _enableODataAnnotationReferencesForResponses = value && this.RefBaseCollectionPaginationCountResponse;
+        }
 
         /// <summary>
         /// Gets/sets a value that specifies the name of the operation for retrieving the next page in a collection of entities.
@@ -342,7 +355,8 @@ namespace Microsoft.OpenApi.OData
                 UseSuccessStatusCodeRange = this.UseSuccessStatusCodeRange,
                 EnableCount = this.EnableCount,
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
-                EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses
+                EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
+                RefBaseCollectionPaginationCountResponse = this.RefBaseCollectionPaginationCountResponse
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -17,8 +17,6 @@ namespace Microsoft.OpenApi.OData
     /// </summary>
     public class OpenApiConvertSettings
     {
-        private bool _enableODataAnnotationReferencesForResponses = true;
-
         /// <summary>
         /// Gets/sets the service root.
         /// </summary>
@@ -110,18 +108,13 @@ namespace Microsoft.OpenApi.OData
         /// <summary>
         /// Gets/sets a value indicating whether or not to reference @odata.nextLink and @odata.count in responses
         /// </summary>
-        [Obsolete("Deprecated in favor of EnableODataAnnotationReferencesForResponses. " +
-            "When both are provided, EnableODataAnnotationReferencesForResponses takes precedence.")]
-        public bool RefBaseCollectionPaginationCountResponse { get; set; } = true;
+        [Obsolete("Deprecated in favor of EnableODataAnnotationReferencesForResponses.")]
+        public bool RefBaseCollectionPaginationCountResponse { get { return EnableODataAnnotationReferencesForResponses; } }
 
         /// <summary>
         /// Gets/sets a value indicating whether or not to reference @odata.nextLink, @odata.deltaLink and @odata.count in responses
         /// </summary>
-        public bool EnableODataAnnotationReferencesForResponses 
-        {
-            get => _enableODataAnnotationReferencesForResponses;
-            set => _enableODataAnnotationReferencesForResponses = value && this.RefBaseCollectionPaginationCountResponse;
-        }
+        public bool EnableODataAnnotationReferencesForResponses { get; set; } = true;
 
         /// <summary>
         /// Gets/sets a value that specifies the name of the operation for retrieving the next page in a collection of entities.
@@ -356,7 +349,6 @@ namespace Microsoft.OpenApi.OData
                 EnableCount = this.EnableCount,
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
-                RefBaseCollectionPaginationCountResponse = this.RefBaseCollectionPaginationCountResponse
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmActionOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmActionOperationHandler.cs
@@ -64,16 +64,6 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetExtensions(OpenApiOperation operation)
         {
             operation.Extensions.Add(Constants.xMsDosOperationType, new OpenApiString("action"));
-            if (Context.Settings.EnablePagination && EdmOperation.ReturnType?.TypeKind() == EdmTypeKind.Collection)
-            {
-                OpenApiObject extension = new OpenApiObject
-                {
-                    { "nextLinkName", new OpenApiString("@odata.nextLink")},
-                    { "operationName", new OpenApiString(Context.Settings.PageableOperationName)}
-                };
-
-                operation.Extensions.Add(Constants.xMsPageable, extension);              
-            }
             base.SetExtensions(operation);
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmFunctionOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmFunctionOperationHandler.cs
@@ -42,16 +42,6 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetExtensions(OpenApiOperation operation)
         {
             operation.Extensions.Add(Constants.xMsDosOperationType, new OpenApiString("function"));
-            if (Context.Settings.EnablePagination && EdmOperation.ReturnType?.TypeKind() == EdmTypeKind.Collection)
-            {
-                OpenApiObject extension = new OpenApiObject
-                {
-                    { "nextLinkName", new OpenApiString("@odata.nextLink")},
-                    { "operationName", new OpenApiString(Context.Settings.PageableOperationName)}
-                };
-
-                operation.Extensions.Add(Constants.xMsPageable, extension);
-            }
             base.SetExtensions(operation);
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -6,7 +6,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
@@ -165,7 +164,7 @@ namespace Microsoft.OpenApi.OData.Operation
         }
 
         /// <inheritdoc/>
-        protected override void SetResponses(OpenApiOperation operation)
+        protected override void SetResponses(OpenApiOperation operation) 
         {
             operation.Responses = Context.CreateResponses(EdmOperation);
             base.SetResponses(operation);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -277,5 +277,21 @@ namespace Microsoft.OpenApi.OData.Operation
                 };
             }
         }
+
+        // <inheritdoc/>
+        protected override void SetExtensions(OpenApiOperation operation)
+        {
+            if (Context.Settings.EnablePagination && EdmOperation.ReturnType?.TypeKind() == EdmTypeKind.Collection)
+            {
+                OpenApiObject extension = new OpenApiObject
+                {
+                    { "nextLinkName", new OpenApiString("@odata.nextLink")},
+                    { "operationName", new OpenApiString(Context.Settings.PageableOperationName)}
+                };
+
+                operation.Extensions.Add(Constants.xMsPageable, extension);
+            }
+            base.SetExtensions(operation);
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -11,14 +11,14 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.ge
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.set -> void
-Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.get -> bool

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get ->
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.get -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.NotNull(response.Content);
             OpenApiMediaType mediaType = response.Content["application/json"];
 
-            // openApi version 2 should have not use nullable
+            // openApi version 2 should not use AnyOf
             if (specVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 Assert.NotNull(mediaType.Schema);
@@ -385,7 +385,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
   ""default"": {
     ""$ref"": ""#/components/responses/error""
   }
-}", json);
+}".ChangeLineBreaks(), json);
             }
             else
             {
@@ -428,7 +428,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
   ""default"": {
     ""$ref"": ""#/components/responses/error""
   }
-}", json);
+}".ChangeLineBreaks(), json);
             }
         }
     }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -320,5 +320,116 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
                 Assert.Equal(new string[] { responseCode, "4XX", "5XX" }, responses.Select(r => r.Key));
             }
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateResponseForDeltaEdmFunctionReturnCorrectResponses(bool enableOdataAnnotationRef)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            OpenApiConvertSettings settings = new()
+            {
+                EnableODataAnnotationReferencesForResponses = enableOdataAnnotationRef
+            };
+            ODataContext context = new(model, settings);
+
+            // Act
+            IEdmFunction operation = model.SchemaElements.OfType<IEdmFunction>().First(o => o.Name == "delta" &&
+                   o.Parameters.First().Type.FullName() == "Collection(microsoft.graph.application)");
+            Assert.NotNull(operation); // guard
+            OpenApiResponses responses = context.CreateResponses(operation);
+            string json = responses.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            Assert.NotNull(responses);
+            Assert.NotEmpty(responses);
+            if (enableOdataAnnotationRef)
+            {
+                Assert.Equal(@"{
+  ""200"": {
+    ""description"": ""Success"",
+    ""content"": {
+      ""application/json"": {
+        ""schema"": {
+          ""title"": ""Collection of application"",
+          ""type"": ""object"",
+          ""allOf"": [
+            {
+              ""$ref"": ""#/components/schemas/BaseDeltaFunctionResponse""
+            },
+            {
+              ""type"": ""object"",
+              ""properties"": {
+                ""value"": {
+                  ""type"": ""array"",
+                  ""items"": {
+                    ""anyOf"": [
+                      {
+                        ""$ref"": ""#/components/schemas/microsoft.graph.application""
+                      },
+                      {
+                        ""type"": ""object"",
+                        ""nullable"": true
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  ""default"": {
+    ""$ref"": ""#/components/responses/error""
+  }
+}", json);
+            }
+            else
+            {
+                Assert.Equal(@"{
+  ""200"": {
+    ""description"": ""Success"",
+    ""content"": {
+      ""application/json"": {
+        ""schema"": {
+          ""title"": ""Collection of application"",
+          ""type"": ""object"",
+          ""properties"": {
+            ""value"": {
+              ""type"": ""array"",
+              ""items"": {
+                ""anyOf"": [
+                  {
+                    ""$ref"": ""#/components/schemas/microsoft.graph.application""
+                  },
+                  {
+                    ""type"": ""object"",
+                    ""nullable"": true
+                  }
+                ]
+              }
+            },
+            ""@odata.nextLink"": {
+              ""type"": ""string"",
+              ""nullable"": true
+            },
+            ""@odata.deltaLink"": {
+              ""type"": ""string"",
+              ""nullable"": true
+            }
+          }
+        }
+      }
+    }
+  },
+  ""default"": {
+    ""$ref"": ""#/components/responses/error""
+  }
+}", json);
+            }
+        }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
@@ -338,5 +338,44 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.False(operation.Extensions.ContainsKey(Common.Constants.xMsPageable));
             }
         }
+
+        [Theory]
+        [InlineData("assign", true)]
+        [InlineData("assign", false)]
+        public void CreateOperationForEdmActionWithCollectionReturnTypeHasResponseWithNextLinkProperty(string operationName, bool enablePagination)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            OpenApiConvertSettings settings = new()
+            {
+                EnableOperationId = true,
+                EnablePagination = enablePagination
+            };
+            ODataContext context = new(model, settings);
+            IEdmAction action = model.SchemaElements.OfType<IEdmAction>()
+                .First(x => x.Name == operationName &&
+                    x.FindParameter("bindingParameter").Type.Definition.ToString() == "microsoft.graph.deviceCompliancePolicy");
+            IEdmEntityContainer container = model.SchemaElements.OfType<IEdmEntityContainer>().First();
+            IEdmSingleton deviceManagement = container.FindSingleton("deviceManagement");
+            IEdmEntityType deviceCompliancePolicy = model.SchemaElements.OfType<IEdmEntityType>().First(x => x.Name == "deviceCompliancePolicy");
+
+            ODataPath path = new(new ODataNavigationSourceSegment(deviceManagement),
+                new ODataKeySegment(deviceCompliancePolicy),
+                new ODataOperationSegment(action));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+            var responseProperties = operation.Responses.First().Value.Content.First().Value.Schema.Properties;
+
+            // Assert
+            if (enablePagination)
+            {
+                Assert.True(responseProperties.ContainsKey("@odata.nextLink"));
+            }
+            else
+            {
+                Assert.False(responseProperties.ContainsKey("@odata.nextLink"));
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #285 

This PR 
- Renames setting from `RefBaseCollectionPaginationCountResponse` to `EnableODataAnnotationReferencesForResponses` to make it apply for all the [control information](http://docs.oasis-open.org/odata/odata-json-format/v4.0/cs01/odata-json-format-v4.0-cs01.html#_Toc365464684) in the response i.e. `@odata.nextLink`, `@odata.deltaLink` and `@odata.count` in our case
- Adds `@odata.nextLink` for all actions and functions that return a collection if `EnablePagination = true`
- Creates referenceable schema named `BaseDeltaFunctionResponse` if there's at least one delta function in the model and `EnableODataAnnotationReferencesForResponses = true`
- References `BaseDeltaFunctionResponse` schema for delta functions if `EnableODataAnnotationReferencesForResponses = true`
- Adds  `@odata.nextLink` and ` @odata.deltaLink` properties to responses of delta functions if  `EnableODataAnnotationReferencesForResponses = false`

**`EnableODataAnnotationReferencesForResponses = false`**
![image](https://user-images.githubusercontent.com/25274795/193543900-20df5617-a812-48e6-bd0c-dfdb39c523d2.png)


**`EnableODataAnnotationReferencesForResponses = true`**
<img width="403" alt="image" src="https://user-images.githubusercontent.com/25274795/193543721-03029ac6-934c-4d22-9178-87a00e1f8541.png">
