### PR TITLE
Only add 'By{Key}' suffix to OperationIds for alternate key paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.2.0-preview10</Version>
+    <Version>1.2.0-preview11</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -32,6 +32,7 @@
 - Adds support for configuring the default value of derived types' @odata.type property #304
 - Adds OData query parameters to $count endpoints #313
 - Finds all the derived types for a schema element #84
+- Add support for paths with alternate keys #120, #329
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
@@ -39,7 +39,11 @@ namespace Microsoft.OpenApi.OData.Operation
             ODataKeySegment keySegment = Path.LastSegment as ODataKeySegment;
 
             // Description
-            string placeHolder = $"Delete entity from {EntitySet.Name} by key ({keySegment.Identifier})";
+            string placeHolder = $"Delete entity from {EntitySet.Name}";
+            if (keySegment.IsAlternateKey)
+            {
+                placeHolder = $"{placeHolder} by {keySegment.Identifier}";
+            }
             operation.Summary = _deleteRestrictions?.Description ?? placeHolder;
             operation.Description = _deleteRestrictions?.LongDescription;
 
@@ -47,8 +51,13 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 string typeName = entityType.Name;
-                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
-                operation.OperationId = $"{EntitySet.Name}.{typeName}.Delete{Utils.UpperFirstChar(typeName)}By{keyName}";
+                string operationName =$"Delete{Utils.UpperFirstChar(typeName)}";
+                if (keySegment.IsAlternateKey)
+                {
+                    string alternateKeyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
+                    operationName = $"{operationName}By{alternateKeyName}";
+                }
+                operation.OperationId =  $"{EntitySet.Name}.{typeName}.{operationName}";          
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -38,9 +38,13 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             IEdmEntityType entityType = EntitySet.EntityType();
             ODataKeySegment keySegment = Path.LastSegment as ODataKeySegment;
-            
+
             // Description
-            string placeHolder = $"Get entity from {EntitySet.Name} by key ({keySegment.Identifier})";
+            string placeHolder = "Get entity from " + EntitySet.Name + " by key";
+            if (keySegment.IsAlternateKey) 
+            {
+                placeHolder = $"{placeHolder} ({keySegment.Identifier})";
+            }
             operation.Summary = _readRestrictions?.ReadByKeyRestrictions?.Description ?? placeHolder;
             operation.Description = _readRestrictions?.ReadByKeyRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(entityType);
 
@@ -48,8 +52,13 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             { 
                 string typeName = entityType.Name;
-                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
-                operation.OperationId = $"{EntitySet.Name}.{typeName}.Get{Utils.UpperFirstChar(typeName)}By{keyName}";
+                string operationName = $"Get{Utils.UpperFirstChar(typeName)}";
+                if (keySegment.IsAlternateKey)
+                {
+                    string alternateKeyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
+                    operationName = $"{operationName}By{alternateKeyName}";
+                }              
+                operation.OperationId = $"{EntitySet.Name}.{typeName}.{operationName}";
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -35,7 +35,11 @@ namespace Microsoft.OpenApi.OData.Operation
             ODataKeySegment keySegment = Path.LastSegment as ODataKeySegment;
 
             // Summary and Description
-            string placeHolder = $"Update entity in {EntitySet.Name} by key ({keySegment.Identifier})";
+            string placeHolder = "Update entity in " + EntitySet.Name;
+            if (keySegment.IsAlternateKey)
+            {
+                placeHolder = $"{placeHolder} by {keySegment.Identifier}";
+            }
             operation.Summary = _updateRestrictions?.Description ?? placeHolder;
             operation.Description = _updateRestrictions?.LongDescription;
 
@@ -43,8 +47,13 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 string typeName = entityType.Name;
-                string keyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
-                operation.OperationId = $"{EntitySet.Name}.{typeName}.Update{Utils.UpperFirstChar(typeName)}By{keyName}";
+                string operationName = $"Update{ Utils.UpperFirstChar(typeName)}";
+                if (keySegment.IsAlternateKey)
+                {
+                    string alternateKeyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
+                    operationName = $"{operationName}By{alternateKeyName}";
+                }
+                operation.OperationId = $"{EntitySet.Name}.{typeName}.{operationName}";
             }
         }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityDeleteOperationHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.DeleteCustomerByID", delete.OperationId);
