### PR TITLE
Add support for paths with alternate keys

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.OData.Common
                 return input;
             }
 
-            char first = Char.ToUpper(input[0]);
+            char first = char.ToUpper(input[0]);
             return first + input.Substring(1);
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OpenApi.OData.Edm
             {
                 IList<string> keys = IsAlternateKey ? 
                     KeyMappings.Values.ToList() : 
-                    EntityType.Key().Select(x => x.Name).ToList();
+                    EntityType.Key().Select(static x => x.Name).ToList();
 
                 return string.Join(",", keys);
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataKeySegment.cs
@@ -38,6 +38,11 @@ namespace Microsoft.OpenApi.OData.Edm
         }
 
         /// <summary>
+        /// Is true if key segment is alternate key
+        /// </summary>
+        public bool IsAlternateKey { get; set; } = false;
+
+        /// <summary>
         /// Gets the key/template mappings.
         /// </summary>
         public IDictionary<string, string> KeyMappings { get; }
@@ -53,13 +58,11 @@ namespace Microsoft.OpenApi.OData.Edm
         {
             get
             {
-                IList<string> keys = new List<string>();
-                foreach (var key in EntityType.Key())
-                {
-                    keys.Add(key.Name);
-                }
+                IList<string> keys = IsAlternateKey ? 
+                    KeyMappings.Values.ToList() : 
+                    EntityType.Key().Select(x => x.Name).ToList();
 
-                return String.Join(",", keys);
+                return string.Join(",", keys);
             }
         }
 
@@ -77,7 +80,7 @@ namespace Microsoft.OpenApi.OData.Edm
             // Use the output key/template mapping
             if (KeyMappings != null)
             {
-                if (KeyMappings.Count == 1)
+                if (KeyMappings.Count == 1 && !IsAlternateKey)
                 {
                     var key = KeyMappings.First();
                     return $"{{{key.Value}}}";
@@ -114,7 +117,7 @@ namespace Microsoft.OpenApi.OData.Edm
                     keyStrings.Add($"{keyProperty.Name}={quote}{{{name}}}{quote}");
                 }
 
-                return String.Join(",", keyStrings);
+                return string.Join(",", keyStrings);
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
@@ -117,7 +117,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <returns>The count.</returns>
         public int GetCount(bool keySegmentAsDepth)
         {
-            return Segments.Count(c => keySegmentAsDepth ? true : !(c is ODataKeySegment));
+            return Segments.Count(c => keySegmentAsDepth || c is not ODataKeySegment);
         }
 
         /// <summary>
@@ -159,8 +159,8 @@ namespace Microsoft.OpenApi.OData.Edm
             {
                 string pathItemName = segment.GetPathItemName(settings, parameters);
 
-                if (segment.Kind == ODataSegmentKind.Key &&
-                    (settings.EnableKeyAsSegment == null || !settings.EnableKeyAsSegment.Value))
+                if (segment is ODataKeySegment keySegment &&
+                    (settings.EnableKeyAsSegment == null || !settings.EnableKeyAsSegment.Value || keySegment.IsAlternateKey))
                 {
                     sb.Append("(");
                     sb.Append(pathItemName);

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -545,19 +545,16 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(entityType, nameof(entityType));
 
             IEnumerable<IDictionary<string, IEdmProperty>> alternateKeys = _model.GetAlternateKeysAnnotation(entityType);
-            if (alternateKeys.Count() > 0)
+            foreach (var keyDict in alternateKeys)
             {
-                foreach (var keyDict in alternateKeys)
+                ODataPath keyPath = currentPath.Clone();
+                IDictionary<string, string> keyMappings = keyDict.ToDictionary(static k => k.Key, static v => v.Value.Name);
+                ODataKeySegment keySegment = new(entityType, keyMappings)
                 {
-                    ODataPath keyPath = currentPath.Clone();
-                    IDictionary<string, string> keyMappings = keyDict.ToDictionary(static k => k.Key, static v => v.Value.Name);
-                    ODataKeySegment keySegment = new(entityType, keyMappings)
-                    {
-                        IsAlternateKey = true
-                    };
-                    keyPath.Push(keySegment);
-                    AppendPath(keyPath);
-                }
+                    IsAlternateKey = true
+                };
+                keyPath.Push(keySegment);
+                AppendPath(keyPath);
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -723,6 +723,7 @@ namespace Microsoft.OpenApi.OData.Edm
                             (!isCollection && !_oDataPathKindsToSkipForOperationsWhenSingle.Contains(subPath.Kind))))
                     {
                         if (lastPathSegment is ODataTypeCastSegment && !convertSettings.AppendBoundOperationsOnDerivedTypeCastSegments) continue;
+                        if (lastPathSegment is ODataKeySegment segment && segment.IsAlternateKey) continue;
                         ODataPath newPath = subPath.Clone();
                         newPath.Push(new ODataOperationSegment(edmOperation, isEscapedFunction));
                         AppendPath(newPath);

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -196,7 +196,8 @@ namespace Microsoft.OpenApi.OData.Edm
 
                 CreateTypeCastPaths(path, convertSettings, entityType, entitySet, true); // ~/entitySet/subType
 
-                CreateAlternateKeyPath(path, entityType); //~/entitySet/{alternateKeyId}
+                if (convertSettings.AddAlternateKeyPaths)
+                    CreateAlternateKeyPath(path, entityType); //~/entitySet/{alternateKeyId}
 
                 path.Push(new ODataKeySegment(entityType)); // ~/entitySet/{id}
                 AppendPath(path.Clone());

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathsGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathsGenerator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OpenApi.OData.Generator
             // Due to the power and flexibility of OData a full representation of all service capabilities
             // in the Paths Object is typically not feasible, so this mapping only describes the minimum
             // information desired in the Paths Object.
-            OpenApiPaths paths = new OpenApiPaths();
+            OpenApiPaths paths = new();
             foreach (var item in context.CreatePathItems())
             {
                 paths.Add(item.Key, item.Value);

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -137,6 +137,11 @@ namespace Microsoft.OpenApi.OData
         public bool EnableDerivedTypesReferencesForRequestBody { get; set; } = false;
 
         /// <summary>
+        /// Gets/sets a value indicating whether or not to generate paths with alternate key parameters
+        /// </summary>
+        public bool AddAlternateKeyPaths { get; set; } = false;
+
+        /// <summary>
         /// Gets/sets a value that specifies a prefix to be prepended to all generated paths.
         /// </summary>
         public string PathPrefix
@@ -356,7 +361,8 @@ namespace Microsoft.OpenApi.OData
                 EnableCount = this.EnableCount,
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
-                EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty
+                EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty,
+                AddAlternateKeyPaths = this.AddAlternateKeyPaths
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 string typeName = entityType.Name;
-                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(x => Utils.UpperFirstChar(x)));
+                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
                 operation.OperationId = $"{EntitySet.Name}.{typeName}.Delete{Utils.UpperFirstChar(typeName)}By{keyName}";
             }
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
@@ -36,9 +36,10 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             IEdmEntityType entityType = EntitySet.EntityType();
+            ODataKeySegment keySegment = Path.LastSegment as ODataKeySegment;
 
             // Description
-            string placeHolder = "Delete entity from " + EntitySet.Name;
+            string placeHolder = $"Delete entity from {EntitySet.Name} by key ({keySegment.Identifier})";
             operation.Summary = _deleteRestrictions?.Description ?? placeHolder;
             operation.Description = _deleteRestrictions?.LongDescription;
 
@@ -46,7 +47,8 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 string typeName = entityType.Name;
-                operation.OperationId = EntitySet.Name + "." + typeName + ".Delete" + Utils.UpperFirstChar(typeName);
+                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(x => Utils.UpperFirstChar(x)));
+                operation.OperationId = $"{EntitySet.Name}.{typeName}.Delete{Utils.UpperFirstChar(typeName)}By{keyName}";
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -37,17 +37,19 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             IEdmEntityType entityType = EntitySet.EntityType();
-
+            ODataKeySegment keySegment = Path.LastSegment as ODataKeySegment;
+            
             // Description
