### PR TITLE
Adds support for configuring the `default` value of derived types' `@odata.type` property

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -184,5 +184,10 @@ namespace Microsoft.OpenApi.OData.Common
         /// decimal format
         /// </summary>
         public static string DecimalFormat = "decimal";
+
+        /// <summary>
+        /// entity name
+        /// </summary>
+        public static string EntityName = "entity";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -237,15 +237,14 @@ namespace Microsoft.OpenApi.OData.Common
             IEnumerable<IEdmStructuredType> structuredTypes = null,
             IEnumerable<IEdmAction> actions = null)
         {
-            const string Entity = "entity";
             string baseTypeName = baseType?.FullTypeName();
-            bool isBaseTypeEntity = Entity.Equals(baseTypeName?.Split('.').Last(), StringComparison.OrdinalIgnoreCase);
+            bool isBaseTypeEntity = Constants.EntityName.Equals(baseTypeName?.Split('.').Last(), StringComparison.OrdinalIgnoreCase);
 
             if (!string.IsNullOrEmpty(baseTypeName) && !isBaseTypeEntity)
             {
                 structuredTypes ??= model.GetAllElements()
                         .Where(static x => x.SchemaElementKind == EdmSchemaElementKind.TypeDefinition)
-                        .Where(static y => !y.Name.Equals(Entity, StringComparison.OrdinalIgnoreCase))
+                        .Where(static y => !y.Name.Equals(Constants.EntityName, StringComparison.OrdinalIgnoreCase))
                         .OfType<IEdmStructuredType>();
 
                 actions ??= model.GetAllElements()

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -230,14 +230,12 @@ namespace Microsoft.OpenApi.OData.Common
         /// <param name="model">The Edm model.</param>
         /// <param name="baseType">The base type of the target <see cref="IEdmStructuredType"/>.</param>
         /// <param name="structuredTypes">Optional: The IEnumerable of <see cref="IEdmStructuredType"/> to check against.</param>
-        /// <param name="complexTypes">Optional: The IEnumerable of <see cref="IEdmComplexType"/> to check against.</param>
         /// <param name="actions">Optional: The IEnumerable of <see cref="IEdmAction"/> to check against.</param>
         /// <returns>True if reference is found, otherwise False.</returns>
         internal static bool IsBaseTypeReferencedAsTypeInModel(
             this IEdmModel model,
             IEdmStructuredType baseType,
             IEnumerable<IEdmStructuredType> structuredTypes = null,
-            IEnumerable<IEdmComplexType> complexTypes = null,
             IEnumerable<IEdmAction> actions = null)
         {
             string baseTypeName = baseType?.FullTypeName();
@@ -249,10 +247,6 @@ namespace Microsoft.OpenApi.OData.Common
                         .Where(static x => x.SchemaElementKind == EdmSchemaElementKind.TypeDefinition)
                         .Where(static y => !y.Name.Equals(Constants.EntityName, StringComparison.OrdinalIgnoreCase))
                         .OfType<IEdmStructuredType>();
-
-                complexTypes ??= model.GetAllElements()
-                    .Where(static x => x.SchemaElementKind == EdmSchemaElementKind.TypeDefinition)
-                    .OfType<IEdmComplexType>();          
 
                 actions ??= model.GetAllElements()
                         .Where(static x => x.SchemaElementKind == EdmSchemaElementKind.Action)
@@ -266,20 +260,12 @@ namespace Microsoft.OpenApi.OData.Common
                     .Any(z => z.Type.FullName().Equals(baseTypeName, StringComparison.OrdinalIgnoreCase)));
                 if (isReferencedInStructuredType) return true;
 
-                // Is base type referenced as a type within a complex type
-                bool isReferencedInComplexType = complexTypes
-                    .Any(x => x.DeclaredProperties.Where(y => y.Type.TypeKind() == EdmTypeKind.Entity ||
-                                                            y.Type.TypeKind() == EdmTypeKind.Collection ||
-                                                            y.Type.TypeKind() == EdmTypeKind.Complex)
-                    .Any(z => z.Type.FullName().Equals(baseTypeName, StringComparison.OrdinalIgnoreCase)));
-                if (isReferencedInComplexType) return true;
-
                 // Is base type referenced as a type in any parameter in an action
                 bool isReferencedInAction = actions.Any(x => x.Parameters.Any(x => x.Type.FullName().Equals(baseTypeName, StringComparison.OrdinalIgnoreCase)));
                 if (isReferencedInAction) return true;
 
                 // Recursively check the base type
-                return model.IsBaseTypeReferencedAsTypeInModel(baseType.BaseType, structuredTypes, complexTypes, actions);
+                return model.IsBaseTypeReferencedAsTypeInModel(baseType.BaseType, structuredTypes, actions);
             }
 
             return false;

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -566,10 +566,21 @@ namespace Microsoft.OpenApi.OData.Generator
 
                 if (context.Settings.EnableDiscriminatorValue)
                 {
+                    OpenApiString defaultValue = null;
+                    bool isBaseTypeEntity = "entity".Equals(structuredType.BaseType?.FullTypeName().Split('.').Last(), StringComparison.OrdinalIgnoreCase);
+                    bool isBaseTypeAbstractNonEntity = (structuredType.BaseType?.IsAbstract ?? false) && !isBaseTypeEntity;
+
+                    if (context.Settings.EnableDefaultValueForOdataTypeProperty ||
+                        isBaseTypeAbstractNonEntity ||
+                        context.Model.IsBaseTypeReferencedAsTypeInModel(structuredType.BaseType))
+                    {
+                        defaultValue = new("#" + structuredType.FullTypeName());
+                    }
+
                     if (!schema.Properties.TryAdd(Constants.OdataType, new OpenApiSchema()
                     {
                         Type = Constants.StringType,
-                        Default = new OpenApiString("#" + structuredType.FullTypeName()),
+                        Default = defaultValue,
                     }))
                     {
                         throw new InvalidOperationException(

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -570,7 +570,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     bool isBaseTypeEntity = Constants.EntityName.Equals(structuredType.BaseType?.FullTypeName().Split('.').Last(), StringComparison.OrdinalIgnoreCase);
                     bool isBaseTypeAbstractNonEntity = (structuredType.BaseType?.IsAbstract ?? false) && !isBaseTypeEntity;
 
-                    if (!context.Settings.EnableTypeDisambiguationForOdataTypePropertyDefaultValue ||
+                    if (!context.Settings.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty ||
                         isBaseTypeAbstractNonEntity ||
                         context.Model.IsBaseTypeReferencedAsTypeInModel(structuredType.BaseType))
                     {

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -570,10 +570,9 @@ namespace Microsoft.OpenApi.OData.Generator
                     bool isBaseTypeEntity = Constants.EntityName.Equals(structuredType.BaseType?.FullTypeName().Split('.').Last(), StringComparison.OrdinalIgnoreCase);
                     bool isBaseTypeAbstractNonEntity = (structuredType.BaseType?.IsAbstract ?? false) && !isBaseTypeEntity;
 
-                    if (context.Settings.EnableDefaultValueForOdataTypeProperty ||
-                        (!context.Settings.EnableDefaultValueForOdataTypeProperty &&
-                        (isBaseTypeAbstractNonEntity ||
-                        context.Model.IsBaseTypeReferencedAsTypeInModel(structuredType.BaseType))))
+                    if (!context.Settings.EnableTypeDisambiguationForOdataTypePropertyDefaultValue ||
+                        isBaseTypeAbstractNonEntity ||
+                        context.Model.IsBaseTypeReferencedAsTypeInModel(structuredType.BaseType))
                     {
                         defaultValue = new("#" + structuredType.FullTypeName());
                     }
@@ -588,7 +587,7 @@ namespace Microsoft.OpenApi.OData.Generator
                             $"Property {Constants.OdataType} is already present in schema {structuredType.FullTypeName()}; verify CSDL.");
                     }
                     schema.Required.Add(Constants.OdataType);
-                }                
+                }
 
                 // It optionally can contain the field description,
                 // whose value is the value of the unqualified annotation Core.Description of the structured type.

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -567,12 +567,13 @@ namespace Microsoft.OpenApi.OData.Generator
                 if (context.Settings.EnableDiscriminatorValue)
                 {
                     OpenApiString defaultValue = null;
-                    bool isBaseTypeEntity = "entity".Equals(structuredType.BaseType?.FullTypeName().Split('.').Last(), StringComparison.OrdinalIgnoreCase);
+                    bool isBaseTypeEntity = Constants.EntityName.Equals(structuredType.BaseType?.FullTypeName().Split('.').Last(), StringComparison.OrdinalIgnoreCase);
                     bool isBaseTypeAbstractNonEntity = (structuredType.BaseType?.IsAbstract ?? false) && !isBaseTypeEntity;
 
                     if (context.Settings.EnableDefaultValueForOdataTypeProperty ||
-                        isBaseTypeAbstractNonEntity ||
-                        context.Model.IsBaseTypeReferencedAsTypeInModel(structuredType.BaseType))
+                        (!context.Settings.EnableDefaultValueForOdataTypeProperty &&
+                        (isBaseTypeAbstractNonEntity ||
+                        context.Model.IsBaseTypeReferencedAsTypeInModel(structuredType.BaseType))))
                     {
                         defaultValue = new("#" + structuredType.FullTypeName());
                     }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.2.0-preview7</Version>
+    <Version>1.2.0-preview8</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -29,6 +29,7 @@
 - Omits paths with PathItems without any operation #148
 - Expands navigation properties of derived types only if declaring navigation property is a containment #269
 - Adds custom parameters to $count and ODataTypeCast paths' Get operations #207
+- Adds support for configuring the default value of derived types' @odata.type property #304
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -302,11 +302,11 @@ namespace Microsoft.OpenApi.OData
         };
 
         /// <summary>
-        /// Gets/sets a value indicating whether to set the default value for the derived type's @odata.type property.
-        /// If false, the value will be set conditionally based on whether the derived type's base type is abstract (and not entity)
+        /// Gets/sets a value indicating whether to set the default value for a structured type's @odata.type property.
+        /// If false, the value will be set conditionally based on whether the type's base type is abstract (and not entity)
         /// and is referenced in the properties of a structural property or an action.
         /// </summary>
-        public bool EnableDefaultValueForOdataTypeProperty { get; set; } = true;
+        public bool EnableTypeDisambiguationForOdataTypePropertyDefaultValue { get; set; } = false;
 
         internal OpenApiConvertSettings Clone()
         {
@@ -356,7 +356,7 @@ namespace Microsoft.OpenApi.OData
                 EnableCount = this.EnableCount,
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
-                EnableDefaultValueForOdataTypeProperty = this.EnableDefaultValueForOdataTypeProperty
+                EnableTypeDisambiguationForOdataTypePropertyDefaultValue = this.EnableTypeDisambiguationForOdataTypePropertyDefaultValue
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -301,6 +301,13 @@ namespace Microsoft.OpenApi.OData
             { LinkRelKey.Function, "https://graph.microsoft.com/rels/docs/function" }
         };
 
+        /// <summary>
+        /// Gets/sets a value indicating whether to set the default value for the derived type's @odata.type property.
+        /// If false, the value will be set conditionally based on whether the derived type's base type is abstract (and not entity)
+        /// and is referenced in the properties of a structural property or an action.
+        /// </summary>
+        public bool EnableDefaultValueForOdataTypeProperty { get; set; } = true;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -349,6 +356,7 @@ namespace Microsoft.OpenApi.OData
                 EnableCount = this.EnableCount,
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
+                EnableDefaultValueForOdataTypeProperty = this.EnableDefaultValueForOdataTypeProperty
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -306,7 +306,7 @@ namespace Microsoft.OpenApi.OData
         /// If false, the value will be set conditionally based on whether the type's base type is abstract (and not entity)
         /// and is referenced in the properties of a structural property or an action.
         /// </summary>
-        public bool EnableTypeDisambiguationForOdataTypePropertyDefaultValue { get; set; } = false;
+        public bool EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty { get; set; } = false;
 
         internal OpenApiConvertSettings Clone()
         {
@@ -356,7 +356,7 @@ namespace Microsoft.OpenApi.OData
                 EnableCount = this.EnableCount,
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
-                EnableTypeDisambiguationForOdataTypePropertyDefaultValue = this.EnableTypeDisambiguationForOdataTypePropertyDefaultValue
+                EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -11,10 +11,10 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.ge
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.set -> void
-Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDefaultValueForOdataTypeProperty.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDefaultValueForOdataTypeProperty.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableTypeDisambiguationForOdataTypePropertyDefaultValue.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableTypeDisambiguationForOdataTypePropertyDefaultValue.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -11,6 +11,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.ge
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDefaultValueForOdataTypeProperty.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableDefaultValueForOdataTypeProperty.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
@@ -20,7 +22,6 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.set ->
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.get -> bool

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -13,8 +13,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.set -> void
-Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableTypeDisambiguationForOdataTypePropertyDefaultValue.get -> bool
-Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableTypeDisambiguationForOdataTypePropertyDefaultValue.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ExpandDerivedTypesNavigationProperties.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get -> System.Collections.Generic.Dictionary<string, string>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.OpenApi.OData.Tests
             ODataContext context = new(model, new OpenApiConvertSettings
             {
                 EnableDiscriminatorValue = true,
-                EnableTypeDisambiguationForOdataTypePropertyDefaultValue = enableTypeDisambiguationForOdataTypePropertyDefaultValue
+                EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = enableTypeDisambiguationForOdataTypePropertyDefaultValue
             });
 
             IEdmComplexType complex = model.SchemaElements.OfType<IEdmComplexType>().First(t => t.Name == "userSet");
@@ -749,7 +749,7 @@ namespace Microsoft.OpenApi.OData.Tests
             ODataContext context = new(model, new OpenApiConvertSettings
             {
                 EnableDiscriminatorValue = true,
-                EnableTypeDisambiguationForOdataTypePropertyDefaultValue = enableTypeDisambiguationForOdataTypePropertyDefaultValue
+                EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = enableTypeDisambiguationForOdataTypePropertyDefaultValue
             });
 
             IEdmEntityType entityType = model.SchemaElements.OfType<IEdmEntityType>().First(t => t.Name == "event");

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -256,14 +256,14 @@ namespace Microsoft.OpenApi.OData.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void CreateStructuredTypeSchemaForComplexTypeWithDiscriminatorValueEnabledReturnsCorrectSchema(bool enableDefaultValueForOdataTypeProperty)
+        public void CreateStructuredTypeSchemaForComplexTypeWithDiscriminatorValueEnabledReturnsCorrectSchema(bool enableTypeDisambiguationForOdataTypePropertyDefaultValue)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.GraphBetaModel;
             ODataContext context = new(model, new OpenApiConvertSettings
             {
                 EnableDiscriminatorValue = true,
-                EnableDefaultValueForOdataTypeProperty = enableDefaultValueForOdataTypeProperty
+                EnableTypeDisambiguationForOdataTypePropertyDefaultValue = enableTypeDisambiguationForOdataTypePropertyDefaultValue
             });
 
             IEdmComplexType complex = model.SchemaElements.OfType<IEdmComplexType>().First(t => t.Name == "userSet");
@@ -275,7 +275,7 @@ namespace Microsoft.OpenApi.OData.Tests
 
             // Assert
             Assert.NotNull(json);
-            string expected = enableDefaultValueForOdataTypeProperty ?
+            string expected = enableTypeDisambiguationForOdataTypePropertyDefaultValue ?
                 @"{
   ""title"": ""userSet"",
   ""required"": [
@@ -288,8 +288,7 @@ namespace Microsoft.OpenApi.OData.Tests
       ""nullable"": true
     },
     ""@odata.type"": {
-      ""type"": ""string"",
-      ""default"": ""#microsoft.graph.userSet""
+      ""type"": ""string""
     }
   },
   ""discriminator"": {
@@ -317,7 +316,8 @@ namespace Microsoft.OpenApi.OData.Tests
       ""nullable"": true
     },
     ""@odata.type"": {
-      ""type"": ""string""
+      ""type"": ""string"",
+      ""default"": ""#microsoft.graph.userSet""
     }
   },
   ""discriminator"": {
@@ -742,14 +742,14 @@ namespace Microsoft.OpenApi.OData.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void CreateStructuredTypeSchemaForEntityTypeWithDefaultValueForOdataTypePropertyEnabledOrDisabledReturnsCorrectSchema(bool enableDefaultValueForOdataTypeProperty)
+        public void CreateStructuredTypeSchemaForEntityTypeWithDefaultValueForOdataTypePropertyEnabledOrDisabledReturnsCorrectSchema(bool enableTypeDisambiguationForOdataTypePropertyDefaultValue)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.GraphBetaModel;
             ODataContext context = new(model, new OpenApiConvertSettings
             {
                 EnableDiscriminatorValue = true,
-                EnableDefaultValueForOdataTypeProperty = enableDefaultValueForOdataTypeProperty
+                EnableTypeDisambiguationForOdataTypePropertyDefaultValue = enableTypeDisambiguationForOdataTypePropertyDefaultValue
             });
 
             IEdmEntityType entityType = model.SchemaElements.OfType<IEdmEntityType>().First(t => t.Name == "event");


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/304

This PR:
- Adds support for setting the `default` value of the `@odata.type` property in the schema of derived types.
- Adds a new convert setting for setting this `default` value. The default value is `true`, meaning the default value will always be emitted. If `false` the value will be set conditionally based on whether the derived type's base type is abstract (and not entity) and is referenced in the properties of a structural property or an action.
- Updates existing tests and adds a new test to validate the above.