### PR TITLE
Add custom parameters to `$count` and `ODataTypeCast` paths' `Get` operations

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.2.0-preview6</Version>
+    <Version>1.2.0-preview7</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -28,6 +28,7 @@
 - Generate odata.nextLink and odata.deltaLink properties on delta functions response schemas #285
 - Omits paths with PathItems without any operation #148
 - Expands navigation properties of derived types only if declaring navigation property is a containment #269
+- Adds custom parameters to $count and ODataTypeCast paths' Get operations #207
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ODataTypeCastGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ODataTypeCastGetOperationHandler.cs
@@ -369,4 +369,34 @@ internal class ODataTypeCastGetOperationHandler : OperationHandler
 
 		base.SetExtensions(operation);
 	}
+
+    protected override void AppendCustomParameters(OpenApiOperation operation)
+    {
+		IEdmVocabularyAnnotatable annotatable;
+		if (entitySet != null)
+			annotatable = entitySet;
+		else if (singleton != null)
+			annotatable = singleton;
+		else if (navigationProperty != null)
+			annotatable = navigationProperty;
+		else
+			return;
+        
+        ReadRestrictionsType readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(annotatable, CapabilitiesConstants.ReadRestrictions);
+
+        if (readRestrictions == null)
+        {
+            return;
+        }
+
+        if (readRestrictions.CustomHeaders != null)
+        {
+            AppendCustomParameters(operation, readRestrictions.CustomHeaders, ParameterLocation.Header);
+        }
+
+        if (readRestrictions.CustomQueryOptions != null)
+        {
+            AppendCustomParameters(operation, readRestrictions.CustomQueryOptions, ParameterLocation.Query);
+        }
+    }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/DollarCountGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/DollarCountGetOperationHandlerTests.cs
@@ -1,0 +1,134 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using System.Linq;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Tests;
+using Xunit;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests
+{
+    public class DollarCountGetOperationHandlerTests
+    {
+        private readonly DollarCountGetOperationHandler _operationHandler = new();
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void CreateDollarCountGetOperationForNavigationPropertyReturnsCorrectOperation(bool enableOperationId, bool useHTTPStatusCodeClass2XX)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.TripServiceModel;
+            OpenApiConvertSettings settings = new()
+            {
+                EnableOperationId = enableOperationId,
+                UseSuccessStatusCodeRange = useHTTPStatusCodeClass2XX
+            };
+            ODataContext context = new(model, settings);
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
+
+            IEdmEntityType person = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Person");
+            IEdmNavigationProperty navProperty = person.DeclaredNavigationProperties().First(c => c.Name == "Trips");
+            ODataPath path = new(new ODataNavigationSourceSegment(people),
+                new ODataKeySegment(people.EntityType()),
+                new ODataNavigationPropertySegment(navProperty),
+                new ODataDollarCountSegment());
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Get the number of the resource", operation.Summary);
+
+            Assert.NotNull(operation.Parameters);
+            Assert.Equal(2, operation.Parameters.Count);
+            Assert.Collection(operation.Parameters,
+                item =>
+                {
+                    Assert.Equal("UserName", item.Name);
+                    Assert.Equal(ParameterLocation.Path, item.In);
+                },
+                item =>
+                {
+                    Assert.Equal("ConsistencyLevel", item.Name);
+                    Assert.Equal(ParameterLocation.Header, item.In);
+                });
+
+            Assert.Null(operation.RequestBody);
+
+            Assert.Equal(2, operation.Responses.Count);
+            var statusCode = useHTTPStatusCodeClass2XX ? "2XX" : "200";
+            Assert.Equal(new string[] { statusCode, "default" }, operation.Responses.Select(e => e.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("Get.Count.Trips-e877", operation.OperationId);
+            }
+            else
+            {
+                Assert.Null(operation.OperationId);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void CreateDollarCountGetOperationForNavigationSourceReturnsCorrectOperation(bool enableOperationId, bool useHTTPStatusCodeClass2XX)
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.TripServiceModel;
+            OpenApiConvertSettings settings = new()
+            {
+                EnableOperationId = enableOperationId,
+                UseSuccessStatusCodeRange = useHTTPStatusCodeClass2XX
+            };
+            ODataContext context = new(model, settings);
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
+
+            ODataPath path = new(new ODataNavigationSourceSegment(people),
+                new ODataDollarCountSegment());
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Get the number of the resource", operation.Summary);
+
+            Assert.NotNull(operation.Parameters);
+            Assert.Equal(1, operation.Parameters.Count);
+            Assert.Collection(operation.Parameters,
+                item =>
+                {
+                    Assert.Equal("ConsistencyLevel", item.Name);
+                    Assert.Equal(ParameterLocation.Header, item.In);
+                });
+
+            Assert.Null(operation.RequestBody);
+
+            Assert.Equal(2, operation.Responses.Count);
+            var statusCode = useHTTPStatusCodeClass2XX ? "2XX" : "200";
+            Assert.Equal(new string[] { statusCode, "default" }, operation.Responses.Select(e => e.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("Get.Count.People-dd8d", operation.OperationId);
+            }
+            else
+            {
+                Assert.Null(operation.OperationId);
+            }
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("People.Trip", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(9, operation.Parameters.Count);
+            Assert.Equal(10, operation.Parameters.Count);
 
             Assert.Null(operation.RequestBody);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ODataTypeCastGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ODataTypeCastGetOperationHandlerTests.cs
@@ -166,7 +166,7 @@ public class ODataTypeCastGetOperationHandlerTests
         Assert.Single(tag.Extensions);
 
         Assert.NotNull(operation.Parameters);
-        Assert.Equal(8, operation.Parameters.Count);
+        Assert.Equal(9, operation.Parameters.Count);
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)
@@ -221,7 +221,7 @@ public class ODataTypeCastGetOperationHandlerTests
         Assert.Empty(tag.Extensions);
 
         Assert.NotNull(operation.Parameters);
-        Assert.Equal(3, operation.Parameters.Count); //select, expand, id
+        Assert.Equal(4, operation.Parameters.Count); //select, expand, id
 
         Assert.Null(operation.RequestBody);
         if(enablePagination)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefGetOperationHandlerTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("People.Trip", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(7, operation.Parameters.Count);
+            Assert.Equal(8, operation.Parameters.Count);
 
             Assert.Null(operation.RequestBody);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -337,6 +337,28 @@
               </Record>
             </Collection>
           </Annotation>
+		  <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+				<Record>
+					<PropertyValue Property="CustomHeaders">
+						<Collection>
+							<Record>
+								<PropertyValue Property="Name" String="ConsistencyLevel" />
+								<PropertyValue Property="Description" String="Indicates the requested consistency level." />
+								<PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
+								<PropertyValue Property="Required" Bool="false" />
+								<PropertyValue Property="ExampleValues">
+									<Collection>
+										<Record>
+											<PropertyValue Property="Value" String="eventual" />
+											<PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+										</Record>
+									</Collection>
+								</PropertyValue>
+							</Record>
+						</Collection>
+					</PropertyValue>
+				</Record>
+			</Annotation>
         </EntitySet>
         <EntitySet Name="Airlines" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline">
           <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
@@ -388,6 +410,24 @@
       <Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person/Trips">
 		<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
 		  <Record>
+			<PropertyValue Property="CustomHeaders">
+				  <Collection>
+					  <Record>
+						  <PropertyValue Property="Name" String="ConsistencyLevel" />
+						  <PropertyValue Property="Description" String="Indicates the requested consistency level." />
+						  <PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
+						  <PropertyValue Property="Required" Bool="false" />
+						  <PropertyValue Property="ExampleValues">
+							  <Collection>
+								  <Record>
+									  <PropertyValue Property="Value" String="eventual" />
+									  <PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+								  </Record>
+							  </Collection>
+						  </PropertyValue>
+					  </Record>
+				  </Collection>
+			  </PropertyValue>
 			<PropertyValue Property="LongDescription" String="Retrieve a list of trips." />
 			<PropertyValue Property="Description" String="List trips." />
 			<PropertyValue Property="ReadByKeyRestrictions">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -5356,6 +5356,12 @@
         "operationId": "Me.ListTrips",
         "parameters": [
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -6114,6 +6120,14 @@
       "get": {
         "summary": "Get the number of the resource",
         "operationId": "Get.Count.Trips-7b69",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/ODataCountResponse"
@@ -9084,6 +9098,12 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -9853,6 +9873,12 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
           }
         ],
         "responses": {
@@ -9889,6 +9915,12 @@
         "summary": "Get entities from People",
         "operationId": "People.Person.ListPerson",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -10057,6 +10089,12 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
           },
           {
             "in": "query",
@@ -12785,6 +12823,12 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -13874,6 +13918,12 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -14918,6 +14968,12 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -15764,6 +15820,12 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
           }
         ],
         "responses": {
@@ -15788,6 +15850,14 @@
       "get": {
         "summary": "Get the number of the resource",
         "operationId": "Get.Count.People-dd8d",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/ODataCountResponse"
@@ -15814,6 +15884,12 @@
         "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
         "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee-013a",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -15951,6 +16027,12 @@
         "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
         "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager-3e14",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
           {
             "$ref": "#/parameters/top"
           },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -3771,6 +3771,10 @@ paths:
       description: Retrieve a list of trips.
       operationId: Me.ListTrips
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -4319,6 +4323,11 @@ paths:
     get:
       summary: Get the number of the resource
       operationId: Get.Count.Trips-7b69
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
       responses:
         '200':
           $ref: '#/responses/ODataCountResponse'
@@ -6412,6 +6421,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -6961,6 +6974,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
       responses:
         '200':
           $ref: '#/responses/ODataCountResponse'
@@ -6984,6 +7001,10 @@ paths:
       summary: Get entities from People
       operationId: People.Person.ListPerson
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -7107,6 +7128,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - in: query
           name: $select
           description: Select properties to be returned
@@ -9062,6 +9087,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - in: query
           name: $select
           description: Select properties to be returned
@@ -9841,6 +9870,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - in: query
           name: $select
           description: Select properties to be returned
@@ -10588,6 +10621,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -11203,6 +11240,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
       responses:
         '200':
           $ref: '#/responses/ODataCountResponse'
@@ -11219,6 +11260,11 @@ paths:
     get:
       summary: Get the number of the resource
       operationId: Get.Count.People-dd8d
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
       responses:
         '200':
           $ref: '#/responses/ODataCountResponse'
@@ -11238,6 +11284,10 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee-013a
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -11339,6 +11389,10 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager-3e14
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -5966,6 +5966,21 @@
         "operationId": "Me.ListTrips",
         "parameters": [
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -6821,6 +6836,23 @@
       "get": {
         "summary": "Get the number of the resource",
         "operationId": "Get.Count.Trips-7b69",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/ODataCountResponse"
@@ -10220,6 +10252,21 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -11121,6 +11168,21 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           }
         ],
         "responses": {
@@ -11157,6 +11219,21 @@
         "summary": "Get entities from People",
         "operationId": "People.Person.ListPerson",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -11338,6 +11415,21 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "name": "$select",
@@ -14444,6 +14536,21 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -15686,6 +15793,21 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -16883,6 +17005,21 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -17861,6 +17998,21 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           }
         ],
         "responses": {
@@ -17885,6 +18037,23 @@
       "get": {
         "summary": "Get the number of the resource",
         "operationId": "Get.Count.People-dd8d",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/ODataCountResponse"
@@ -17911,6 +18080,21 @@
         "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
         "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee-013a",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -18063,6 +18247,21 @@
         "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
         "operationId": "Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager-3e14",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -4195,6 +4195,16 @@ paths:
       description: Retrieve a list of trips.
       operationId: Me.ListTrips
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -4810,6 +4820,17 @@ paths:
     get:
       summary: Get the number of the resource
       operationId: Get.Count.Trips-7b69
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
       responses:
         '200':
           $ref: '#/components/responses/ODataCountResponse'
@@ -7203,6 +7224,16 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -7842,6 +7873,16 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
       responses:
         '200':
           $ref: '#/components/responses/ODataCountResponse'
@@ -7865,6 +7906,16 @@ paths:
       summary: Get entities from People
       operationId: People.Person.ListPerson
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -7998,6 +8049,16 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -10219,6 +10280,16 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -11106,6 +11177,16 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -11957,6 +12038,16 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -12662,6 +12753,16 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
       responses:
         '200':
           $ref: '#/components/responses/ODataCountResponse'
@@ -12678,6 +12779,17 @@ paths:
     get:
       summary: Get the number of the resource
       operationId: Get.Count.People-dd8d
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
       responses:
         '200':
           $ref: '#/components/responses/ODataCountResponse'
@@ -12697,6 +12809,16 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee-013a
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -12810,6 +12932,16 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Get.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person.Items.As.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager-3e14
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          style: simple
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/207

This PR:
- Adds custom parameters to `$count` and `ODataTypeCast` paths' `Get` operations where either the target navigation property or navigation source has been appropriately annotated with the `CustomHeaders` property in its `ReadRestrictions` annotation.
- Adds a new test class and test methods for `DollarCountGetOperationHandler.cs` --> `DollarCountGetOperationHandlerTests.cs`
- Updates some tests
- Updates some integration test files

NB: In response to this [comment](https://github.com/microsoft/OpenAPI.NET.OData/issues/207#issuecomment-1131601713), we already do add custom headers to navigation properties, and index endpoints where appropriate.