-            string placeHolder = "Get entity from " + EntitySet.Name + " by key";
+            string placeHolder = $"Get entity from {EntitySet.Name} by key ({keySegment.Identifier})";
             operation.Summary = _readRestrictions?.ReadByKeyRestrictions?.Description ?? placeHolder;
             operation.Description = _readRestrictions?.ReadByKeyRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(entityType);
 
             // OperationId
             if (Context.Settings.EnableOperationId)
-            {
+            { 
                 string typeName = entityType.Name;
-                operation.OperationId = EntitySet.Name + "." + typeName + ".Get" + Utils.UpperFirstChar(typeName);
+                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(x => Utils.UpperFirstChar(x)));
+                operation.OperationId = $"{EntitySet.Name}.{typeName}.Get{Utils.UpperFirstChar(typeName)}By{keyName}";
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             { 
                 string typeName = entityType.Name;
-                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(x => Utils.UpperFirstChar(x)));
+                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
                 operation.OperationId = $"{EntitySet.Name}.{typeName}.Get{Utils.UpperFirstChar(typeName)}By{keyName}";
             }
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -32,9 +32,10 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             IEdmEntityType entityType = EntitySet.EntityType();
+            ODataKeySegment keySegment = Path.LastSegment as ODataKeySegment;
 
             // Summary and Description
-            string placeHolder = "Update entity in " + EntitySet.Name;
+            string placeHolder = $"Update entity in {EntitySet.Name} by key ({keySegment.Identifier})";
             operation.Summary = _updateRestrictions?.Description ?? placeHolder;
             operation.Description = _updateRestrictions?.LongDescription;
 
@@ -42,7 +43,8 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 string typeName = entityType.Name;
-                operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(typeName);
+                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(x => Utils.UpperFirstChar(x)));
+                operation.OperationId = $"{EntitySet.Name}.{typeName}.Update{Utils.UpperFirstChar(typeName)}By{keyName}";
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 string typeName = entityType.Name;
-                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(x => Utils.UpperFirstChar(x)));
+                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
                 operation.OperationId = $"{EntitySet.Name}.{typeName}.Update{Utils.UpperFirstChar(typeName)}By{keyName}";
             }
         }

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
 Microsoft.OpenApi.OData.Edm.ODataKeySegment.IsAlternateKey.get -> bool
 Microsoft.OpenApi.OData.Edm.ODataKeySegment.IsAlternateKey.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ abstract Microsoft.OpenApi.OData.Edm.ODataSegment.GetAnnotables() -> System.Coll
 Microsoft.OpenApi.OData.Common.Utils
 Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
+Microsoft.OpenApi.OData.Edm.ODataKeySegment.IsAlternateKey.get -> bool
+Microsoft.OpenApi.OData.Edm.ODataKeySegment.IsAlternateKey.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/EdmModelHelper.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/EdmModelHelper.cs
@@ -38,6 +38,7 @@ namespace Microsoft.OpenApi.OData.Tests
         public static IEdmModel CompositeKeyModel { get; }
 
         public static IEdmModel TripServiceModel { get; }
+
         public static IEdmModel ContractServiceModel { get; }
 
         public static IEdmModel GraphBetaModel { get; }
@@ -302,7 +303,7 @@ namespace Microsoft.OpenApi.OData.Tests
             model.AddElement(customer);
 
             var container = new EdmEntityContainer("NS", "Container");
-            var customers = container.AddEntitySet("Customers", customer);
+            container.AddEntitySet("Customers", customer);
             model.AddElement(container);
             return model;
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -40,8 +40,11 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         {
             // Arrange
             IEdmModel model = EdmModelHelper.GraphBetaModel;
-            ODataPathProvider provider = new ODataPathProvider();
-            var settings = new OpenApiConvertSettings();
+            ODataPathProvider provider = new();
+            OpenApiConvertSettings settings = new()
+            {
+                AddAlternateKeyPaths = true
+            };
 
             // Act
             var paths = provider.GetPaths(model, settings);
@@ -69,7 +72,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(19774, paths.Count());
+            Assert.Equal(19773, paths.Count());
         }
 
         [Fact]
@@ -642,7 +645,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             ODataPathProvider provider = new();
             OpenApiConvertSettings settings = new()
             {
-                EnableKeyAsSegment = true
+                EnableKeyAsSegment = true,
+                AddAlternateKeyPaths= true
             };
 
             // Act
@@ -686,7 +690,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             ODataPathProvider provider = new();
             OpenApiConvertSettings settings = new()
             {
-                EnableKeyAsSegment = true
+                EnableKeyAsSegment = true,
+                AddAlternateKeyPaths = true
             };
 
             // Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -623,12 +623,12 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         {
             string alternateKeyProperty =
 @"<Property Name=""SSN"" Type=""Edm.String""/>
-    <Annotation Term=""OData.Community.Keys.V1.AlternateKeys"">
+    <Annotation Term=""Org.OData.Core.V1.AlternateKeys"">
         <Collection>
-            <Record Type=""OData.Community.Keys.V1.AlternateKey"">
+            <Record Type=""Org.OData.Core.V1.AlternateKey"">
                 <PropertyValue Property=""Key"">
                 <Collection>
-                    <Record Type=""OData.Community.Keys.V1.PropertyRef"">
+                    <Record Type=""Org.OData.Core.V1.PropertyRef"">
                         <PropertyValue Property=""Alias"" String=""SSN""/>
                         <PropertyValue Property=""Name"" PropertyPath=""SSN""/>
                     </Record>
@@ -660,19 +660,19 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         [Fact]
         public void GetPathsWithCompositeAlternateKeyParametersWorks()
         {
-            string alternateKeyProperty =
+            string alternateKeyProperties =
 @"<Property Name=""UserName"" Type=""Edm.String"" Nullable=""false"" />
     <Property Name=""AppID"" Type=""Edm.String"" Nullable=""false"" />
-    <Annotation Term=""OData.Community.Keys.V1.AlternateKeys"">
+    <Annotation Term=""Org.OData.Core.V1.AlternateKeys"">
         <Collection>
-            <Record Type=""OData.Community.Keys.V1.AlternateKey"">
+            <Record Type=""Org.OData.Core.V1.AlternateKey"">
                 <PropertyValue Property=""Key"">
                 <Collection>
-                    <Record Type=""OData.Community.Keys.V1.PropertyRef"">
+                    <Record Type=""Org.OData.Core.V1.PropertyRef"">
                         <PropertyValue Property=""Alias"" String=""username""/>
                         <PropertyValue Property=""Name"" PropertyPath=""UserName""/>
                     </Record>
-                    <Record Type=""OData.Community.Keys.V1.PropertyRef"">
+                    <Record Type=""Org.OData.Core.V1.PropertyRef"">
                         <PropertyValue Property=""Alias"" String=""appId""/>
                         <PropertyValue Property=""Name"" PropertyPath=""AppID""/>
                     </Record>
@@ -682,7 +682,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         </Collection>
     </Annotation>";
 
-            IEdmModel model = GetEdmModel(null, null, alternateKeyProperty);
+            IEdmModel model = GetEdmModel(null, null, alternateKeyProperties);
             ODataPathProvider provider = new();
             OpenApiConvertSettings settings = new()
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
@@ -280,6 +280,104 @@ schema:
         }
 
         [Fact]
