### PR TITLE
Omit paths with `PathItems` without any operation

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
@@ -42,13 +43,19 @@ namespace Microsoft.OpenApi.OData.Generator
                     continue;
                 }
 
+                OpenApiPathItem pathItem = handler.CreatePathItem(context, path);
+                if (!pathItem.Operations.Any() && path.Kind != ODataPathKind.MediaEntity)
+                {
+                    continue;
+                }
+
                 if (path.PathTemplate != null)
                 {
-                    pathItems.Add(path.PathTemplate, handler.CreatePathItem(context, path));
+                    pathItems.Add(path.PathTemplate, pathItem);
                 }
                 else
                 {
-                    pathItems.Add(path.GetPathItemName(settings), handler.CreatePathItem(context, path));
+                    pathItems.Add(path.GetPathItemName(settings), pathItem);
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.OData.Generator
                 }
 
                 OpenApiPathItem pathItem = handler.CreatePathItem(context, path);
-                if (!pathItem.Operations.Any() && path.Kind != ODataPathKind.MediaEntity)
+                if (!pathItem.Operations.Any())
                 {
                     continue;
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -27,6 +27,7 @@
 - Add support for alternate keys parameters #120
 - Adds create and update operations to non-containment navigation properties when restrictions annotations are explicitly set to true #265
 - Generate odata.nextLink and odata.deltaLink properties on delta functions response schemas #285
+- Omits paths with PathItems without any operation #148
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/148

This PR:
- Ensures `PathItems` with no operations are not added to the list of paths.
- Adds a test to validate this.