### PR TITLE
Adds create and update operations on non-containment nav. props when restrictions annotations are explicitly set to true

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.2.0</Version>
+    <Version>1.2.0-preview3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.2.0-preview2</Version>
+    <Version>1.2.0</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -23,6 +23,7 @@
     <PackageReleaseNotes>
 - Use convert setting to toggle between referencing @odata.count and @odata.nextLink #282
 - Fixes URL Path parameters of type datetime generated as strings with quotes #262
+- Adds create and update operations to non-containment navigation properties when restrictions annotations are explicitly set to true #265
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -73,31 +73,33 @@ namespace Microsoft.OpenApi.OData.PathItem
                 return;
             }
 
-            // containment: Get / (Post - Collection | Patch - Single)
-            // non-containment: Get
             AddGetOperation(item, restriction);
 
+            UpdateRestrictionsType navPropUpdateRestriction = restriction?.UpdateRestrictions ??
+                Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty);
+            InsertRestrictionsType navPropInsertRestriction = restriction?.InsertRestrictions ??
+                Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty);
+            UpdateRestrictionsType entityUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(_navPropEntityType);
+
+            // containment: Get / (Post - Collection | Patch - Single)           
             if (NavigationProperty.ContainsTarget)
             {
+                UpdateRestrictionsType updateRestrictionType = navPropUpdateRestriction ?? entityUpdateRestriction;
                 if (NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
                 {
                     if (LastSegmentIsKeySegment)
                     {
-                        UpdateRestrictionsType entityUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(_navPropEntityType);
-                        UpdateRestrictionsType navPropUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty);
+
                         if ((entityUpdateRestriction?.IsUpdatable ?? true) &&
                             (navPropUpdateRestriction?.IsUpdatable ?? true))
                         {
-                            UpdateRestrictionsType updateRestrictionType = navPropUpdateRestriction ?? entityUpdateRestriction;
-                            AddUpdateOperation(item, restriction, updateRestrictionType);
+
+                            AddUpdateOperation(item, updateRestrictionType);
                         }
                     }
                     else
                     {
-                        InsertRestrictionsType navPropInsertRestriction = restriction?.InsertRestrictions ??
-                            Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty);
                         InsertRestrictionsType entityInsertRestriction = Context.Model.GetRecord<InsertRestrictionsType>(_navPropEntityType);
-
                         bool isInsertableDefault = navPropInsertRestriction == null && entityInsertRestriction == null;
 
                         if (isInsertableDefault ||
@@ -110,7 +112,35 @@ namespace Microsoft.OpenApi.OData.PathItem
                 }
                 else
                 {
-                    AddUpdateOperation(item, restriction);
+                    AddUpdateOperation(item, updateRestrictionType);
+                }
+            }
+            else
+            {
+                // non-containment: Get / (Post - Collection | Patch - Single) --> only if annotations are explicitly set
+                if (NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
+                {
+                    if (LastSegmentIsKeySegment)
+                    {
+                        if (navPropUpdateRestriction?.IsUpdatable ?? false)
+                        {
+                            AddUpdateOperation(item, navPropUpdateRestriction);
+                        }
+                    }
+                    else
+                    {
+                        if (navPropInsertRestriction?.IsInsertable ?? false)
+                        {
+                            AddOperation(item, OperationType.Post);
+                        }
+                    }
+                }
+                else
+                {
+                    if (navPropUpdateRestriction?.IsUpdatable ?? false)
+                    {
+                        AddUpdateOperation(item, navPropUpdateRestriction);
+                    }             
                 }
             }
 
@@ -165,34 +195,42 @@ namespace Microsoft.OpenApi.OData.PathItem
         {
             Debug.Assert(!LastSegmentIsRefSegment);
 
-            if (!NavigationProperty.ContainsTarget)
-            {
-                return;
-            }
-
             DeleteRestrictionsType navPropDeleteRestriction = restriction?.DeleteRestrictions ??
-                Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty);
-            DeleteRestrictionsType entityDeleteRestriction = Context.Model.GetRecord<DeleteRestrictionsType>(_navPropEntityType);
-            bool isDeletableDefault = navPropDeleteRestriction == null && entityDeleteRestriction == null;
+               Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty);
 
-            if (isDeletableDefault ||
-               ((entityDeleteRestriction?.IsDeletable ?? true) &&
-               (navPropDeleteRestriction?.IsDeletable ?? true)))
+            if (NavigationProperty.ContainsTarget)
             {
-                if (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment)
+                DeleteRestrictionsType entityDeleteRestriction = Context.Model.GetRecord<DeleteRestrictionsType>(_navPropEntityType);
+                bool isDeletableDefault = navPropDeleteRestriction == null && entityDeleteRestriction == null;
+
+                if (isDeletableDefault ||
+                ((entityDeleteRestriction?.IsDeletable ?? true) &&
+                (navPropDeleteRestriction?.IsDeletable ?? true)))
+                {
+                    if (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment)
+                    {
+                        AddOperation(item, OperationType.Delete);
+                    }
+                }
+            }
+            else
+            {
+                if ((navPropDeleteRestriction?.IsDeletable ?? false) &&
+                    (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many ||
+                    LastSegmentIsKeySegment))
                 {
                     AddOperation(item, OperationType.Delete);
                 }
-                return;
             }
+
+            return;
         }
 
