### PR TITLE
Resolves `operationId` and `tag` names for OData cast paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
 
 namespace Microsoft.OpenApi.OData.Common
@@ -22,7 +23,7 @@ namespace Microsoft.OpenApi.OData.Common
         {
             Utils.CheckArgumentNull(structuredType, nameof(structuredType));
             Utils.CheckArgumentNull(edmModel, nameof(edmModel));
-            if(structuredType is not IEdmSchemaElement schemaElement) throw new ArgumentException("The type is not a schema element.", nameof(structuredType));
+            if (structuredType is not IEdmSchemaElement schemaElement) throw new ArgumentException("The type is not a schema element.", nameof(structuredType));
 
             IEnumerable<IEdmSchemaElement> derivedTypes = edmModel.FindAllDerivedTypes(structuredType).OfType<IEdmSchemaElement>();
 
@@ -32,12 +33,12 @@ namespace Microsoft.OpenApi.OData.Common
             }
 
             OpenApiSchema schema = new()
-			{
+            {
                 OneOf = new List<OpenApiSchema>()
             };
 
             OpenApiSchema baseTypeSchema = new()
-			{
+            {
                 UnresolvedReference = true,
                 Reference = new OpenApiReference
                 {
@@ -50,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Common
             foreach (IEdmSchemaElement derivedType in derivedTypes)
             {
                 OpenApiSchema derivedTypeSchema = new()
-				{
+                {
                     UnresolvedReference = true,
                     Reference = new OpenApiReference
                     {
@@ -62,7 +63,7 @@ namespace Microsoft.OpenApi.OData.Common
             };
 
             return schema;
-        }            
+        }
 
         /// <summary>
         /// Verifies whether the provided navigation restrictions allow for navigability of a navigation property. 
@@ -83,7 +84,91 @@ namespace Microsoft.OpenApi.OData.Common
             // if the individual has no navigability setting, use the global navigability setting
             // Default navigability for all navigation properties of the annotation target.
             // Individual navigation properties can override this value via `RestrictedProperties/Navigability`.
-            return restrictionProperty?.Navigability != null || restrictionType == null || restrictionType.IsNavigable;            
+            return restrictionProperty?.Navigability != null || restrictionType == null || restrictionType.IsNavigable;
+        }
+
+        /// <summary>
+        /// Generates the operation id for a navigation property path.
+        /// </summary>
+        /// <param name="path">The target <see cref="ODataPath"/>.</param>
+        /// <param name="navigationSource">The <see cref="IEdmNavigationSource"/> of the target path.</param>
+        /// <param name="prefix">Identifier indicating whether it is a collection-valued non-indexed navigation property.</param>
+        /// <returns>The operation id name.</returns>
+        internal static string GenerateNavigationPropertyPathOperationId(ODataPath path, IEdmNavigationSource navigationSource, string prefix = null)
+        {
+            if (path == null || navigationSource == null)
+                return null;
+
+            IList<string> items = new List<string>
+            {
+                navigationSource.Name
+            };
+
+            var lastpath = path.Segments.Last(c => c is ODataNavigationPropertySegment);
+            foreach (var segment in path.Segments.Skip(1).OfType<ODataNavigationPropertySegment>())
+            {
+                if (segment == lastpath)
+                {
+                    if (prefix != null)
+                    {
+                        items.Add(prefix + Utils.UpperFirstChar(segment.NavigationProperty.Name));
+                    }
+                    else
+                    {
+                        items.Add(Utils.UpperFirstChar(segment.NavigationProperty.Name));
+                    }
+
+                    break;
+                }
+                else
+                {
+                    items.Add(segment.NavigationProperty.Name);
+                }
+            }
+
+            return string.Join(".", items);
+        }
+
+        /// <summary>
+        /// Generates the tag for a navigation property path.
+        /// </summary>
+        /// <param name="path">The target <see cref="ODataPath"/>.</param>
+        /// <param name="navigationSource">The <see cref="IEdmNavigationSource"/> of the target path.</param>
+        /// <param name="navigationProperty">The target <see cref="IEdmNavigationProperty"/>.</param>
+        /// <param name="context">The <see cref="ODataContext"/>.</param>
+        /// <returns>The tag name.</returns>
+        internal static string GenerateNavigationPropertyPathTag(ODataPath path, IEdmNavigationSource navigationSource, IEdmNavigationProperty navigationProperty, ODataContext context)
+        {
+            if (path == null || navigationSource == null || navigationProperty == null)
+                return null;
+
+            IList<string> items = new List<string>
+            {
+                navigationSource.Name
+            };
+
+            foreach (var segment in path.Segments.Skip(1).OfType<ODataNavigationPropertySegment>())
+            {
+                if (segment.NavigationProperty == navigationProperty)
+                {
+                    items.Add(navigationProperty.ToEntityType().Name);
+                    break;
+                }
+                else
+                {
+                    if (items.Count >= context.Settings.TagDepth - 1)
+                    {
+                        items.Add(segment.NavigationProperty.ToEntityType().Name);
+                        break;
+                    }
+                    else
+                    {
+                        items.Add(segment.NavigationProperty.Name);
+                    }
+                }
+            }
+
+            return string.Join(".", items);
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -78,33 +78,7 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetTags(OpenApiOperation operation)
         {
-            IList<string> items = new List<string>
-            {
-                NavigationSource.Name
-            };
-
-            foreach (var segment in Path.Segments.Skip(1).OfType<ODataNavigationPropertySegment>())
-            {
-                if (segment.NavigationProperty == NavigationProperty)
-                {
-                    items.Add(NavigationProperty.ToEntityType().Name);
-                    break;
-                }
-                else
-                {
-                    if (items.Count >= Context.Settings.TagDepth - 1)
-                    {
-                        items.Add(segment.NavigationProperty.ToEntityType().Name);
-                        break;
-                    }
-                    else
-                    {
-                        items.Add(segment.NavigationProperty.Name);
-                    }
-                }
-            }
-
-            string name = string.Join(".", items);
+            string name = EdmModelHelper.GenerateNavigationPropertyPathTag(Path, NavigationSource, NavigationProperty, Context);
             OpenApiTag tag = new()
             {
                 Name = name
@@ -125,43 +99,10 @@ namespace Microsoft.OpenApi.OData.Operation
             base.SetExtensions(operation);
         }
 
-        internal string GetOperationId(string prefix = null, ODataPath path = null)
-        {
-            ODataPath odataPath = Path ?? path;
-            if (odataPath == null)
-            {
-                return null;
-            }
-
-            IList<string> items = new List<string>
-            {
-                NavigationSource.Name
-            };
-
-            var lastpath = odataPath.Segments.Last(c => c is ODataNavigationPropertySegment);
-            foreach (var segment in odataPath.Segments.Skip(1).OfType<ODataNavigationPropertySegment>())
-            {
-                if (segment == lastpath)
-                {
-                    if (prefix != null)
-                    {
-                        items.Add(prefix + Utils.UpperFirstChar(segment.NavigationProperty.Name));
-                    }
-                    else
-                    {
-                        items.Add(Utils.UpperFirstChar(segment.NavigationProperty.Name));
-                    }
-
-                    break;
-                }
-                else
-                {
-                    items.Add(segment.NavigationProperty.Name);
-                }
-            }
-
-            return string.Join(".", items);
-        }
+        internal string GetOperationId(string prefix = null)
+        {            
+            return EdmModelHelper.GenerateNavigationPropertyPathOperationId(Path, NavigationSource, prefix);
+        }               
 
         /// <inheritdoc/>
         protected override void SetExternalDocs(OpenApiOperation operation)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -125,15 +125,21 @@ namespace Microsoft.OpenApi.OData.Operation
             base.SetExtensions(operation);
         }
 
-        protected string GetOperationId(string prefix = null)
+        internal string GetOperationId(string prefix = null, ODataPath path = null)
         {
+            ODataPath odataPath = Path ?? path;
+            if (odataPath == null)
+            {
+                return null;
+            }
+
             IList<string> items = new List<string>
             {
                 NavigationSource.Name
             };
 
-            var lastpath = Path.Segments.Last(c => c is ODataNavigationPropertySegment);
-            foreach (var segment in Path.Segments.Skip(1).OfType<ODataNavigationPropertySegment>())
+            var lastpath = odataPath.Segments.Last(c => c is ODataNavigationPropertySegment);
+            foreach (var segment in odataPath.Segments.Skip(1).OfType<ODataNavigationPropertySegment>())
             {
                 if (segment == lastpath)
                 {


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/324

This PR:
- Renames the `operationId` and `tag` names for OData cast paths to conform with other no non-OData cast paths.


**NB:** The PR is currently in draft because:
- The relevant Integration and unit tests haven't been updated yet. I will need to lock in any requested changes before updating these.
- Complex properties and `$count` paths currently don't have tags generated for them. We need to agree on a format before these can be updated into this fix. The discussion can be found [here](https://github.com/microsoft/OpenAPI.NET.OData/issues/324#issuecomment-1411686480).

