### PR TITLE
Finds all the derived types for a schema element

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.OData.Common
             Utils.CheckArgumentNull(edmModel, nameof(edmModel));
             if(structuredType is not IEdmSchemaElement schemaElement) throw new ArgumentException("The type is not a schema element.", nameof(structuredType));
 
-            IEnumerable<IEdmSchemaElement> derivedTypes = edmModel.FindDirectlyDerivedTypes(structuredType).OfType<IEdmSchemaElement>();
+            IEnumerable<IEdmSchemaElement> derivedTypes = edmModel.FindAllDerivedTypes(structuredType).OfType<IEdmSchemaElement>();
 
             if (!derivedTypes.Any())
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.2.0-preview9</Version>
+    <Version>1.2.0-preview10</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -31,6 +31,7 @@
 - Adds custom parameters to $count and ODataTypeCast paths' Get operations #207
 - Adds support for configuring the default value of derived types' @odata.type property #304
 - Adds OData query parameters to $count endpoints #313
+- Finds all the derived types for a schema element #84
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -960,7 +960,7 @@ namespace Microsoft.OpenApi.OData.Tests
 
             // Act
             schema = Common.EdmModelHelper.GetDerivedTypesReferenceSchema(entityType, edmModel);
-            int derivedTypesCount = edmModel.FindDirectlyDerivedTypes(entityType).OfType<IEdmEntityType>().Count() + 1; // + 1 the base type
+            int derivedTypesCount = edmModel.FindAllDerivedTypes(entityType).OfType<IEdmEntityType>().Count() + 1; // + 1 the base type
 
             // Assert
             Assert.NotNull(schema.OneOf);


### PR DESCRIPTION
This PR: 
- Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/84
- Finds all the derived types for a schema element and not just the directly derived types for this element.
- Updates test to validate the above.
- Updates release notes.