+        public void CreateKeyParametersForAlternateKeyWithSinglePropertyWorks()
+        {
+            // Arrange
+            EdmModel model = new();
+            EdmEntityType customer = new("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String));
+
+            IEdmProperty alternateId = customer.AddStructuralProperty("AlternateId", EdmPrimitiveTypeKind.String);
+            model.AddAlternateKeyAnnotation(customer, new Dictionary<string, IEdmProperty> { { "AltId", alternateId } });
+
+            model.AddElement(customer);
+            ODataContext context = new(model);
+            ODataKeySegment keySegment = new(customer)
+            {
+                IsAlternateKey = true
+            };
+
+            // Act
+            var parameters = context.CreateKeyParameters(keySegment);
+            var altParameter = parameters.Last();
+
+            // Assert
+            Assert.NotNull(parameters);
+            Assert.Equal(1, parameters.Count);
+            string json = altParameter.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            Assert.Equal(@"{
+  ""name"": ""AltId"",
+  ""in"": ""path"",
+  ""description"": ""Alternate key: AlternateId of Customer"",
+  ""required"": true,
+  ""style"": ""simple"",
+  ""schema"": {
+    ""type"": ""string"",
+    ""nullable"": true
+  }
+}".ChangeLineBreaks(), json);
+        }
+
+        [Fact]
+        public void CreateKeyParametersForAlternateKeyWithMultiplePropertiesWorks()
+        {
+            // Arrange
+            EdmModel model = new();
+            EdmEntityType customer = new("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String));
+
+            IEdmProperty alternateId1 = customer.AddStructuralProperty("AlternateId1", EdmPrimitiveTypeKind.String);
+            IEdmProperty alternateId2 = customer.AddStructuralProperty("AlternateId2", EdmPrimitiveTypeKind.String);
+            model.AddAlternateKeyAnnotation(customer,
+                new Dictionary<string, IEdmProperty>
+                {
+                    { "AltId1", alternateId1 },
+                    { "AltId2", alternateId2 }
+                });
+
+            model.AddElement(customer);
+            ODataContext context = new(model);
+            ODataKeySegment keySegment = new(customer)
+            {
+                IsAlternateKey = true
+            };
+
+            // Act
+            var parameters = context.CreateKeyParameters(keySegment);
+            var altParameter1 = parameters.First();
+            var altParameter2 = parameters.Last();
+
+            // Assert
+            Assert.NotNull(parameters);
+            Assert.Equal(2, parameters.Count);
+            string json1 = altParameter1.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            Assert.Equal(@"{
+  ""name"": ""AltId1"",
+  ""in"": ""path"",
+  ""description"": ""Composite alternate key: AlternateId1 of Customer"",
+  ""required"": true,
+  ""style"": ""simple"",
+  ""schema"": {
+    ""type"": ""string"",
+    ""nullable"": true
+  }
+}".ChangeLineBreaks(), json1);
+
+            string json2 = altParameter2.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            Assert.Equal(@"{
+  ""name"": ""AltId2"",
+  ""in"": ""path"",
+  ""description"": ""Composite alternate key: AlternateId2 of Customer"",
+  ""required"": true,
+  ""style"": ""simple"",
+  ""schema"": {
+    ""type"": ""string"",
+    ""nullable"": true
+  }
+}".ChangeLineBreaks(), json2);
+        }
+
+        [Fact]
         public void CreateOrderByAndSelectAndExpandParametersWorks()
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityDeleteOperationHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.DeleteCustomer", delete.OperationId);
+                Assert.Equal("Customers.Customer.DeleteCustomerByID", delete.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityGetOperationHandlerTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.GetCustomer", get.OperationId);
+                Assert.Equal("Customers.Customer.GetCustomerByID", get.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.UpdateCustomer", patch.OperationId);
+                Assert.Equal("Customers.Customer.UpdateCustomerByID", patch.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.UpdateCustomer", putOperation.OperationId);
+                Assert.Equal("Customers.Customer.UpdateCustomerByID", putOperation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -123,8 +123,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Get entity from City by key",
-        "operationId": "City.City.GetCity",
+        "summary": "Get entity from City by key (Name)",
+        "operationId": "City.City.GetCityByName",
         "produces": [
           "application/json"
         ],
@@ -179,8 +179,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Update entity in City",
-        "operationId": "City.City.UpdateCity",
+        "summary": "Update entity in City by key (Name)",
+        "operationId": "City.City.UpdateCityByName",
         "consumes": [
           "application/json"
         ],
@@ -217,8 +217,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Delete entity from City",
-        "operationId": "City.City.DeleteCity",
+        "summary": "Delete entity from City by key (Name)",
+        "operationId": "City.City.DeleteCityByName",
         "parameters": [
           {
             "in": "path",
@@ -375,8 +375,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Get entity from CountryOrRegion by key",
-        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegion",
+        "summary": "Get entity from CountryOrRegion by key (Name)",
+        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName",
         "produces": [
           "application/json"
         ],
@@ -431,8 +431,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Update entity in CountryOrRegion",
-        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion",
+        "summary": "Update entity in CountryOrRegion by key (Name)",
+        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName",
         "consumes": [
           "application/json"
         ],
@@ -469,8 +469,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Delete entity from CountryOrRegion",
-        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion",
+        "summary": "Delete entity from CountryOrRegion by key (Name)",
+        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName",
         "parameters": [
           {
             "in": "path",
@@ -721,8 +721,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key",
-        "operationId": "People.Person.GetPerson",
+        "summary": "Get entity from People by key (UserName)",
+        "operationId": "People.Person.GetPersonByUserName",
         "produces": [
           "application/json"
         ],
@@ -780,8 +780,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People",
-        "operationId": "People.Person.UpdatePerson",
+        "summary": "Update entity in People by key (UserName)",
+        "operationId": "People.Person.UpdatePersonByUserName",
         "consumes": [
           "application/json"
         ],
@@ -818,8 +818,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People",
-        "operationId": "People.Person.DeletePerson",
+        "summary": "Delete entity from People by key (UserName)",
+        "operationId": "People.Person.DeletePersonByUserName",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -78,8 +78,8 @@ paths:
     get:
       tags:
         - City.City
-      summary: Get entity from City by key
-      operationId: City.City.GetCity
+      summary: Get entity from City by key (Name)
+      operationId: City.City.GetCityByName
       produces:
         - application/json
       parameters:
@@ -116,8 +116,8 @@ paths:
     patch:
       tags:
         - City.City
-      summary: Update entity in City
-      operationId: City.City.UpdateCity
+      summary: Update entity in City by key (Name)
+      operationId: City.City.UpdateCityByName
       consumes:
         - application/json
       parameters:
@@ -142,8 +142,8 @@ paths:
     delete:
       tags:
         - City.City
-      summary: Delete entity from City
-      operationId: City.City.DeleteCity
+      summary: Delete entity from City by key (Name)
+      operationId: City.City.DeleteCityByName
       parameters:
         - in: path
           name: Name
@@ -243,8 +243,8 @@ paths:
     get:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Get entity from CountryOrRegion by key
-      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegion
+      summary: Get entity from CountryOrRegion by key (Name)
+      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName
       produces:
         - application/json
       parameters:
@@ -281,8 +281,8 @@ paths:
     patch:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Update entity in CountryOrRegion
-      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion
+      summary: Update entity in CountryOrRegion by key (Name)
+      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName
       consumes:
         - application/json
       parameters:
@@ -307,8 +307,8 @@ paths:
     delete:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Delete entity from CountryOrRegion
-      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion
+      summary: Delete entity from CountryOrRegion by key (Name)
+      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName
       parameters:
         - in: path
           name: Name
@@ -475,8 +475,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key
-      operationId: People.Person.GetPerson
+      summary: Get entity from People by key (UserName)
+      operationId: People.Person.GetPersonByUserName
       produces:
         - application/json
       parameters:
@@ -516,8 +516,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People
-      operationId: People.Person.UpdatePerson
+      summary: Update entity in People by key (UserName)
+      operationId: People.Person.UpdatePersonByUserName
       consumes:
         - application/json
       parameters:
@@ -542,8 +542,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People
-      operationId: People.Person.DeletePerson
+      summary: Delete entity from People by key (UserName)
+      operationId: People.Person.DeletePersonByUserName
       parameters:
         - in: path
           name: UserName

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -138,8 +138,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Get entity from City by key",
-        "operationId": "City.City.GetCity",
+        "summary": "Get entity from City by key (Name)",
+        "operationId": "City.City.GetCityByName",
         "parameters": [
           {
             "name": "Name",
@@ -208,8 +208,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Update entity in City",
-        "operationId": "City.City.UpdateCity",
+        "summary": "Update entity in City by key (Name)",
+        "operationId": "City.City.UpdateCityByName",
         "parameters": [
           {
             "name": "Name",
@@ -248,8 +248,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Delete entity from City",
-        "operationId": "City.City.DeleteCity",
+        "summary": "Delete entity from City by key (Name)",
+        "operationId": "City.City.DeleteCityByName",
         "parameters": [
           {
             "name": "Name",
@@ -425,8 +425,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Get entity from CountryOrRegion by key",
-        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegion",
+        "summary": "Get entity from CountryOrRegion by key (Name)",
+        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName",
         "parameters": [
           {
             "name": "Name",
@@ -495,8 +495,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Update entity in CountryOrRegion",
-        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion",
+        "summary": "Update entity in CountryOrRegion by key (Name)",
+        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName",
         "parameters": [
           {
             "name": "Name",
@@ -535,8 +535,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Delete entity from CountryOrRegion",
-        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion",
+        "summary": "Delete entity from CountryOrRegion by key (Name)",
+        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName",
         "parameters": [
           {
             "name": "Name",
@@ -814,8 +814,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key",
-        "operationId": "People.Person.GetPerson",
+        "summary": "Get entity from People by key (UserName)",
+        "operationId": "People.Person.GetPersonByUserName",
         "parameters": [
           {
             "name": "UserName",
@@ -887,8 +887,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People",
-        "operationId": "People.Person.UpdatePerson",
+        "summary": "Update entity in People by key (UserName)",
+        "operationId": "People.Person.UpdatePersonByUserName",
         "parameters": [
           {
             "name": "UserName",
@@ -927,8 +927,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People",
-        "operationId": "People.Person.DeletePerson",
+        "summary": "Delete entity from People by key (UserName)",
+        "operationId": "People.Person.DeletePersonByUserName",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -88,8 +88,8 @@ paths:
     get:
       tags:
         - City.City
-      summary: Get entity from City by key
-      operationId: City.City.GetCity
+      summary: Get entity from City by key (Name)
+      operationId: City.City.GetCityByName
       parameters:
         - name: Name
           in: path
@@ -136,8 +136,8 @@ paths:
     patch:
       tags:
         - City.City
-      summary: Update entity in City
-      operationId: City.City.UpdateCity
+      summary: Update entity in City by key (Name)
+      operationId: City.City.UpdateCityByName
       parameters:
         - name: Name
           in: path
@@ -163,8 +163,8 @@ paths:
     delete:
       tags:
         - City.City
-      summary: Delete entity from City
-      operationId: City.City.DeleteCity
+      summary: Delete entity from City by key (Name)
+      operationId: City.City.DeleteCityByName
       parameters:
         - name: Name
           in: path
@@ -278,8 +278,8 @@ paths:
     get:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Get entity from CountryOrRegion by key
-      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegion
+      summary: Get entity from CountryOrRegion by key (Name)
+      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName
       parameters:
         - name: Name
           in: path
@@ -326,8 +326,8 @@ paths:
     patch:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Update entity in CountryOrRegion
-      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion
+      summary: Update entity in CountryOrRegion by key (Name)
+      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName
       parameters:
         - name: Name
           in: path
@@ -353,8 +353,8 @@ paths:
     delete:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Delete entity from CountryOrRegion
-      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion
+      summary: Delete entity from CountryOrRegion by key (Name)
+      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName
       parameters:
         - name: Name
           in: path
@@ -541,8 +541,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key
-      operationId: People.Person.GetPerson
+      summary: Get entity from People by key (UserName)
+      operationId: People.Person.GetPersonByUserName
       parameters:
         - name: UserName
           in: path
@@ -592,8 +592,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People
-      operationId: People.Person.UpdatePerson
+      summary: Update entity in People by key (UserName)
+      operationId: People.Person.UpdatePersonByUserName
       parameters:
         - name: UserName
           in: path
@@ -619,8 +619,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People
-      operationId: People.Person.DeletePerson
+      summary: Delete entity from People by key (UserName)
+      operationId: People.Person.DeletePersonByUserName
       parameters:
         - name: UserName
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -138,8 +138,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Get entity from Categories by key",
-        "operationId": "Categories.CategoryDto.GetCategoryDto",
+        "summary": "Get entity from Categories by key (Id)",
+        "operationId": "Categories.CategoryDto.GetCategoryDtoById",
         "produces": [
           "application/json"
         ],
@@ -202,8 +202,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Update entity in Categories",
-        "operationId": "Categories.CategoryDto.UpdateCategoryDto",
+        "summary": "Update entity in Categories by key (Id)",
+        "operationId": "Categories.CategoryDto.UpdateCategoryDtoById",
         "consumes": [
           "application/json"
         ],
@@ -243,8 +243,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Delete entity from Categories",
-        "operationId": "Categories.CategoryDto.DeleteCategoryDto",
+        "summary": "Delete entity from Categories by key (Id)",
+        "operationId": "Categories.CategoryDto.DeleteCategoryDtoById",
         "parameters": [
           {
             "in": "path",
@@ -433,8 +433,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Get entity from Documents by key",
-        "operationId": "Documents.DocumentDto.GetDocumentDto",
+        "summary": "Get entity from Documents by key (Id)",
+        "operationId": "Documents.DocumentDto.GetDocumentDtoById",
         "produces": [
           "application/json"
         ],
@@ -503,8 +503,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Update entity in Documents",
-        "operationId": "Documents.DocumentDto.UpdateDocumentDto",
+        "summary": "Update entity in Documents by key (Id)",
+        "operationId": "Documents.DocumentDto.UpdateDocumentDtoById",
         "consumes": [
           "application/json"
         ],
@@ -544,8 +544,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Delete entity from Documents",
-        "operationId": "Documents.DocumentDto.DeleteDocumentDto",
+        "summary": "Delete entity from Documents by key (Id)",
+        "operationId": "Documents.DocumentDto.DeleteDocumentDtoById",
         "parameters": [
           {
             "in": "path",
@@ -1319,8 +1319,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Get entity from Libraries by key",
-        "operationId": "Libraries.LibraryDto.GetLibraryDto",
+        "summary": "Get entity from Libraries by key (Id)",
+        "operationId": "Libraries.LibraryDto.GetLibraryDtoById",
         "produces": [
           "application/json"
         ],
@@ -1394,8 +1394,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Update entity in Libraries",
-        "operationId": "Libraries.LibraryDto.UpdateLibraryDto",
+        "summary": "Update entity in Libraries by key (Id)",
+        "operationId": "Libraries.LibraryDto.UpdateLibraryDtoById",
         "consumes": [
           "application/json"
         ],
@@ -1435,8 +1435,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Delete entity from Libraries",
-        "operationId": "Libraries.LibraryDto.DeleteLibraryDto",
+        "summary": "Delete entity from Libraries by key (Id)",
+        "operationId": "Libraries.LibraryDto.DeleteLibraryDtoById",
         "parameters": [
           {
             "in": "path",
@@ -2193,8 +2193,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Get entity from Revisions by key",
-        "operationId": "Revisions.RevisionDto.GetRevisionDto",
+        "summary": "Get entity from Revisions by key (Id)",
+        "operationId": "Revisions.RevisionDto.GetRevisionDtoById",
         "produces": [
           "application/json"
         ],
@@ -2270,8 +2270,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Update entity in Revisions",
-        "operationId": "Revisions.RevisionDto.UpdateRevisionDto",
+        "summary": "Update entity in Revisions by key (Id)",
+        "operationId": "Revisions.RevisionDto.UpdateRevisionDtoById",
         "consumes": [
           "application/json"
         ],
@@ -2311,8 +2311,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Delete entity from Revisions",
-        "operationId": "Revisions.RevisionDto.DeleteRevisionDto",
+        "summary": "Delete entity from Revisions by key (Id)",
+        "operationId": "Revisions.RevisionDto.DeleteRevisionDtoById",
         "parameters": [
           {
             "in": "path",
@@ -3157,8 +3157,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Get entity from Tasks by key",
-        "operationId": "Tasks.DocumentDto.GetDocumentDto",
+        "summary": "Get entity from Tasks by key (Id)",
+        "operationId": "Tasks.DocumentDto.GetDocumentDtoById",
         "produces": [
           "application/json"
         ],
@@ -3227,8 +3227,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Update entity in Tasks",
-        "operationId": "Tasks.DocumentDto.UpdateDocumentDto",
+        "summary": "Update entity in Tasks by key (Id)",
+        "operationId": "Tasks.DocumentDto.UpdateDocumentDtoById",
         "consumes": [
           "application/json"
         ],
@@ -3268,8 +3268,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Delete entity from Tasks",
-        "operationId": "Tasks.DocumentDto.DeleteDocumentDto",
+        "summary": "Delete entity from Tasks by key (Id)",
+        "operationId": "Tasks.DocumentDto.DeleteDocumentDtoById",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -93,8 +93,8 @@ paths:
     get:
       tags:
         - Categories.CategoryDto
-      summary: Get entity from Categories by key
-      operationId: Categories.CategoryDto.GetCategoryDto
+      summary: Get entity from Categories by key (Id)
+      operationId: Categories.CategoryDto.GetCategoryDtoById
       produces:
         - application/json
       parameters:
@@ -139,8 +139,8 @@ paths:
     patch:
       tags:
         - Categories.CategoryDto
-      summary: Update entity in Categories
-      operationId: Categories.CategoryDto.UpdateCategoryDto
+      summary: Update entity in Categories by key (Id)
+      operationId: Categories.CategoryDto.UpdateCategoryDtoById
       consumes:
         - application/json
       parameters:
@@ -168,8 +168,8 @@ paths:
     delete:
       tags:
         - Categories.CategoryDto
-      summary: Delete entity from Categories
-      operationId: Categories.CategoryDto.DeleteCategoryDto
+      summary: Delete entity from Categories by key (Id)
+      operationId: Categories.CategoryDto.DeleteCategoryDtoById
       parameters:
         - in: path
           name: Id
@@ -301,8 +301,8 @@ paths:
     get:
       tags:
         - Documents.DocumentDto
-      summary: Get entity from Documents by key
-      operationId: Documents.DocumentDto.GetDocumentDto
+      summary: Get entity from Documents by key (Id)
+      operationId: Documents.DocumentDto.GetDocumentDtoById
       produces:
         - application/json
       parameters:
@@ -353,8 +353,8 @@ paths:
     patch:
       tags:
         - Documents.DocumentDto
-      summary: Update entity in Documents
-      operationId: Documents.DocumentDto.UpdateDocumentDto
+      summary: Update entity in Documents by key (Id)
+      operationId: Documents.DocumentDto.UpdateDocumentDtoById
       consumes:
         - application/json
       parameters:
@@ -382,8 +382,8 @@ paths:
     delete:
       tags:
         - Documents.DocumentDto
-      summary: Delete entity from Documents
-      operationId: Documents.DocumentDto.DeleteDocumentDto
+      summary: Delete entity from Documents by key (Id)
+      operationId: Documents.DocumentDto.DeleteDocumentDtoById
       parameters:
         - in: path
           name: Id
@@ -940,8 +940,8 @@ paths:
     get:
       tags:
         - Libraries.LibraryDto
-      summary: Get entity from Libraries by key
-      operationId: Libraries.LibraryDto.GetLibraryDto
+      summary: Get entity from Libraries by key (Id)
+      operationId: Libraries.LibraryDto.GetLibraryDtoById
       produces:
         - application/json
       parameters:
@@ -997,8 +997,8 @@ paths:
     patch:
       tags:
         - Libraries.LibraryDto
-      summary: Update entity in Libraries
-      operationId: Libraries.LibraryDto.UpdateLibraryDto
+      summary: Update entity in Libraries by key (Id)
+      operationId: Libraries.LibraryDto.UpdateLibraryDtoById
       consumes:
         - application/json
       parameters:
@@ -1026,8 +1026,8 @@ paths:
     delete:
       tags:
         - Libraries.LibraryDto
-      summary: Delete entity from Libraries
-      operationId: Libraries.LibraryDto.DeleteLibraryDto
+      summary: Delete entity from Libraries by key (Id)
+      operationId: Libraries.LibraryDto.DeleteLibraryDtoById
       parameters:
         - in: path
           name: Id
@@ -1568,8 +1568,8 @@ paths:
     get:
       tags:
         - Revisions.RevisionDto
-      summary: Get entity from Revisions by key
-      operationId: Revisions.RevisionDto.GetRevisionDto
+      summary: Get entity from Revisions by key (Id)
+      operationId: Revisions.RevisionDto.GetRevisionDtoById
       produces:
         - application/json
       parameters:
@@ -1627,8 +1627,8 @@ paths:
     patch:
       tags:
         - Revisions.RevisionDto
-      summary: Update entity in Revisions
-      operationId: Revisions.RevisionDto.UpdateRevisionDto
+      summary: Update entity in Revisions by key (Id)
+      operationId: Revisions.RevisionDto.UpdateRevisionDtoById
       consumes:
         - application/json
       parameters:
@@ -1656,8 +1656,8 @@ paths:
     delete:
       tags:
         - Revisions.RevisionDto
-      summary: Delete entity from Revisions
-      operationId: Revisions.RevisionDto.DeleteRevisionDto
+      summary: Delete entity from Revisions by key (Id)
+      operationId: Revisions.RevisionDto.DeleteRevisionDtoById
       parameters:
         - in: path
           name: Id
@@ -2267,8 +2267,8 @@ paths:
     get:
       tags:
         - Tasks.DocumentDto
-      summary: Get entity from Tasks by key
-      operationId: Tasks.DocumentDto.GetDocumentDto
+      summary: Get entity from Tasks by key (Id)
+      operationId: Tasks.DocumentDto.GetDocumentDtoById
       produces:
         - application/json
       parameters:
@@ -2319,8 +2319,8 @@ paths:
     patch:
       tags:
         - Tasks.DocumentDto
-      summary: Update entity in Tasks
-      operationId: Tasks.DocumentDto.UpdateDocumentDto
+      summary: Update entity in Tasks by key (Id)
+      operationId: Tasks.DocumentDto.UpdateDocumentDtoById
       consumes:
         - application/json
       parameters:
@@ -2348,8 +2348,8 @@ paths:
     delete:
       tags:
         - Tasks.DocumentDto
-      summary: Delete entity from Tasks
-      operationId: Tasks.DocumentDto.DeleteDocumentDto
+      summary: Delete entity from Tasks by key (Id)
+      operationId: Tasks.DocumentDto.DeleteDocumentDtoById
       parameters:
         - in: path
           name: Id

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -153,8 +153,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Get entity from Categories by key",
-        "operationId": "Categories.CategoryDto.GetCategoryDto",
+        "summary": "Get entity from Categories by key (Id)",
+        "operationId": "Categories.CategoryDto.GetCategoryDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -231,8 +231,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Update entity in Categories",
-        "operationId": "Categories.CategoryDto.UpdateCategoryDto",
+        "summary": "Update entity in Categories by key (Id)",
+        "operationId": "Categories.CategoryDto.UpdateCategoryDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -274,8 +274,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Delete entity from Categories",
-        "operationId": "Categories.CategoryDto.DeleteCategoryDto",
+        "summary": "Delete entity from Categories by key (Id)",
+        "operationId": "Categories.CategoryDto.DeleteCategoryDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -483,8 +483,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Get entity from Documents by key",
-        "operationId": "Documents.DocumentDto.GetDocumentDto",
+        "summary": "Get entity from Documents by key (Id)",
+        "operationId": "Documents.DocumentDto.GetDocumentDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -578,8 +578,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Update entity in Documents",
-        "operationId": "Documents.DocumentDto.UpdateDocumentDto",
+        "summary": "Update entity in Documents by key (Id)",
+        "operationId": "Documents.DocumentDto.UpdateDocumentDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -621,8 +621,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Delete entity from Documents",
-        "operationId": "Documents.DocumentDto.DeleteDocumentDto",
+        "summary": "Delete entity from Documents by key (Id)",
+        "operationId": "Documents.DocumentDto.DeleteDocumentDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -1486,8 +1486,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Get entity from Libraries by key",
-        "operationId": "Libraries.LibraryDto.GetLibraryDto",
+        "summary": "Get entity from Libraries by key (Id)",
+        "operationId": "Libraries.LibraryDto.GetLibraryDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -1583,8 +1583,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Update entity in Libraries",
-        "operationId": "Libraries.LibraryDto.UpdateLibraryDto",
+        "summary": "Update entity in Libraries by key (Id)",
+        "operationId": "Libraries.LibraryDto.UpdateLibraryDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -1626,8 +1626,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Delete entity from Libraries",
-        "operationId": "Libraries.LibraryDto.DeleteLibraryDto",
+        "summary": "Delete entity from Libraries by key (Id)",
+        "operationId": "Libraries.LibraryDto.DeleteLibraryDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -2483,8 +2483,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Get entity from Revisions by key",
-        "operationId": "Revisions.RevisionDto.GetRevisionDto",
+        "summary": "Get entity from Revisions by key (Id)",
+        "operationId": "Revisions.RevisionDto.GetRevisionDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -2582,8 +2582,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Update entity in Revisions",
-        "operationId": "Revisions.RevisionDto.UpdateRevisionDto",
+        "summary": "Update entity in Revisions by key (Id)",
+        "operationId": "Revisions.RevisionDto.UpdateRevisionDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -2625,8 +2625,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Delete entity from Revisions",
-        "operationId": "Revisions.RevisionDto.DeleteRevisionDto",
+        "summary": "Delete entity from Revisions by key (Id)",
+        "operationId": "Revisions.RevisionDto.DeleteRevisionDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -3634,8 +3634,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Get entity from Tasks by key",
-        "operationId": "Tasks.DocumentDto.GetDocumentDto",
+        "summary": "Get entity from Tasks by key (Id)",
+        "operationId": "Tasks.DocumentDto.GetDocumentDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -3729,8 +3729,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Update entity in Tasks",
-        "operationId": "Tasks.DocumentDto.UpdateDocumentDto",
+        "summary": "Update entity in Tasks by key (Id)",
+        "operationId": "Tasks.DocumentDto.UpdateDocumentDtoById",
         "parameters": [
           {
             "name": "Id",
@@ -3772,8 +3772,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Delete entity from Tasks",
-        "operationId": "Tasks.DocumentDto.DeleteDocumentDto",
+        "summary": "Delete entity from Tasks by key (Id)",
+        "operationId": "Tasks.DocumentDto.DeleteDocumentDtoById",
         "parameters": [
           {
             "name": "Id",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -103,8 +103,8 @@ paths:
     get:
       tags:
         - Categories.CategoryDto
-      summary: Get entity from Categories by key
-      operationId: Categories.CategoryDto.GetCategoryDto
+      summary: Get entity from Categories by key (Id)
+      operationId: Categories.CategoryDto.GetCategoryDtoById
       parameters:
         - name: Id
           in: path
@@ -159,8 +159,8 @@ paths:
     patch:
       tags:
         - Categories.CategoryDto
-      summary: Update entity in Categories
-      operationId: Categories.CategoryDto.UpdateCategoryDto
+      summary: Update entity in Categories by key (Id)
+      operationId: Categories.CategoryDto.UpdateCategoryDtoById
       parameters:
         - name: Id
           in: path
@@ -189,8 +189,8 @@ paths:
     delete:
       tags:
         - Categories.CategoryDto
-      summary: Delete entity from Categories
-      operationId: Categories.CategoryDto.DeleteCategoryDto
+      summary: Delete entity from Categories by key (Id)
+      operationId: Categories.CategoryDto.DeleteCategoryDtoById
       parameters:
         - name: Id
           in: path
@@ -336,8 +336,8 @@ paths:
     get:
       tags:
         - Documents.DocumentDto
-      summary: Get entity from Documents by key
-      operationId: Documents.DocumentDto.GetDocumentDto
+      summary: Get entity from Documents by key (Id)
+      operationId: Documents.DocumentDto.GetDocumentDtoById
       parameters:
         - name: Id
           in: path
@@ -405,8 +405,8 @@ paths:
     patch:
       tags:
         - Documents.DocumentDto
-      summary: Update entity in Documents
-      operationId: Documents.DocumentDto.UpdateDocumentDto
+      summary: Update entity in Documents by key (Id)
+      operationId: Documents.DocumentDto.UpdateDocumentDtoById
       parameters:
         - name: Id
           in: path
@@ -435,8 +435,8 @@ paths:
     delete:
       tags:
         - Documents.DocumentDto
-      summary: Delete entity from Documents
-      operationId: Documents.DocumentDto.DeleteDocumentDto
+      summary: Delete entity from Documents by key (Id)
+      operationId: Documents.DocumentDto.DeleteDocumentDtoById
       parameters:
         - name: Id
           in: path
@@ -1058,8 +1058,8 @@ paths:
     get:
       tags:
         - Libraries.LibraryDto
-      summary: Get entity from Libraries by key
-      operationId: Libraries.LibraryDto.GetLibraryDto
+      summary: Get entity from Libraries by key (Id)
+      operationId: Libraries.LibraryDto.GetLibraryDtoById
       parameters:
         - name: Id
           in: path
@@ -1130,8 +1130,8 @@ paths:
     patch:
       tags:
         - Libraries.LibraryDto
-      summary: Update entity in Libraries
-      operationId: Libraries.LibraryDto.UpdateLibraryDto
+      summary: Update entity in Libraries by key (Id)
+      operationId: Libraries.LibraryDto.UpdateLibraryDtoById
       parameters:
         - name: Id
           in: path
@@ -1160,8 +1160,8 @@ paths:
     delete:
       tags:
         - Libraries.LibraryDto
-      summary: Delete entity from Libraries
-      operationId: Libraries.LibraryDto.DeleteLibraryDto
+      summary: Delete entity from Libraries by key (Id)
+      operationId: Libraries.LibraryDto.DeleteLibraryDtoById
       parameters:
         - name: Id
           in: path
@@ -1773,8 +1773,8 @@ paths:
     get:
       tags:
         - Revisions.RevisionDto
-      summary: Get entity from Revisions by key
-      operationId: Revisions.RevisionDto.GetRevisionDto
+      summary: Get entity from Revisions by key (Id)
+      operationId: Revisions.RevisionDto.GetRevisionDtoById
       parameters:
         - name: Id
           in: path
@@ -1847,8 +1847,8 @@ paths:
     patch:
       tags:
         - Revisions.RevisionDto
-      summary: Update entity in Revisions
-      operationId: Revisions.RevisionDto.UpdateRevisionDto
+      summary: Update entity in Revisions by key (Id)
+      operationId: Revisions.RevisionDto.UpdateRevisionDtoById
       parameters:
         - name: Id
           in: path
@@ -1877,8 +1877,8 @@ paths:
     delete:
       tags:
         - Revisions.RevisionDto
-      summary: Delete entity from Revisions
-      operationId: Revisions.RevisionDto.DeleteRevisionDto
+      summary: Delete entity from Revisions by key (Id)
+      operationId: Revisions.RevisionDto.DeleteRevisionDtoById
       parameters:
         - name: Id
           in: path
@@ -2600,8 +2600,8 @@ paths:
     get:
       tags:
         - Tasks.DocumentDto
-      summary: Get entity from Tasks by key
-      operationId: Tasks.DocumentDto.GetDocumentDto
+      summary: Get entity from Tasks by key (Id)
+      operationId: Tasks.DocumentDto.GetDocumentDtoById
       parameters:
         - name: Id
           in: path
@@ -2669,8 +2669,8 @@ paths:
     patch:
       tags:
         - Tasks.DocumentDto
-      summary: Update entity in Tasks
-      operationId: Tasks.DocumentDto.UpdateDocumentDto
+      summary: Update entity in Tasks by key (Id)
+      operationId: Tasks.DocumentDto.UpdateDocumentDtoById
       parameters:
         - name: Id
           in: path
@@ -2699,8 +2699,8 @@ paths:
     delete:
       tags:
         - Tasks.DocumentDto
-      summary: Delete entity from Tasks
-      operationId: Tasks.DocumentDto.DeleteDocumentDto
+      summary: Delete entity from Tasks by key (Id)
+      operationId: Tasks.DocumentDto.DeleteDocumentDtoById
       parameters:
         - name: Id
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -127,8 +127,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Get entity from Airlines by key",
-        "operationId": "Airlines.Airline.GetAirline",
+        "summary": "Get entity from Airlines by key (AirlineCode)",
+        "operationId": "Airlines.Airline.GetAirlineByAirlineCode",
         "produces": [
           "application/json"
         ],
@@ -184,8 +184,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Update entity in Airlines",
-        "operationId": "Airlines.Airline.UpdateAirline",
+        "summary": "Update entity in Airlines by key (AirlineCode)",
+        "operationId": "Airlines.Airline.UpdateAirlineByAirlineCode",
         "consumes": [
           "application/json"
         ],
@@ -222,8 +222,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Delete entity from Airlines",
-        "operationId": "Airlines.Airline.DeleteAirline",
+        "summary": "Delete entity from Airlines by key (AirlineCode)",
+        "operationId": "Airlines.Airline.DeleteAirlineByAirlineCode",
         "parameters": [
           {
             "in": "path",
@@ -389,8 +389,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Get entity from Airports by key",
-        "operationId": "Airports.Airport.GetAirport",
+        "summary": "Get entity from Airports by key (IcaoCode)",
+        "operationId": "Airports.Airport.GetAirportByIcaoCode",
         "produces": [
           "application/json"
         ],
@@ -448,8 +448,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Update entity in Airports",
-        "operationId": "Airports.Airport.UpdateAirport",
+        "summary": "Update entity in Airports by key (IcaoCode)",
+        "operationId": "Airports.Airport.UpdateAirportByIcaoCode",
         "consumes": [
           "application/json"
         ],
@@ -486,8 +486,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Delete entity from Airports",
-        "operationId": "Airports.Airport.DeleteAirport",
+        "summary": "Delete entity from Airports by key (IcaoCode)",
+        "operationId": "Airports.Airport.DeleteAirportByIcaoCode",
         "parameters": [
           {
             "in": "path",
@@ -6295,8 +6295,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Get entity from NewComePeople by key",
-        "operationId": "NewComePeople.Person.GetPerson",
+        "summary": "Get entity from NewComePeople by key (UserName)",
+        "operationId": "NewComePeople.Person.GetPersonByUserName",
         "produces": [
           "application/json"
         ],
@@ -6367,8 +6367,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Update entity in NewComePeople",
-        "operationId": "NewComePeople.Person.UpdatePerson",
+        "summary": "Update entity in NewComePeople by key (UserName)",
+        "operationId": "NewComePeople.Person.UpdatePersonByUserName",
         "consumes": [
           "application/json"
         ],
@@ -6405,8 +6405,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Delete entity from NewComePeople",
-        "operationId": "NewComePeople.Person.DeletePerson",
+        "summary": "Delete entity from NewComePeople by key (UserName)",
+        "operationId": "NewComePeople.Person.DeletePersonByUserName",
         "parameters": [
           {
             "in": "path",
@@ -10076,8 +10076,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key",
-        "operationId": "People.Person.GetPerson",
+        "summary": "Get entity from People by key (UserName)",
+        "operationId": "People.Person.GetPersonByUserName",
         "produces": [
           "application/json"
         ],
@@ -10161,8 +10161,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People",
-        "operationId": "People.Person.UpdatePerson",
+        "summary": "Update entity in People by key (UserName)",
+        "operationId": "People.Person.UpdatePersonByUserName",
         "consumes": [
           "application/json"
         ],
@@ -10206,8 +10206,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People",
-        "operationId": "People.Person.DeletePerson",
+        "summary": "Delete entity from People by key (UserName)",
+        "operationId": "People.Person.DeletePersonByUserName",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -82,8 +82,8 @@ paths:
     get:
       tags:
         - Airlines.Airline
-      summary: Get entity from Airlines by key
-      operationId: Airlines.Airline.GetAirline
+      summary: Get entity from Airlines by key (AirlineCode)
+      operationId: Airlines.Airline.GetAirlineByAirlineCode
       produces:
         - application/json
       parameters:
@@ -121,8 +121,8 @@ paths:
     put:
       tags:
         - Airlines.Airline
-      summary: Update entity in Airlines
-      operationId: Airlines.Airline.UpdateAirline
+      summary: Update entity in Airlines by key (AirlineCode)
+      operationId: Airlines.Airline.UpdateAirlineByAirlineCode
       consumes:
         - application/json
       parameters:
@@ -147,8 +147,8 @@ paths:
     delete:
       tags:
         - Airlines.Airline
-      summary: Delete entity from Airlines
-      operationId: Airlines.Airline.DeleteAirline
+      summary: Delete entity from Airlines by key (AirlineCode)
+      operationId: Airlines.Airline.DeleteAirlineByAirlineCode
       parameters:
         - in: path
           name: AirlineCode
@@ -257,8 +257,8 @@ paths:
     get:
       tags:
         - Airports.Airport
-      summary: Get entity from Airports by key
-      operationId: Airports.Airport.GetAirport
+      summary: Get entity from Airports by key (IcaoCode)
+      operationId: Airports.Airport.GetAirportByIcaoCode
       produces:
         - application/json
       parameters:
@@ -298,8 +298,8 @@ paths:
     patch:
       tags:
         - Airports.Airport
-      summary: Update entity in Airports
-      operationId: Airports.Airport.UpdateAirport
+      summary: Update entity in Airports by key (IcaoCode)
+      operationId: Airports.Airport.UpdateAirportByIcaoCode
       consumes:
         - application/json
       parameters:
@@ -324,8 +324,8 @@ paths:
     delete:
       tags:
         - Airports.Airport
-      summary: Delete entity from Airports
-      operationId: Airports.Airport.DeleteAirport
+      summary: Delete entity from Airports by key (IcaoCode)
+      operationId: Airports.Airport.DeleteAirportByIcaoCode
       parameters:
         - in: path
           name: IcaoCode
@@ -4447,8 +4447,8 @@ paths:
     get:
       tags:
         - NewComePeople.Person
-      summary: Get entity from NewComePeople by key
-      operationId: NewComePeople.Person.GetPerson
+      summary: Get entity from NewComePeople by key (UserName)
+      operationId: NewComePeople.Person.GetPersonByUserName
       produces:
         - application/json
       parameters:
@@ -4501,8 +4501,8 @@ paths:
     patch:
       tags:
         - NewComePeople.Person
-      summary: Update entity in NewComePeople
-      operationId: NewComePeople.Person.UpdatePerson
+      summary: Update entity in NewComePeople by key (UserName)
+      operationId: NewComePeople.Person.UpdatePersonByUserName
       consumes:
         - application/json
       parameters:
@@ -4527,8 +4527,8 @@ paths:
     delete:
       tags:
         - NewComePeople.Person
-      summary: Delete entity from NewComePeople
-      operationId: NewComePeople.Person.DeletePerson
+      summary: Delete entity from NewComePeople by key (UserName)
+      operationId: NewComePeople.Person.DeletePersonByUserName
       parameters:
         - in: path
           name: UserName
@@ -7117,8 +7117,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key
-      operationId: People.Person.GetPerson
+      summary: Get entity from People by key (UserName)
+      operationId: People.Person.GetPersonByUserName
       produces:
         - application/json
       parameters:
@@ -7181,8 +7181,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People
-      operationId: People.Person.UpdatePerson
+      summary: Update entity in People by key (UserName)
+      operationId: People.Person.UpdatePersonByUserName
       consumes:
         - application/json
       parameters:
@@ -7213,8 +7213,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People
-      operationId: People.Person.DeletePerson
+      summary: Delete entity from People by key (UserName)
+      operationId: People.Person.DeletePersonByUserName
       parameters:
         - in: path
           name: UserName

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -141,8 +141,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Get entity from Airlines by key",
-        "operationId": "Airlines.Airline.GetAirline",
+        "summary": "Get entity from Airlines by key (AirlineCode)",
+        "operationId": "Airlines.Airline.GetAirlineByAirlineCode",
         "parameters": [
           {
             "name": "AirlineCode",
@@ -212,8 +212,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Update entity in Airlines",
-        "operationId": "Airlines.Airline.UpdateAirline",
+        "summary": "Update entity in Airlines by key (AirlineCode)",
+        "operationId": "Airlines.Airline.UpdateAirlineByAirlineCode",
         "parameters": [
           {
             "name": "AirlineCode",
@@ -252,8 +252,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Delete entity from Airlines",
-        "operationId": "Airlines.Airline.DeleteAirline",
+        "summary": "Delete entity from Airlines by key (AirlineCode)",
+        "operationId": "Airlines.Airline.DeleteAirlineByAirlineCode",
         "parameters": [
           {
             "name": "AirlineCode",
@@ -438,8 +438,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Get entity from Airports by key",
-        "operationId": "Airports.Airport.GetAirport",
+        "summary": "Get entity from Airports by key (IcaoCode)",
+        "operationId": "Airports.Airport.GetAirportByIcaoCode",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -511,8 +511,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Update entity in Airports",
-        "operationId": "Airports.Airport.UpdateAirport",
+        "summary": "Update entity in Airports by key (IcaoCode)",
+        "operationId": "Airports.Airport.UpdateAirportByIcaoCode",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -551,8 +551,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Delete entity from Airports",
-        "operationId": "Airports.Airport.DeleteAirport",
+        "summary": "Delete entity from Airports by key (IcaoCode)",
+        "operationId": "Airports.Airport.DeleteAirportByIcaoCode",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -7033,8 +7033,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Get entity from NewComePeople by key",
-        "operationId": "NewComePeople.Person.GetPerson",
+        "summary": "Get entity from NewComePeople by key (UserName)",
+        "operationId": "NewComePeople.Person.GetPersonByUserName",
         "parameters": [
           {
             "name": "UserName",
@@ -7119,8 +7119,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Update entity in NewComePeople",
-        "operationId": "NewComePeople.Person.UpdatePerson",
+        "summary": "Update entity in NewComePeople by key (UserName)",
+        "operationId": "NewComePeople.Person.UpdatePersonByUserName",
         "parameters": [
           {
             "name": "UserName",
@@ -7159,8 +7159,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Delete entity from NewComePeople",
-        "operationId": "NewComePeople.Person.DeletePerson",
+        "summary": "Delete entity from NewComePeople by key (UserName)",
+        "operationId": "NewComePeople.Person.DeletePersonByUserName",
         "parameters": [
           {
             "name": "UserName",
@@ -11402,8 +11402,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key",
-        "operationId": "People.Person.GetPerson",
+        "summary": "Get entity from People by key (UserName)",
+        "operationId": "People.Person.GetPersonByUserName",
         "parameters": [
           {
             "name": "UserName",
@@ -11510,8 +11510,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People",
-        "operationId": "People.Person.UpdatePerson",
+        "summary": "Update entity in People by key (UserName)",
+        "operationId": "People.Person.UpdatePersonByUserName",
         "parameters": [
           {
             "name": "UserName",
@@ -11557,8 +11557,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People",
-        "operationId": "People.Person.DeletePerson",
+        "summary": "Delete entity from People by key (UserName)",
+        "operationId": "People.Person.DeletePersonByUserName",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -91,8 +91,8 @@ paths:
     get:
       tags:
         - Airlines.Airline
-      summary: Get entity from Airlines by key
-      operationId: Airlines.Airline.GetAirline
+      summary: Get entity from Airlines by key (AirlineCode)
+      operationId: Airlines.Airline.GetAirlineByAirlineCode
       parameters:
         - name: AirlineCode
           in: path
@@ -140,8 +140,8 @@ paths:
     put:
       tags:
         - Airlines.Airline
-      summary: Update entity in Airlines
-      operationId: Airlines.Airline.UpdateAirline
+      summary: Update entity in Airlines by key (AirlineCode)
+      operationId: Airlines.Airline.UpdateAirlineByAirlineCode
       parameters:
         - name: AirlineCode
           in: path
@@ -167,8 +167,8 @@ paths:
     delete:
       tags:
         - Airlines.Airline
-      summary: Delete entity from Airlines
-      operationId: Airlines.Airline.DeleteAirline
+      summary: Delete entity from Airlines by key (AirlineCode)
+      operationId: Airlines.Airline.DeleteAirlineByAirlineCode
       parameters:
         - name: AirlineCode
           in: path
@@ -291,8 +291,8 @@ paths:
     get:
       tags:
         - Airports.Airport
-      summary: Get entity from Airports by key
-      operationId: Airports.Airport.GetAirport
+      summary: Get entity from Airports by key (IcaoCode)
+      operationId: Airports.Airport.GetAirportByIcaoCode
       parameters:
         - name: IcaoCode
           in: path
@@ -342,8 +342,8 @@ paths:
     patch:
       tags:
         - Airports.Airport
-      summary: Update entity in Airports
-      operationId: Airports.Airport.UpdateAirport
+      summary: Update entity in Airports by key (IcaoCode)
+      operationId: Airports.Airport.UpdateAirportByIcaoCode
       parameters:
         - name: IcaoCode
           in: path
@@ -369,8 +369,8 @@ paths:
     delete:
       tags:
         - Airports.Airport
-      summary: Delete entity from Airports
-      operationId: Airports.Airport.DeleteAirport
+      summary: Delete entity from Airports by key (IcaoCode)
+      operationId: Airports.Airport.DeleteAirportByIcaoCode
       parameters:
         - name: IcaoCode
           in: path
@@ -4960,8 +4960,8 @@ paths:
     get:
       tags:
         - NewComePeople.Person
-      summary: Get entity from NewComePeople by key
-      operationId: NewComePeople.Person.GetPerson
+      summary: Get entity from NewComePeople by key (UserName)
+      operationId: NewComePeople.Person.GetPersonByUserName
       parameters:
         - name: UserName
           in: path
@@ -5024,8 +5024,8 @@ paths:
     patch:
       tags:
         - NewComePeople.Person
-      summary: Update entity in NewComePeople
-      operationId: NewComePeople.Person.UpdatePerson
+      summary: Update entity in NewComePeople by key (UserName)
+      operationId: NewComePeople.Person.UpdatePersonByUserName
       parameters:
         - name: UserName
           in: path
@@ -5051,8 +5051,8 @@ paths:
     delete:
       tags:
         - NewComePeople.Person
-      summary: Delete entity from NewComePeople
-      operationId: NewComePeople.Person.DeletePerson
+      summary: Delete entity from NewComePeople by key (UserName)
+      operationId: NewComePeople.Person.DeletePersonByUserName
       parameters:
         - name: UserName
           in: path
@@ -8038,8 +8038,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key
-      operationId: People.Person.GetPerson
+      summary: Get entity from People by key (UserName)
+      operationId: People.Person.GetPersonByUserName
       parameters:
         - name: UserName
           in: path
@@ -8118,8 +8118,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People
-      operationId: People.Person.UpdatePerson
+      summary: Update entity in People by key (UserName)
+      operationId: People.Person.UpdatePersonByUserName
       parameters:
         - name: UserName
           in: path
@@ -8151,8 +8151,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People
-      operationId: People.Person.DeletePerson
+      summary: Delete entity from People by key (UserName)
+      operationId: People.Person.DeletePersonByUserName
       parameters:
         - name: UserName
           in: path


### PR DESCRIPTION
Fixes #120 

This PR:
- Adds new paths for entities that have alternate keys
- Renames the summary and OperationId of operations to include key name
- Add a setting to enable the generation of paths with alternate keys