-        private void AddUpdateOperation(OpenApiPathItem item, NavigationPropertyRestriction restriction, UpdateRestrictionsType updateRestrictionsType = null)
+        private void AddUpdateOperation(OpenApiPathItem item, UpdateRestrictionsType updateRestrictionsType)
         {
-            UpdateRestrictionsType update = restriction?.UpdateRestrictions ?? updateRestrictionsType;
-            if (update == null || update.IsUpdatable)
+            if (updateRestrictionsType == null || updateRestrictionsType.IsUpdatable)
             {
-                if (update != null && update.IsUpdateMethodPut)
+                if (updateRestrictionsType != null && updateRestrictionsType.IsUpdateMethodPut)
                 {
                     AddOperation(item, OperationType.Put);
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty);
             UpdateRestrictionsType entityUpdateRestriction = Context.Model.GetRecord<UpdateRestrictionsType>(_navPropEntityType);
 
-            // containment: Get / (Post - Collection | Patch - Single)           
+            // containment: (Post - Collection | Patch/Put - Single)           
             if (NavigationProperty.ContainsTarget)
             {
                 UpdateRestrictionsType updateRestrictionType = navPropUpdateRestriction ?? entityUpdateRestriction;
@@ -117,19 +117,20 @@ namespace Microsoft.OpenApi.OData.PathItem
             }
             else
             {
-                // non-containment: Get / (Post - Collection | Patch - Single) --> only if annotations are explicitly set
+                // non-containment: (Post - Collection | Patch/Put - Single) --> only if annotations are explicitly set to true
+                // Note: Use Updatable and not IsUpdatable | Insertable and not IsInsertable
                 if (NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
                 {
                     if (LastSegmentIsKeySegment)
                     {
-                        if (navPropUpdateRestriction?.IsUpdatable ?? false)
+                        if (navPropUpdateRestriction?.Updatable ?? false)
                         {
                             AddUpdateOperation(item, navPropUpdateRestriction);
                         }
                     }
                     else
                     {
-                        if (navPropInsertRestriction?.IsInsertable ?? false)
+                        if (navPropInsertRestriction?.Insertable ?? false)
                         {
                             AddOperation(item, OperationType.Post);
                         }
@@ -137,7 +138,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 }
                 else
                 {
-                    if (navPropUpdateRestriction?.IsUpdatable ?? false)
+                    if (navPropUpdateRestriction?.Updatable ?? false)
                     {
                         AddUpdateOperation(item, navPropUpdateRestriction);
                     }             

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -106,7 +106,8 @@
                   <PropertyValue Property="UpdateRestrictions">
                     <Record>
                       <PropertyValue Property="LongDescription" String="Update an instance of a best friend." />
-                      <PropertyValue Property="Description" String="Update the best friend." />                      
+                      <PropertyValue Property="Description" String="Update the best friend." />
+					  <PropertyValue Property="Updatable" Bool="true" />
                     </Record>
                   </PropertyValue>
                 </Record>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1627,6 +1627,44 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateBestFriend",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
       "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
     },
     "/Me/BestFriend/$ref": {
@@ -9797,6 +9835,52 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
+      "patch": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "NewComePeople.UpdateBestFriend",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
       "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
     },
     "/NewComePeople/{UserName}/BestFriend/$ref": {
@@ -16903,6 +16987,52 @@
             "schema": {
               "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
             }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateBestFriend",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "key: UserName of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1113,6 +1113,33 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateBestFriend
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   /Me/BestFriend/$ref:
     get:
@@ -6925,6 +6952,39 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - NewComePeople.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: NewComePeople.UpdateBestFriend
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+      x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
   '/NewComePeople/{UserName}/BestFriend/$ref':
     get:
@@ -11951,6 +12011,39 @@ paths:
           description: Retrieved navigation property
           schema:
             $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateBestFriend
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: 'key: UserName of Person'
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
         default:
           $ref: '#/responses/error'
       deprecated: true

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1869,6 +1869,41 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateBestFriend",
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/BestFriend/$ref": {
@@ -10981,6 +11016,54 @@
           "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         },
         "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "NewComePeople.UpdateBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        },
+        "x-ms-docs-operation-type": "operation"
       }
     },
     "/NewComePeople/{UserName}/BestFriend/$ref": {
@@ -19211,6 +19294,54 @@
                 }
               }
             }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "key: UserName of Person",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -1269,6 +1269,31 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateBestFriend
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
   /Me/BestFriend/$ref:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -7755,6 +7780,40 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
       x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - NewComePeople.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: NewComePeople.UpdateBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+      x-ms-docs-operation-type: operation
   '/NewComePeople/{UserName}/BestFriend/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -13562,6 +13621,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: 'key: UserName of Person'
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        required: true
+      responses:
+        '204':
+          description: Success
         default:
           $ref: '#/components/responses/error'
       deprecated: true


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/265

Proposes:
- Adding support for update and delete operations on non-containment navigation properties when restrictions annotations are explicitly set to true.
- Updates tests to validate the above.
- Updates integration files.
- Updates release notes.