+                Assert.Equal("Customers.Customer.DeleteCustomer", delete.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityGetOperationHandlerTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.GetCustomerByID", get.OperationId);
+                Assert.Equal("Customers.Customer.GetCustomer", get.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.UpdateCustomerByID", patch.OperationId);
+                Assert.Equal("Customers.Customer.UpdateCustomer", patch.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.UpdateCustomerByID", putOperation.OperationId);
+                Assert.Equal("Customers.Customer.UpdateCustomer", putOperation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -123,8 +123,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Get entity from City by key (Name)",
-        "operationId": "City.City.GetCityByName",
+        "summary": "Get entity from City by key",
+        "operationId": "City.City.GetCity",
         "produces": [
           "application/json"
         ],
@@ -179,8 +179,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Update entity in City by key (Name)",
-        "operationId": "City.City.UpdateCityByName",
+        "summary": "Update entity in City",
+        "operationId": "City.City.UpdateCity",
         "consumes": [
           "application/json"
         ],
@@ -217,8 +217,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Delete entity from City by key (Name)",
-        "operationId": "City.City.DeleteCityByName",
+        "summary": "Delete entity from City",
+        "operationId": "City.City.DeleteCity",
         "parameters": [
           {
             "in": "path",
@@ -383,8 +383,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Get entity from CountryOrRegion by key (Name)",
-        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName",
+        "summary": "Get entity from CountryOrRegion by key",
+        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegion",
         "produces": [
           "application/json"
         ],
@@ -439,8 +439,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Update entity in CountryOrRegion by key (Name)",
-        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName",
+        "summary": "Update entity in CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion",
         "consumes": [
           "application/json"
         ],
@@ -477,8 +477,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Delete entity from CountryOrRegion by key (Name)",
-        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName",
+        "summary": "Delete entity from CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion",
         "parameters": [
           {
             "in": "path",
@@ -737,8 +737,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key (UserName)",
-        "operationId": "People.Person.GetPersonByUserName",
+        "summary": "Get entity from People by key",
+        "operationId": "People.Person.GetPerson",
         "produces": [
           "application/json"
         ],
@@ -796,8 +796,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People by key (UserName)",
-        "operationId": "People.Person.UpdatePersonByUserName",
+        "summary": "Update entity in People",
+        "operationId": "People.Person.UpdatePerson",
         "consumes": [
           "application/json"
         ],
@@ -834,8 +834,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People by key (UserName)",
-        "operationId": "People.Person.DeletePersonByUserName",
+        "summary": "Delete entity from People",
+        "operationId": "People.Person.DeletePerson",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -78,8 +78,8 @@ paths:
     get:
       tags:
         - City.City
-      summary: Get entity from City by key (Name)
-      operationId: City.City.GetCityByName
+      summary: Get entity from City by key
+      operationId: City.City.GetCity
       produces:
         - application/json
       parameters:
@@ -116,8 +116,8 @@ paths:
     patch:
       tags:
         - City.City
-      summary: Update entity in City by key (Name)
-      operationId: City.City.UpdateCityByName
+      summary: Update entity in City
+      operationId: City.City.UpdateCity
       consumes:
         - application/json
       parameters:
@@ -142,8 +142,8 @@ paths:
     delete:
       tags:
         - City.City
-      summary: Delete entity from City by key (Name)
-      operationId: City.City.DeleteCityByName
+      summary: Delete entity from City
+      operationId: City.City.DeleteCity
       parameters:
         - in: path
           name: Name
@@ -246,8 +246,8 @@ paths:
     get:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Get entity from CountryOrRegion by key (Name)
-      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName
+      summary: Get entity from CountryOrRegion by key
+      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegion
       produces:
         - application/json
       parameters:
@@ -284,8 +284,8 @@ paths:
     patch:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Update entity in CountryOrRegion by key (Name)
-      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName
+      summary: Update entity in CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion
       consumes:
         - application/json
       parameters:
@@ -310,8 +310,8 @@ paths:
     delete:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Delete entity from CountryOrRegion by key (Name)
-      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName
+      summary: Delete entity from CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion
       parameters:
         - in: path
           name: Name
@@ -481,8 +481,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key (UserName)
-      operationId: People.Person.GetPersonByUserName
+      summary: Get entity from People by key
+      operationId: People.Person.GetPerson
       produces:
         - application/json
       parameters:
@@ -522,8 +522,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People by key (UserName)
-      operationId: People.Person.UpdatePersonByUserName
+      summary: Update entity in People
+      operationId: People.Person.UpdatePerson
       consumes:
         - application/json
       parameters:
@@ -548,8 +548,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People by key (UserName)
-      operationId: People.Person.DeletePersonByUserName
+      summary: Delete entity from People
+      operationId: People.Person.DeletePerson
       parameters:
         - in: path
           name: UserName

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -138,8 +138,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Get entity from City by key (Name)",
-        "operationId": "City.City.GetCityByName",
+        "summary": "Get entity from City by key",
+        "operationId": "City.City.GetCity",
         "parameters": [
           {
             "name": "Name",
@@ -207,8 +207,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Update entity in City by key (Name)",
-        "operationId": "City.City.UpdateCityByName",
+        "summary": "Update entity in City",
+        "operationId": "City.City.UpdateCity",
         "parameters": [
           {
             "name": "Name",
@@ -246,8 +246,8 @@
         "tags": [
           "City.City"
         ],
-        "summary": "Delete entity from City by key (Name)",
-        "operationId": "City.City.DeleteCityByName",
+        "summary": "Delete entity from City",
+        "operationId": "City.City.DeleteCity",
         "parameters": [
           {
             "name": "Name",
@@ -429,8 +429,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Get entity from CountryOrRegion by key (Name)",
-        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName",
+        "summary": "Get entity from CountryOrRegion by key",
+        "operationId": "CountryOrRegion.CountryOrRegion.GetCountryOrRegion",
         "parameters": [
           {
             "name": "Name",
@@ -498,8 +498,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Update entity in CountryOrRegion by key (Name)",
-        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName",
+        "summary": "Update entity in CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion",
         "parameters": [
           {
             "name": "Name",
@@ -537,8 +537,8 @@
         "tags": [
           "CountryOrRegion.CountryOrRegion"
         ],
-        "summary": "Delete entity from CountryOrRegion by key (Name)",
-        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName",
+        "summary": "Delete entity from CountryOrRegion",
+        "operationId": "CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion",
         "parameters": [
           {
             "name": "Name",
@@ -822,8 +822,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key (UserName)",
-        "operationId": "People.Person.GetPersonByUserName",
+        "summary": "Get entity from People by key",
+        "operationId": "People.Person.GetPerson",
         "parameters": [
           {
             "name": "UserName",
@@ -894,8 +894,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People by key (UserName)",
-        "operationId": "People.Person.UpdatePersonByUserName",
+        "summary": "Update entity in People",
+        "operationId": "People.Person.UpdatePerson",
         "parameters": [
           {
             "name": "UserName",
@@ -933,8 +933,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People by key (UserName)",
-        "operationId": "People.Person.DeletePersonByUserName",
+        "summary": "Delete entity from People",
+        "operationId": "People.Person.DeletePerson",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -88,8 +88,8 @@ paths:
     get:
       tags:
         - City.City
-      summary: Get entity from City by key (Name)
-      operationId: City.City.GetCityByName
+      summary: Get entity from City by key
+      operationId: City.City.GetCity
       parameters:
         - name: Name
           in: path
@@ -135,8 +135,8 @@ paths:
     patch:
       tags:
         - City.City
-      summary: Update entity in City by key (Name)
-      operationId: City.City.UpdateCityByName
+      summary: Update entity in City
+      operationId: City.City.UpdateCity
       parameters:
         - name: Name
           in: path
@@ -161,8 +161,8 @@ paths:
     delete:
       tags:
         - City.City
-      summary: Delete entity from City by key (Name)
-      operationId: City.City.DeleteCityByName
+      summary: Delete entity from City
+      operationId: City.City.DeleteCity
       parameters:
         - name: Name
           in: path
@@ -277,8 +277,8 @@ paths:
     get:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Get entity from CountryOrRegion by key (Name)
-      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegionByName
+      summary: Get entity from CountryOrRegion by key
+      operationId: CountryOrRegion.CountryOrRegion.GetCountryOrRegion
       parameters:
         - name: Name
           in: path
@@ -324,8 +324,8 @@ paths:
     patch:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Update entity in CountryOrRegion by key (Name)
-      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegionByName
+      summary: Update entity in CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.UpdateCountryOrRegion
       parameters:
         - name: Name
           in: path
@@ -350,8 +350,8 @@ paths:
     delete:
       tags:
         - CountryOrRegion.CountryOrRegion
-      summary: Delete entity from CountryOrRegion by key (Name)
-      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegionByName
+      summary: Delete entity from CountryOrRegion
+      operationId: CountryOrRegion.CountryOrRegion.DeleteCountryOrRegion
       parameters:
         - name: Name
           in: path
@@ -539,8 +539,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key (UserName)
-      operationId: People.Person.GetPersonByUserName
+      summary: Get entity from People by key
+      operationId: People.Person.GetPerson
       parameters:
         - name: UserName
           in: path
@@ -589,8 +589,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People by key (UserName)
-      operationId: People.Person.UpdatePersonByUserName
+      summary: Update entity in People
+      operationId: People.Person.UpdatePerson
       parameters:
         - name: UserName
           in: path
@@ -615,8 +615,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People by key (UserName)
-      operationId: People.Person.DeletePersonByUserName
+      summary: Delete entity from People
+      operationId: People.Person.DeletePerson
       parameters:
         - name: UserName
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -138,8 +138,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Get entity from Categories by key (Id)",
-        "operationId": "Categories.CategoryDto.GetCategoryDtoById",
+        "summary": "Get entity from Categories by key",
+        "operationId": "Categories.CategoryDto.GetCategoryDto",
         "produces": [
           "application/json"
         ],
@@ -202,8 +202,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Update entity in Categories by key (Id)",
-        "operationId": "Categories.CategoryDto.UpdateCategoryDtoById",
+        "summary": "Update entity in Categories",
+        "operationId": "Categories.CategoryDto.UpdateCategoryDto",
         "consumes": [
           "application/json"
         ],
@@ -243,8 +243,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Delete entity from Categories by key (Id)",
-        "operationId": "Categories.CategoryDto.DeleteCategoryDtoById",
+        "summary": "Delete entity from Categories",
+        "operationId": "Categories.CategoryDto.DeleteCategoryDto",
         "parameters": [
           {
             "in": "path",
@@ -441,8 +441,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Get entity from Documents by key (Id)",
-        "operationId": "Documents.DocumentDto.GetDocumentDtoById",
+        "summary": "Get entity from Documents by key",
+        "operationId": "Documents.DocumentDto.GetDocumentDto",
         "produces": [
           "application/json"
         ],
@@ -511,8 +511,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Update entity in Documents by key (Id)",
-        "operationId": "Documents.DocumentDto.UpdateDocumentDtoById",
+        "summary": "Update entity in Documents",
+        "operationId": "Documents.DocumentDto.UpdateDocumentDto",
         "consumes": [
           "application/json"
         ],
@@ -552,8 +552,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Delete entity from Documents by key (Id)",
-        "operationId": "Documents.DocumentDto.DeleteDocumentDtoById",
+        "summary": "Delete entity from Documents",
+        "operationId": "Documents.DocumentDto.DeleteDocumentDto",
         "parameters": [
           {
             "in": "path",
@@ -1343,8 +1343,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Get entity from Libraries by key (Id)",
-        "operationId": "Libraries.LibraryDto.GetLibraryDtoById",
+        "summary": "Get entity from Libraries by key",
+        "operationId": "Libraries.LibraryDto.GetLibraryDto",
         "produces": [
           "application/json"
         ],
@@ -1418,8 +1418,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Update entity in Libraries by key (Id)",
-        "operationId": "Libraries.LibraryDto.UpdateLibraryDtoById",
+        "summary": "Update entity in Libraries",
+        "operationId": "Libraries.LibraryDto.UpdateLibraryDto",
         "consumes": [
           "application/json"
         ],
@@ -1459,8 +1459,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Delete entity from Libraries by key (Id)",
-        "operationId": "Libraries.LibraryDto.DeleteLibraryDtoById",
+        "summary": "Delete entity from Libraries",
+        "operationId": "Libraries.LibraryDto.DeleteLibraryDto",
         "parameters": [
           {
             "in": "path",
@@ -2233,8 +2233,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Get entity from Revisions by key (Id)",
-        "operationId": "Revisions.RevisionDto.GetRevisionDtoById",
+        "summary": "Get entity from Revisions by key",
+        "operationId": "Revisions.RevisionDto.GetRevisionDto",
         "produces": [
           "application/json"
         ],
@@ -2310,8 +2310,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Update entity in Revisions by key (Id)",
-        "operationId": "Revisions.RevisionDto.UpdateRevisionDtoById",
+        "summary": "Update entity in Revisions",
+        "operationId": "Revisions.RevisionDto.UpdateRevisionDto",
         "consumes": [
           "application/json"
         ],
@@ -2351,8 +2351,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Delete entity from Revisions by key (Id)",
-        "operationId": "Revisions.RevisionDto.DeleteRevisionDtoById",
+        "summary": "Delete entity from Revisions",
+        "operationId": "Revisions.RevisionDto.DeleteRevisionDto",
         "parameters": [
           {
             "in": "path",
@@ -3214,8 +3214,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Get entity from Tasks by key (Id)",
-        "operationId": "Tasks.DocumentDto.GetDocumentDtoById",
+        "summary": "Get entity from Tasks by key",
+        "operationId": "Tasks.DocumentDto.GetDocumentDto",
         "produces": [
           "application/json"
         ],
@@ -3284,8 +3284,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Update entity in Tasks by key (Id)",
-        "operationId": "Tasks.DocumentDto.UpdateDocumentDtoById",
+        "summary": "Update entity in Tasks",
+        "operationId": "Tasks.DocumentDto.UpdateDocumentDto",
         "consumes": [
           "application/json"
         ],
@@ -3325,8 +3325,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Delete entity from Tasks by key (Id)",
-        "operationId": "Tasks.DocumentDto.DeleteDocumentDtoById",
+        "summary": "Delete entity from Tasks",
+        "operationId": "Tasks.DocumentDto.DeleteDocumentDto",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -93,8 +93,8 @@ paths:
     get:
       tags:
         - Categories.CategoryDto
-      summary: Get entity from Categories by key (Id)
-      operationId: Categories.CategoryDto.GetCategoryDtoById
+      summary: Get entity from Categories by key
+      operationId: Categories.CategoryDto.GetCategoryDto
       produces:
         - application/json
       parameters:
@@ -139,8 +139,8 @@ paths:
     patch:
       tags:
         - Categories.CategoryDto
-      summary: Update entity in Categories by key (Id)
-      operationId: Categories.CategoryDto.UpdateCategoryDtoById
+      summary: Update entity in Categories
+      operationId: Categories.CategoryDto.UpdateCategoryDto
       consumes:
         - application/json
       parameters:
@@ -168,8 +168,8 @@ paths:
     delete:
       tags:
         - Categories.CategoryDto
-      summary: Delete entity from Categories by key (Id)
-      operationId: Categories.CategoryDto.DeleteCategoryDtoById
+      summary: Delete entity from Categories
+      operationId: Categories.CategoryDto.DeleteCategoryDto
       parameters:
         - in: path
           name: Id
@@ -304,8 +304,8 @@ paths:
     get:
       tags:
         - Documents.DocumentDto
-      summary: Get entity from Documents by key (Id)
-      operationId: Documents.DocumentDto.GetDocumentDtoById
+      summary: Get entity from Documents by key
+      operationId: Documents.DocumentDto.GetDocumentDto
       produces:
         - application/json
       parameters:
@@ -356,8 +356,8 @@ paths:
     patch:
       tags:
         - Documents.DocumentDto
-      summary: Update entity in Documents by key (Id)
-      operationId: Documents.DocumentDto.UpdateDocumentDtoById
+      summary: Update entity in Documents
+      operationId: Documents.DocumentDto.UpdateDocumentDto
       consumes:
         - application/json
       parameters:
@@ -385,8 +385,8 @@ paths:
     delete:
       tags:
         - Documents.DocumentDto
-      summary: Delete entity from Documents by key (Id)
-      operationId: Documents.DocumentDto.DeleteDocumentDtoById
+      summary: Delete entity from Documents
+      operationId: Documents.DocumentDto.DeleteDocumentDto
       parameters:
         - in: path
           name: Id
@@ -946,8 +946,8 @@ paths:
     get:
       tags:
         - Libraries.LibraryDto
-      summary: Get entity from Libraries by key (Id)
-      operationId: Libraries.LibraryDto.GetLibraryDtoById
+      summary: Get entity from Libraries by key
+      operationId: Libraries.LibraryDto.GetLibraryDto
       produces:
         - application/json
       parameters:
@@ -1003,8 +1003,8 @@ paths:
     patch:
       tags:
         - Libraries.LibraryDto
-      summary: Update entity in Libraries by key (Id)
-      operationId: Libraries.LibraryDto.UpdateLibraryDtoById
+      summary: Update entity in Libraries
+      operationId: Libraries.LibraryDto.UpdateLibraryDto
       consumes:
         - application/json
       parameters:
@@ -1032,8 +1032,8 @@ paths:
     delete:
       tags:
         - Libraries.LibraryDto
-      summary: Delete entity from Libraries by key (Id)
-      operationId: Libraries.LibraryDto.DeleteLibraryDtoById
+      summary: Delete entity from Libraries
+      operationId: Libraries.LibraryDto.DeleteLibraryDto
       parameters:
         - in: path
           name: Id
@@ -1577,8 +1577,8 @@ paths:
     get:
       tags:
         - Revisions.RevisionDto
-      summary: Get entity from Revisions by key (Id)
-      operationId: Revisions.RevisionDto.GetRevisionDtoById
+      summary: Get entity from Revisions by key
+      operationId: Revisions.RevisionDto.GetRevisionDto
       produces:
         - application/json
       parameters:
@@ -1636,8 +1636,8 @@ paths:
     patch:
       tags:
         - Revisions.RevisionDto
-      summary: Update entity in Revisions by key (Id)
-      operationId: Revisions.RevisionDto.UpdateRevisionDtoById
+      summary: Update entity in Revisions
+      operationId: Revisions.RevisionDto.UpdateRevisionDto
       consumes:
         - application/json
       parameters:
@@ -1665,8 +1665,8 @@ paths:
     delete:
       tags:
         - Revisions.RevisionDto
-      summary: Delete entity from Revisions by key (Id)
-      operationId: Revisions.RevisionDto.DeleteRevisionDtoById
+      summary: Delete entity from Revisions
+      operationId: Revisions.RevisionDto.DeleteRevisionDto
       parameters:
         - in: path
           name: Id
@@ -2280,8 +2280,8 @@ paths:
     get:
       tags:
         - Tasks.DocumentDto
-      summary: Get entity from Tasks by key (Id)
-      operationId: Tasks.DocumentDto.GetDocumentDtoById
+      summary: Get entity from Tasks by key
+      operationId: Tasks.DocumentDto.GetDocumentDto
       produces:
         - application/json
       parameters:
@@ -2332,8 +2332,8 @@ paths:
     patch:
       tags:
         - Tasks.DocumentDto
-      summary: Update entity in Tasks by key (Id)
-      operationId: Tasks.DocumentDto.UpdateDocumentDtoById
+      summary: Update entity in Tasks
+      operationId: Tasks.DocumentDto.UpdateDocumentDto
       consumes:
         - application/json
       parameters:
@@ -2361,8 +2361,8 @@ paths:
     delete:
       tags:
         - Tasks.DocumentDto
-      summary: Delete entity from Tasks by key (Id)
-      operationId: Tasks.DocumentDto.DeleteDocumentDtoById
+      summary: Delete entity from Tasks
+      operationId: Tasks.DocumentDto.DeleteDocumentDto
       parameters:
         - in: path
           name: Id

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -153,8 +153,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Get entity from Categories by key (Id)",
-        "operationId": "Categories.CategoryDto.GetCategoryDtoById",
+        "summary": "Get entity from Categories by key",
+        "operationId": "Categories.CategoryDto.GetCategoryDto",
         "parameters": [
           {
             "name": "Id",
@@ -230,8 +230,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Update entity in Categories by key (Id)",
-        "operationId": "Categories.CategoryDto.UpdateCategoryDtoById",
+        "summary": "Update entity in Categories",
+        "operationId": "Categories.CategoryDto.UpdateCategoryDto",
         "parameters": [
           {
             "name": "Id",
@@ -272,8 +272,8 @@
         "tags": [
           "Categories.CategoryDto"
         ],
-        "summary": "Delete entity from Categories by key (Id)",
-        "operationId": "Categories.CategoryDto.DeleteCategoryDtoById",
+        "summary": "Delete entity from Categories",
+        "operationId": "Categories.CategoryDto.DeleteCategoryDto",
         "parameters": [
           {
             "name": "Id",
@@ -487,8 +487,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Get entity from Documents by key (Id)",
-        "operationId": "Documents.DocumentDto.GetDocumentDtoById",
+        "summary": "Get entity from Documents by key",
+        "operationId": "Documents.DocumentDto.GetDocumentDto",
         "parameters": [
           {
             "name": "Id",
@@ -581,8 +581,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Update entity in Documents by key (Id)",
-        "operationId": "Documents.DocumentDto.UpdateDocumentDtoById",
+        "summary": "Update entity in Documents",
+        "operationId": "Documents.DocumentDto.UpdateDocumentDto",
         "parameters": [
           {
             "name": "Id",
@@ -623,8 +623,8 @@
         "tags": [
           "Documents.DocumentDto"
         ],
-        "summary": "Delete entity from Documents by key (Id)",
-        "operationId": "Documents.DocumentDto.DeleteDocumentDtoById",
+        "summary": "Delete entity from Documents",
+        "operationId": "Documents.DocumentDto.DeleteDocumentDto",
         "parameters": [
           {
             "name": "Id",
@@ -1492,8 +1492,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Get entity from Libraries by key (Id)",
-        "operationId": "Libraries.LibraryDto.GetLibraryDtoById",
+        "summary": "Get entity from Libraries by key",
+        "operationId": "Libraries.LibraryDto.GetLibraryDto",
         "parameters": [
           {
             "name": "Id",
@@ -1588,8 +1588,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Update entity in Libraries by key (Id)",
-        "operationId": "Libraries.LibraryDto.UpdateLibraryDtoById",
+        "summary": "Update entity in Libraries",
+        "operationId": "Libraries.LibraryDto.UpdateLibraryDto",
         "parameters": [
           {
             "name": "Id",
@@ -1630,8 +1630,8 @@
         "tags": [
           "Libraries.LibraryDto"
         ],
-        "summary": "Delete entity from Libraries by key (Id)",
-        "operationId": "Libraries.LibraryDto.DeleteLibraryDtoById",
+        "summary": "Delete entity from Libraries",
+        "operationId": "Libraries.LibraryDto.DeleteLibraryDto",
         "parameters": [
           {
             "name": "Id",
@@ -2488,8 +2488,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Get entity from Revisions by key (Id)",
-        "operationId": "Revisions.RevisionDto.GetRevisionDtoById",
+        "summary": "Get entity from Revisions by key",
+        "operationId": "Revisions.RevisionDto.GetRevisionDto",
         "parameters": [
           {
             "name": "Id",
@@ -2586,8 +2586,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Update entity in Revisions by key (Id)",
-        "operationId": "Revisions.RevisionDto.UpdateRevisionDtoById",
+        "summary": "Update entity in Revisions",
+        "operationId": "Revisions.RevisionDto.UpdateRevisionDto",
         "parameters": [
           {
             "name": "Id",
@@ -2628,8 +2628,8 @@
         "tags": [
           "Revisions.RevisionDto"
         ],
-        "summary": "Delete entity from Revisions by key (Id)",
-        "operationId": "Revisions.RevisionDto.DeleteRevisionDtoById",
+        "summary": "Delete entity from Revisions",
+        "operationId": "Revisions.RevisionDto.DeleteRevisionDto",
         "parameters": [
           {
             "name": "Id",
@@ -3640,8 +3640,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Get entity from Tasks by key (Id)",
-        "operationId": "Tasks.DocumentDto.GetDocumentDtoById",
+        "summary": "Get entity from Tasks by key",
+        "operationId": "Tasks.DocumentDto.GetDocumentDto",
         "parameters": [
           {
             "name": "Id",
@@ -3734,8 +3734,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Update entity in Tasks by key (Id)",
-        "operationId": "Tasks.DocumentDto.UpdateDocumentDtoById",
+        "summary": "Update entity in Tasks",
+        "operationId": "Tasks.DocumentDto.UpdateDocumentDto",
         "parameters": [
           {
             "name": "Id",
@@ -3776,8 +3776,8 @@
         "tags": [
           "Tasks.DocumentDto"
         ],
-        "summary": "Delete entity from Tasks by key (Id)",
-        "operationId": "Tasks.DocumentDto.DeleteDocumentDtoById",
+        "summary": "Delete entity from Tasks",
+        "operationId": "Tasks.DocumentDto.DeleteDocumentDto",
         "parameters": [
           {
             "name": "Id",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -103,8 +103,8 @@ paths:
     get:
       tags:
         - Categories.CategoryDto
-      summary: Get entity from Categories by key (Id)
-      operationId: Categories.CategoryDto.GetCategoryDtoById
+      summary: Get entity from Categories by key
+      operationId: Categories.CategoryDto.GetCategoryDto
       parameters:
         - name: Id
           in: path
@@ -158,8 +158,8 @@ paths:
     patch:
       tags:
         - Categories.CategoryDto
-      summary: Update entity in Categories by key (Id)
-      operationId: Categories.CategoryDto.UpdateCategoryDtoById
+      summary: Update entity in Categories
+      operationId: Categories.CategoryDto.UpdateCategoryDto
       parameters:
         - name: Id
           in: path
@@ -187,8 +187,8 @@ paths:
     delete:
       tags:
         - Categories.CategoryDto
-      summary: Delete entity from Categories by key (Id)
-      operationId: Categories.CategoryDto.DeleteCategoryDtoById
+      summary: Delete entity from Categories
+      operationId: Categories.CategoryDto.DeleteCategoryDto
       parameters:
         - name: Id
           in: path
@@ -335,8 +335,8 @@ paths:
     get:
       tags:
         - Documents.DocumentDto
-      summary: Get entity from Documents by key (Id)
-      operationId: Documents.DocumentDto.GetDocumentDtoById
+      summary: Get entity from Documents by key
+      operationId: Documents.DocumentDto.GetDocumentDto
       parameters:
         - name: Id
           in: path
@@ -403,8 +403,8 @@ paths:
     patch:
       tags:
         - Documents.DocumentDto
-      summary: Update entity in Documents by key (Id)
-      operationId: Documents.DocumentDto.UpdateDocumentDtoById
+      summary: Update entity in Documents
+      operationId: Documents.DocumentDto.UpdateDocumentDto
       parameters:
         - name: Id
           in: path
@@ -432,8 +432,8 @@ paths:
     delete:
       tags:
         - Documents.DocumentDto
-      summary: Delete entity from Documents by key (Id)
-      operationId: Documents.DocumentDto.DeleteDocumentDtoById
+      summary: Delete entity from Documents
+      operationId: Documents.DocumentDto.DeleteDocumentDto
       parameters:
         - name: Id
           in: path
@@ -1046,8 +1046,8 @@ paths:
     get:
       tags:
         - Libraries.LibraryDto
-      summary: Get entity from Libraries by key (Id)
-      operationId: Libraries.LibraryDto.GetLibraryDtoById
+      summary: Get entity from Libraries by key
+      operationId: Libraries.LibraryDto.GetLibraryDto
       parameters:
         - name: Id
           in: path
@@ -1117,8 +1117,8 @@ paths:
     patch:
       tags:
         - Libraries.LibraryDto
-      summary: Update entity in Libraries by key (Id)
-      operationId: Libraries.LibraryDto.UpdateLibraryDtoById
+      summary: Update entity in Libraries
+      operationId: Libraries.LibraryDto.UpdateLibraryDto
       parameters:
         - name: Id
           in: path
@@ -1146,8 +1146,8 @@ paths:
     delete:
       tags:
         - Libraries.LibraryDto
-      summary: Delete entity from Libraries by key (Id)
-      operationId: Libraries.LibraryDto.DeleteLibraryDtoById
+      summary: Delete entity from Libraries
+      operationId: Libraries.LibraryDto.DeleteLibraryDto
       parameters:
         - name: Id
           in: path
@@ -1747,8 +1747,8 @@ paths:
     get:
       tags:
         - Revisions.RevisionDto
-      summary: Get entity from Revisions by key (Id)
-      operationId: Revisions.RevisionDto.GetRevisionDtoById
+      summary: Get entity from Revisions by key
+      operationId: Revisions.RevisionDto.GetRevisionDto
       parameters:
         - name: Id
           in: path
@@ -1820,8 +1820,8 @@ paths:
     patch:
       tags:
         - Revisions.RevisionDto
-      summary: Update entity in Revisions by key (Id)
-      operationId: Revisions.RevisionDto.UpdateRevisionDtoById
+      summary: Update entity in Revisions
+      operationId: Revisions.RevisionDto.UpdateRevisionDto
       parameters:
         - name: Id
           in: path
@@ -1849,8 +1849,8 @@ paths:
     delete:
       tags:
         - Revisions.RevisionDto
-      summary: Delete entity from Revisions by key (Id)
-      operationId: Revisions.RevisionDto.DeleteRevisionDtoById
+      summary: Delete entity from Revisions
+      operationId: Revisions.RevisionDto.DeleteRevisionDto
       parameters:
         - name: Id
           in: path
@@ -2562,8 +2562,8 @@ paths:
     get:
       tags:
         - Tasks.DocumentDto
-      summary: Get entity from Tasks by key (Id)
-      operationId: Tasks.DocumentDto.GetDocumentDtoById
+      summary: Get entity from Tasks by key
+      operationId: Tasks.DocumentDto.GetDocumentDto
       parameters:
         - name: Id
           in: path
@@ -2630,8 +2630,8 @@ paths:
     patch:
       tags:
         - Tasks.DocumentDto
-      summary: Update entity in Tasks by key (Id)
-      operationId: Tasks.DocumentDto.UpdateDocumentDtoById
+      summary: Update entity in Tasks
+      operationId: Tasks.DocumentDto.UpdateDocumentDto
       parameters:
         - name: Id
           in: path
@@ -2659,8 +2659,8 @@ paths:
     delete:
       tags:
         - Tasks.DocumentDto
-      summary: Delete entity from Tasks by key (Id)
-      operationId: Tasks.DocumentDto.DeleteDocumentDtoById
+      summary: Delete entity from Tasks
+      operationId: Tasks.DocumentDto.DeleteDocumentDto
       parameters:
         - name: Id
           in: path

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -127,8 +127,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Get entity from Airlines by key (AirlineCode)",
-        "operationId": "Airlines.Airline.GetAirlineByAirlineCode",
+        "summary": "Get entity from Airlines by key",
+        "operationId": "Airlines.Airline.GetAirline",
         "produces": [
           "application/json"
         ],
@@ -184,8 +184,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Update entity in Airlines by key (AirlineCode)",
-        "operationId": "Airlines.Airline.UpdateAirlineByAirlineCode",
+        "summary": "Update entity in Airlines",
+        "operationId": "Airlines.Airline.UpdateAirline",
         "consumes": [
           "application/json"
         ],
@@ -222,8 +222,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Delete entity from Airlines by key (AirlineCode)",
-        "operationId": "Airlines.Airline.DeleteAirlineByAirlineCode",
+        "summary": "Delete entity from Airlines",
+        "operationId": "Airlines.Airline.DeleteAirline",
         "parameters": [
           {
             "in": "path",
@@ -397,8 +397,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Get entity from Airports by key (IcaoCode)",
-        "operationId": "Airports.Airport.GetAirportByIcaoCode",
+        "summary": "Get entity from Airports by key",
+        "operationId": "Airports.Airport.GetAirport",
         "produces": [
           "application/json"
         ],
@@ -456,8 +456,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Update entity in Airports by key (IcaoCode)",
-        "operationId": "Airports.Airport.UpdateAirportByIcaoCode",
+        "summary": "Update entity in Airports",
+        "operationId": "Airports.Airport.UpdateAirport",
         "consumes": [
           "application/json"
         ],
@@ -494,8 +494,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Delete entity from Airports by key (IcaoCode)",
-        "operationId": "Airports.Airport.DeleteAirportByIcaoCode",
+        "summary": "Delete entity from Airports",
+        "operationId": "Airports.Airport.DeleteAirport",
         "parameters": [
           {
             "in": "path",
@@ -6415,8 +6415,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Get entity from NewComePeople by key (UserName)",
-        "operationId": "NewComePeople.Person.GetPersonByUserName",
+        "summary": "Get entity from NewComePeople by key",
+        "operationId": "NewComePeople.Person.GetPerson",
         "produces": [
           "application/json"
         ],
@@ -6487,8 +6487,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Update entity in NewComePeople by key (UserName)",
-        "operationId": "NewComePeople.Person.UpdatePersonByUserName",
+        "summary": "Update entity in NewComePeople",
+        "operationId": "NewComePeople.Person.UpdatePerson",
         "consumes": [
           "application/json"
         ],
@@ -6525,8 +6525,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Delete entity from NewComePeople by key (UserName)",
-        "operationId": "NewComePeople.Person.DeletePersonByUserName",
+        "summary": "Delete entity from NewComePeople",
+        "operationId": "NewComePeople.Person.DeletePerson",
         "parameters": [
           {
             "in": "path",
@@ -10289,8 +10289,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key (UserName)",
-        "operationId": "People.Person.GetPersonByUserName",
+        "summary": "Get entity from People by key",
+        "operationId": "People.Person.GetPerson",
         "produces": [
           "application/json"
         ],
@@ -10374,8 +10374,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People by key (UserName)",
-        "operationId": "People.Person.UpdatePersonByUserName",
+        "summary": "Update entity in People",
+        "operationId": "People.Person.UpdatePerson",
         "consumes": [
           "application/json"
         ],
@@ -10419,8 +10419,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People by key (UserName)",
-        "operationId": "People.Person.DeletePersonByUserName",
+        "summary": "Delete entity from People",
+        "operationId": "People.Person.DeletePerson",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -82,8 +82,8 @@ paths:
     get:
       tags:
         - Airlines.Airline
-      summary: Get entity from Airlines by key (AirlineCode)
-      operationId: Airlines.Airline.GetAirlineByAirlineCode
+      summary: Get entity from Airlines by key
+      operationId: Airlines.Airline.GetAirline
       produces:
         - application/json
       parameters:
@@ -121,8 +121,8 @@ paths:
     put:
       tags:
         - Airlines.Airline
-      summary: Update entity in Airlines by key (AirlineCode)
-      operationId: Airlines.Airline.UpdateAirlineByAirlineCode
+      summary: Update entity in Airlines
+      operationId: Airlines.Airline.UpdateAirline
       consumes:
         - application/json
       parameters:
@@ -147,8 +147,8 @@ paths:
     delete:
       tags:
         - Airlines.Airline
-      summary: Delete entity from Airlines by key (AirlineCode)
-      operationId: Airlines.Airline.DeleteAirlineByAirlineCode
+      summary: Delete entity from Airlines
+      operationId: Airlines.Airline.DeleteAirline
       parameters:
         - in: path
           name: AirlineCode
@@ -260,8 +260,8 @@ paths:
     get:
       tags:
         - Airports.Airport
-      summary: Get entity from Airports by key (IcaoCode)
-      operationId: Airports.Airport.GetAirportByIcaoCode
+      summary: Get entity from Airports by key
+      operationId: Airports.Airport.GetAirport
       produces:
         - application/json
       parameters:
@@ -301,8 +301,8 @@ paths:
     patch:
       tags:
         - Airports.Airport
-      summary: Update entity in Airports by key (IcaoCode)
-      operationId: Airports.Airport.UpdateAirportByIcaoCode
+      summary: Update entity in Airports
+      operationId: Airports.Airport.UpdateAirport
       consumes:
         - application/json
       parameters:
@@ -327,8 +327,8 @@ paths:
     delete:
       tags:
         - Airports.Airport
-      summary: Delete entity from Airports by key (IcaoCode)
-      operationId: Airports.Airport.DeleteAirportByIcaoCode
+      summary: Delete entity from Airports
+      operationId: Airports.Airport.DeleteAirport
       parameters:
         - in: path
           name: IcaoCode
@@ -4472,8 +4472,8 @@ paths:
     get:
       tags:
         - NewComePeople.Person
-      summary: Get entity from NewComePeople by key (UserName)
-      operationId: NewComePeople.Person.GetPersonByUserName
+      summary: Get entity from NewComePeople by key
+      operationId: NewComePeople.Person.GetPerson
       produces:
         - application/json
       parameters:
@@ -4526,8 +4526,8 @@ paths:
     patch:
       tags:
         - NewComePeople.Person
-      summary: Update entity in NewComePeople by key (UserName)
-      operationId: NewComePeople.Person.UpdatePersonByUserName
+      summary: Update entity in NewComePeople
+      operationId: NewComePeople.Person.UpdatePerson
       consumes:
         - application/json
       parameters:
@@ -4552,8 +4552,8 @@ paths:
     delete:
       tags:
         - NewComePeople.Person
-      summary: Delete entity from NewComePeople by key (UserName)
-      operationId: NewComePeople.Person.DeletePersonByUserName
+      summary: Delete entity from NewComePeople
+      operationId: NewComePeople.Person.DeletePerson
       parameters:
         - in: path
           name: UserName
@@ -7174,8 +7174,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key (UserName)
-      operationId: People.Person.GetPersonByUserName
+      summary: Get entity from People by key
+      operationId: People.Person.GetPerson
       produces:
         - application/json
       parameters:
@@ -7238,8 +7238,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People by key (UserName)
-      operationId: People.Person.UpdatePersonByUserName
+      summary: Update entity in People
+      operationId: People.Person.UpdatePerson
       consumes:
         - application/json
       parameters:
@@ -7270,8 +7270,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People by key (UserName)
-      operationId: People.Person.DeletePersonByUserName
+      summary: Delete entity from People
+      operationId: People.Person.DeletePerson
       parameters:
         - in: path
           name: UserName

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -141,8 +141,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Get entity from Airlines by key (AirlineCode)",
-        "operationId": "Airlines.Airline.GetAirlineByAirlineCode",
+        "summary": "Get entity from Airlines by key",
+        "operationId": "Airlines.Airline.GetAirline",
         "parameters": [
           {
             "name": "AirlineCode",
@@ -211,8 +211,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Update entity in Airlines by key (AirlineCode)",
-        "operationId": "Airlines.Airline.UpdateAirlineByAirlineCode",
+        "summary": "Update entity in Airlines",
+        "operationId": "Airlines.Airline.UpdateAirline",
         "parameters": [
           {
             "name": "AirlineCode",
@@ -250,8 +250,8 @@
         "tags": [
           "Airlines.Airline"
         ],
-        "summary": "Delete entity from Airlines by key (AirlineCode)",
-        "operationId": "Airlines.Airline.DeleteAirlineByAirlineCode",
+        "summary": "Delete entity from Airlines",
+        "operationId": "Airlines.Airline.DeleteAirline",
         "parameters": [
           {
             "name": "AirlineCode",
@@ -442,8 +442,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Get entity from Airports by key (IcaoCode)",
-        "operationId": "Airports.Airport.GetAirportByIcaoCode",
+        "summary": "Get entity from Airports by key",
+        "operationId": "Airports.Airport.GetAirport",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -514,8 +514,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Update entity in Airports by key (IcaoCode)",
-        "operationId": "Airports.Airport.UpdateAirportByIcaoCode",
+        "summary": "Update entity in Airports",
+        "operationId": "Airports.Airport.UpdateAirport",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -553,8 +553,8 @@
         "tags": [
           "Airports.Airport"
         ],
-        "summary": "Delete entity from Airports by key (IcaoCode)",
-        "operationId": "Airports.Airport.DeleteAirportByIcaoCode",
+        "summary": "Delete entity from Airports",
+        "operationId": "Airports.Airport.DeleteAirport",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -7093,8 +7093,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Get entity from NewComePeople by key (UserName)",
-        "operationId": "NewComePeople.Person.GetPersonByUserName",
+        "summary": "Get entity from NewComePeople by key",
+        "operationId": "NewComePeople.Person.GetPerson",
         "parameters": [
           {
             "name": "UserName",
@@ -7178,8 +7178,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Update entity in NewComePeople by key (UserName)",
-        "operationId": "NewComePeople.Person.UpdatePersonByUserName",
+        "summary": "Update entity in NewComePeople",
+        "operationId": "NewComePeople.Person.UpdatePerson",
         "parameters": [
           {
             "name": "UserName",
@@ -7217,8 +7217,8 @@
         "tags": [
           "NewComePeople.Person"
         ],
-        "summary": "Delete entity from NewComePeople by key (UserName)",
-        "operationId": "NewComePeople.Person.DeletePersonByUserName",
+        "summary": "Delete entity from NewComePeople",
+        "operationId": "NewComePeople.Person.DeletePerson",
         "parameters": [
           {
             "name": "UserName",
@@ -11517,8 +11517,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get entity from People by key (UserName)",
-        "operationId": "People.Person.GetPersonByUserName",
+        "summary": "Get entity from People by key",
+        "operationId": "People.Person.GetPerson",
         "parameters": [
           {
             "name": "UserName",
@@ -11623,8 +11623,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Update entity in People by key (UserName)",
-        "operationId": "People.Person.UpdatePersonByUserName",
+        "summary": "Update entity in People",
+        "operationId": "People.Person.UpdatePerson",
         "parameters": [
           {
             "name": "UserName",
@@ -11669,8 +11669,8 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete entity from People by key (UserName)",
-        "operationId": "People.Person.DeletePersonByUserName",
+        "summary": "Delete entity from People",
+        "operationId": "People.Person.DeletePerson",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -91,8 +91,8 @@ paths:
     get:
       tags:
         - Airlines.Airline
-      summary: Get entity from Airlines by key (AirlineCode)
-      operationId: Airlines.Airline.GetAirlineByAirlineCode
+      summary: Get entity from Airlines by key
+      operationId: Airlines.Airline.GetAirline
       parameters:
         - name: AirlineCode
           in: path
@@ -139,8 +139,8 @@ paths:
     put:
       tags:
         - Airlines.Airline
-      summary: Update entity in Airlines by key (AirlineCode)
-      operationId: Airlines.Airline.UpdateAirlineByAirlineCode
+      summary: Update entity in Airlines
+      operationId: Airlines.Airline.UpdateAirline
       parameters:
         - name: AirlineCode
           in: path
@@ -165,8 +165,8 @@ paths:
     delete:
       tags:
         - Airlines.Airline
-      summary: Delete entity from Airlines by key (AirlineCode)
-      operationId: Airlines.Airline.DeleteAirlineByAirlineCode
+      summary: Delete entity from Airlines
+      operationId: Airlines.Airline.DeleteAirline
       parameters:
         - name: AirlineCode
           in: path
@@ -290,8 +290,8 @@ paths:
     get:
       tags:
         - Airports.Airport
-      summary: Get entity from Airports by key (IcaoCode)
-      operationId: Airports.Airport.GetAirportByIcaoCode
+      summary: Get entity from Airports by key
+      operationId: Airports.Airport.GetAirport
       parameters:
         - name: IcaoCode
           in: path
@@ -340,8 +340,8 @@ paths:
     patch:
       tags:
         - Airports.Airport
-      summary: Update entity in Airports by key (IcaoCode)
-      operationId: Airports.Airport.UpdateAirportByIcaoCode
+      summary: Update entity in Airports
+      operationId: Airports.Airport.UpdateAirport
       parameters:
         - name: IcaoCode
           in: path
@@ -366,8 +366,8 @@ paths:
     delete:
       tags:
         - Airports.Airport
-      summary: Delete entity from Airports by key (IcaoCode)
-      operationId: Airports.Airport.DeleteAirportByIcaoCode
+      summary: Delete entity from Airports
+      operationId: Airports.Airport.DeleteAirport
       parameters:
         - name: IcaoCode
           in: path
@@ -4925,8 +4925,8 @@ paths:
     get:
       tags:
         - NewComePeople.Person
-      summary: Get entity from NewComePeople by key (UserName)
-      operationId: NewComePeople.Person.GetPersonByUserName
+      summary: Get entity from NewComePeople by key
+      operationId: NewComePeople.Person.GetPerson
       parameters:
         - name: UserName
           in: path
@@ -4988,8 +4988,8 @@ paths:
     patch:
       tags:
         - NewComePeople.Person
-      summary: Update entity in NewComePeople by key (UserName)
-      operationId: NewComePeople.Person.UpdatePersonByUserName
+      summary: Update entity in NewComePeople
+      operationId: NewComePeople.Person.UpdatePerson
       parameters:
         - name: UserName
           in: path
@@ -5014,8 +5014,8 @@ paths:
     delete:
       tags:
         - NewComePeople.Person
-      summary: Delete entity from NewComePeople by key (UserName)
-      operationId: NewComePeople.Person.DeletePersonByUserName
+      summary: Delete entity from NewComePeople
+      operationId: NewComePeople.Person.DeletePerson
       parameters:
         - name: UserName
           in: path
@@ -7979,8 +7979,8 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get entity from People by key (UserName)
-      operationId: People.Person.GetPersonByUserName
+      summary: Get entity from People by key
+      operationId: People.Person.GetPerson
       parameters:
         - name: UserName
           in: path
@@ -8057,8 +8057,8 @@ paths:
     patch:
       tags:
         - People.Person
-      summary: Update entity in People by key (UserName)
-      operationId: People.Person.UpdatePersonByUserName
+      summary: Update entity in People
+      operationId: People.Person.UpdatePerson
       parameters:
         - name: UserName
           in: path
@@ -8089,8 +8089,8 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete entity from People by key (UserName)
-      operationId: People.Person.DeletePersonByUserName
+      summary: Delete entity from People
+      operationId: People.Person.DeletePerson
       parameters:
         - name: UserName
           in: path


### PR DESCRIPTION
Fixes #329 
This PR
- Removes 'ById' suffix from OperationIds for EntitySet operations and only adds the prefix for operations that use alternate keys
- Updates tests
