### PR TITLE
Strips namespace prefix from operation segments and aliases type cast segments

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -288,7 +288,7 @@ namespace Microsoft.OpenApi.OData.Common
                 return value;
             }
 
-            string defaultNamespace = settings.DefaultNamespace.EndsWith(".")
+            string defaultNamespace = settings.DefaultNamespace.EndsWith(".", StringComparison.OrdinalIgnoreCase)
                 ? settings.DefaultNamespace
                 : settings.DefaultNamespace + ".";
 

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -286,7 +286,7 @@ namespace Microsoft.OpenApi.OData.Common
             // Trim trailing '.' for uniformity
             prefix = prefix.TrimEnd('.');
 
-            return value.StartsWith(prefix)
+            return value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
                 ? value.Substring(prefix.Length).TrimStart('.')
                 : value;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -272,27 +272,27 @@ namespace Microsoft.OpenApi.OData.Common
             return false;
         }
 
-        /// <summary>
-        /// Removes the default namespace from a string value.
-        /// </summary>
-        /// <param name="value">The target string value.</param>
-        /// <param name="settings">Convert settings.</param>
-        /// <returns>The string value with the namespace removed.</returns>
-        internal static string RemoveDefaultNamespace(this string value, OpenApiConvertSettings settings)
-        {
-            CheckArgumentNullOrEmpty(value, nameof(value));
-            CheckArgumentNull(settings, nameof(settings));
+        ///// <summary>
+        ///// Removes the default namespace from a string value.
+        ///// </summary>
+        ///// <param name="value">The target string value.</param>
+        ///// <param name="settings">Convert settings.</param>
+        ///// <returns>The string value with the namespace removed.</returns>
+        //internal static string RemoveDefaultNamespace(this string value, OpenApiConvertSettings settings)
+        //{
+        //    CheckArgumentNullOrEmpty(value, nameof(value));
+        //    CheckArgumentNull(settings, nameof(settings));
 
-            if (string.IsNullOrEmpty(settings.DefaultNamespace))
-            {
-                return value;
-            }
+        //    if (string.IsNullOrEmpty(settings.DefaultNamespace))
+        //    {
+        //        return value;
+        //    }
 
-            string defaultNamespace = settings.DefaultNamespace.EndsWith(".", StringComparison.OrdinalIgnoreCase)
-                ? settings.DefaultNamespace
-                : settings.DefaultNamespace + ".";
+        //    string defaultNamespace = settings.DefaultNamespace.EndsWith(".", StringComparison.OrdinalIgnoreCase)
+        //        ? settings.DefaultNamespace
+        //        : settings.DefaultNamespace + ".";
 
-            return value.Replace(defaultNamespace, "");
-        }
+        //    return value.Replace(defaultNamespace, "");
+        //}
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -270,29 +270,6 @@ namespace Microsoft.OpenApi.OData.Common
             }
 
             return false;
-        }
-
-        ///// <summary>
-        ///// Removes the default namespace from a string value.
-        ///// </summary>
-        ///// <param name="value">The target string value.</param>
-        ///// <param name="settings">Convert settings.</param>
-        ///// <returns>The string value with the namespace removed.</returns>
-        //internal static string RemoveDefaultNamespace(this string value, OpenApiConvertSettings settings)
-        //{
-        //    CheckArgumentNullOrEmpty(value, nameof(value));
-        //    CheckArgumentNull(settings, nameof(settings));
-
-        //    if (string.IsNullOrEmpty(settings.DefaultNamespace))
-        //    {
-        //        return value;
-        //    }
-
-        //    string defaultNamespace = settings.DefaultNamespace.EndsWith(".", StringComparison.OrdinalIgnoreCase)
-        //        ? settings.DefaultNamespace
-        //        : settings.DefaultNamespace + ".";
-
-        //    return value.Replace(defaultNamespace, "");
-        //}
+        }                
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -273,12 +273,12 @@ namespace Microsoft.OpenApi.OData.Common
         }
 
         /// <summary>
-        /// Removes the base namespace from a string value.
+        /// Removes the default namespace from a string value.
         /// </summary>
         /// <param name="value">The target string value.</param>
         /// <param name="settings">Convert settings.</param>
         /// <returns>The string value with the namespace removed.</returns>
-        internal static string RemoveBaseNamespace(this string value, OpenApiConvertSettings settings)
+        internal static string RemoveDefaultNamespace(this string value, OpenApiConvertSettings settings)
         {
             CheckArgumentNullOrEmpty(value, nameof(value));
             CheckArgumentNull(settings, nameof(settings));
@@ -288,12 +288,11 @@ namespace Microsoft.OpenApi.OData.Common
                 return value;
             }
 
-            string baseNamespace = settings.DefaultNamespace.EndsWith(".")
+            string defaultNamespace = settings.DefaultNamespace.EndsWith(".")
                 ? settings.DefaultNamespace
                 : settings.DefaultNamespace + ".";
 
-            string escapedPattern = Regex.Escape(baseNamespace);
-            return Regex.Replace(value, escapedPattern, "", RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));
+            return value.Replace(defaultNamespace, "");
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Text.RegularExpressions;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Any;
@@ -269,6 +270,30 @@ namespace Microsoft.OpenApi.OData.Common
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Removes the base namespace from a string value.
+        /// </summary>
+        /// <param name="value">The target string value.</param>
+        /// <param name="settings">Convert settings.</param>
+        /// <returns>The string value with the namespace removed.</returns>
+        internal static string RemoveBaseNamespace(this string value, OpenApiConvertSettings settings)
+        {
+            CheckArgumentNullOrEmpty(value, nameof(value));
+            CheckArgumentNull(settings, nameof(settings));
+
+            if (string.IsNullOrEmpty(settings.BaseNamespace))
+            {
+                return value;
+            }
+
+            string baseNamespace = settings.BaseNamespace.EndsWith(".")
+                ? settings.BaseNamespace
+                : settings.BaseNamespace + ".";
+
+            string escapedPattern = Regex.Escape(baseNamespace);
+            return Regex.Replace(value, escapedPattern, "", RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -270,6 +270,25 @@ namespace Microsoft.OpenApi.OData.Common
             }
 
             return false;
-        }                
+        }
+        
+        /// <summary>
+        /// Strips off a prefix value from a string.
+        /// </summary>
+        /// <param name="value">The target string value.</param>
+        /// <param name="prefix">The prefix value to strip off.</param>
+        /// <returns>The value with the prefix stripped off.</returns>
+        internal static string StripNamespacePrefix(this string value, string prefix)
+        {
+            CheckArgumentNullOrEmpty(value, nameof(value));
+            CheckArgumentNullOrEmpty(prefix, nameof(prefix));
+
+            // Trim trailing '.' for uniformity
+            prefix = prefix.TrimEnd('.');
+
+            return value.StartsWith(prefix)
+                ? value.Substring(prefix.Length).TrimStart('.')
+                : value;
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -283,14 +283,14 @@ namespace Microsoft.OpenApi.OData.Common
             CheckArgumentNullOrEmpty(value, nameof(value));
             CheckArgumentNull(settings, nameof(settings));
 
-            if (string.IsNullOrEmpty(settings.BaseNamespace))
+            if (string.IsNullOrEmpty(settings.DefaultNamespace))
             {
                 return value;
             }
 
-            string baseNamespace = settings.BaseNamespace.EndsWith(".")
-                ? settings.BaseNamespace
-                : settings.BaseNamespace + ".";
+            string baseNamespace = settings.DefaultNamespace.EndsWith(".")
+                ? settings.DefaultNamespace
+                : settings.DefaultNamespace + ".";
 
             string escapedPattern = Regex.Escape(baseNamespace);
             return Regex.Replace(value, escapedPattern, "", RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Utils.cs
@@ -7,8 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
-using System.Text.RegularExpressions;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Any;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
@@ -130,14 +131,17 @@ namespace Microsoft.OpenApi.OData.Edm
                 }
             }
 
-            StringBuilder functionName = new StringBuilder();
+            StringBuilder functionName = new();
+            string selectedName = function.FullName();
+
             if (settings.EnableUnqualifiedCall)
             {
-                functionName.Append(function.Name);
+                selectedName = settings.BaseNamespace != null ? selectedName.RemoveBaseNamespace(settings) : function.Name;
+                functionName.Append(selectedName);
             }
             else
             {
-                functionName.Append(function.FullName());
+                functionName.Append(selectedName);
             }
             functionName.Append("(");
             
@@ -158,13 +162,15 @@ namespace Microsoft.OpenApi.OData.Edm
 
         private string ActionName(IEdmAction action, OpenApiConvertSettings settings)
         {
+            var actionName = action.FullName();
+
             if (settings.EnableUnqualifiedCall)
             {
-                return action.Name;
+                return settings.BaseNamespace != null ? actionName.RemoveBaseNamespace(settings) : action.Name;
             }
             else
             {
-                return action.FullName();
+                return actionName;
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -118,14 +118,10 @@ namespace Microsoft.OpenApi.OData.Edm
             }
             else
             {
-                if (!string.IsNullOrEmpty(settings.NamespacePrefixToStripForInMethodPaths))
-                {
-                    return operation.Namespace.Replace(settings.NamespacePrefixToStripForInMethodPaths, "").TrimStart('.') + "." + operation.Name;
-                }
-                else
-                {
-                    return operation.FullName();
-                }
+                string selectedName = operation.FullName();
+                return !string.IsNullOrEmpty(settings.NamespacePrefixToStripForInMethodPaths)
+                    ? selectedName.StripNamespacePrefix(settings.NamespacePrefixToStripForInMethodPaths)
+                    : selectedName;
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OpenApi.OData.Edm
                 return FunctionName(Operation as IEdmFunction, settings, parameters);
             }
 
-            return ActionName(Operation as IEdmAction, settings);
+            return OperationName(Operation, settings);
         }
 
         internal IDictionary<string, string> GetNameMapping(OpenApiConvertSettings settings, HashSet<string> parameters)
@@ -113,6 +113,14 @@ namespace Microsoft.OpenApi.OData.Edm
             return parameterNamesMapping;
         }
 
+        private string OperationName(IEdmOperation operation, OpenApiConvertSettings settings)
+        {
+            string selectedName = operation.FullName();
+            return settings.EnableUnqualifiedCall
+                ? settings.DefaultNamespace != null ? selectedName.RemoveDefaultNamespace(settings) : operation.Name
+                : selectedName;
+        }
+
         private string FunctionName(IEdmFunction function, OpenApiConvertSettings settings, HashSet<string> parameters)
         {
             if (settings.EnableUriEscapeFunctionCall && IsEscapedFunction)
@@ -132,17 +140,7 @@ namespace Microsoft.OpenApi.OData.Edm
             }
 
             StringBuilder functionName = new();
-            string selectedName = function.FullName();
-
-            if (settings.EnableUnqualifiedCall)
-            {
-                selectedName = settings.DefaultNamespace != null ? selectedName.RemoveBaseNamespace(settings) : function.Name;
-                functionName.Append(selectedName);
-            }
-            else
-            {
-                functionName.Append(selectedName);
-            }
+            functionName.Append(OperationName(function, settings));
             functionName.Append("(");
             
             int skip = function.IsBound ? 1 : 0;
@@ -158,20 +156,6 @@ namespace Microsoft.OpenApi.OData.Edm
             functionName.Append(")");
 
             return functionName.ToString();
-        }
-
-        private string ActionName(IEdmAction action, OpenApiConvertSettings settings)
-        {
-            var actionName = action.FullName();
-
-            if (settings.EnableUnqualifiedCall)
-            {
-                return settings.DefaultNamespace != null ? actionName.RemoveBaseNamespace(settings) : action.Name;
-            }
-            else
-            {
-                return actionName;
-            }
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -3,12 +3,9 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
@@ -115,10 +112,21 @@ namespace Microsoft.OpenApi.OData.Edm
 
         private string OperationName(IEdmOperation operation, OpenApiConvertSettings settings)
         {
-            string selectedName = operation.FullName();
-            return settings.EnableUnqualifiedCall
-                ? settings.DefaultNamespace != null ? selectedName.RemoveDefaultNamespace(settings) : operation.Name
-                : selectedName;
+            if (settings.EnableUnqualifiedCall)
+            {
+                return operation.Name;
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(settings.NamespacePrefixToStripForInMethodPaths))
+                {
+                    return operation.Namespace.Replace(settings.NamespacePrefixToStripForInMethodPaths, "").TrimStart('.') + "." + operation.Name;
+                }
+                else
+                {
+                    return operation.FullName();
+                }
+            }
         }
 
         private string FunctionName(IEdmFunction function, OpenApiConvertSettings settings, HashSet<string> parameters)

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataOperationSegment.cs
@@ -136,7 +136,7 @@ namespace Microsoft.OpenApi.OData.Edm
 
             if (settings.EnableUnqualifiedCall)
             {
-                selectedName = settings.BaseNamespace != null ? selectedName.RemoveBaseNamespace(settings) : function.Name;
+                selectedName = settings.DefaultNamespace != null ? selectedName.RemoveBaseNamespace(settings) : function.Name;
                 functionName.Append(selectedName);
             }
             else
@@ -166,7 +166,7 @@ namespace Microsoft.OpenApi.OData.Edm
 
             if (settings.EnableUnqualifiedCall)
             {
-                return settings.BaseNamespace != null ? actionName.RemoveBaseNamespace(settings) : action.Name;
+                return settings.DefaultNamespace != null ? actionName.RemoveBaseNamespace(settings) : action.Name;
             }
             else
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -657,7 +657,7 @@ namespace Microsoft.OpenApi.OData.Edm
 
             foreach (var targetType in targetTypes)
             {
-                var targetTypeSegment = new ODataTypeCastSegment(targetType);
+                var targetTypeSegment = new ODataTypeCastSegment(targetType, _model);
 
                 if (currentPath.Segments.Any(x => x.Identifier.Equals(targetTypeSegment.Identifier)))
                 {
@@ -860,7 +860,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         {
                             if (ns is IEdmEntitySet)
                             {
-                                ODataPath newPath = new ODataPath(new ODataNavigationSourceSegment(ns), new ODataTypeCastSegment(bindingEntityType),
+                                ODataPath newPath = new ODataPath(new ODataNavigationSourceSegment(ns), new ODataTypeCastSegment(bindingEntityType, _model),
                                     new ODataOperationSegment(edmOperation, isEscapedFunction));
                                 AppendPath(newPath);
                             }
@@ -869,14 +869,14 @@ namespace Microsoft.OpenApi.OData.Edm
                         {
                             if (ns is IEdmSingleton)
                             {
-                                ODataPath newPath = new ODataPath(new ODataNavigationSourceSegment(ns), new ODataTypeCastSegment(bindingEntityType),
+                                ODataPath newPath = new ODataPath(new ODataNavigationSourceSegment(ns), new ODataTypeCastSegment(bindingEntityType, _model),
                                     new ODataOperationSegment(edmOperation, isEscapedFunction));
                                 AppendPath(newPath);
                             }
                             else
                             {
                                 ODataPath newPath = new ODataPath(new ODataNavigationSourceSegment(ns), new ODataKeySegment(ns.EntityType()),
-                                    new ODataTypeCastSegment(bindingEntityType),
+                                    new ODataTypeCastSegment(bindingEntityType , _model),
                                     new ODataOperationSegment(edmOperation, isEscapedFunction));
                                 AppendPath(newPath);
                             }
@@ -956,7 +956,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         }
 
                         ODataPath newPath = path.Clone();
-                        newPath.Push(new ODataTypeCastSegment(bindingEntityType));
+                        newPath.Push(new ODataTypeCastSegment(bindingEntityType, _model));
                         newPath.Push(new ODataOperationSegment(edmOperation, isEscapedFunction));
                         AppendPath(newPath);
                     }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataTypeCastSegment.cs
@@ -3,8 +3,11 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Common;
 
@@ -18,11 +21,14 @@ public class ODataTypeCastSegment : ODataSegment
     /// Initializes a new instance of <see cref="ODataTypeCastSegment"/> class.
     /// </summary>
     /// <param name="structuredType">The target type cast type.</param>
-    public ODataTypeCastSegment(IEdmStructuredType structuredType)
+    /// <param name="model">The model the type is a part of.</param>
+    public ODataTypeCastSegment(IEdmStructuredType structuredType, IEdmModel model)
     {
         StructuredType = structuredType ?? throw Error.ArgumentNull(nameof(structuredType));
+        _model = model ?? throw Error.ArgumentNull(nameof(model));
     }
 
+    private readonly IEdmModel _model;
     /// <inheritdoc />
     public override IEdmEntityType EntityType => null;
 
@@ -44,5 +50,23 @@ public class ODataTypeCastSegment : ODataSegment
     }
 
     /// <inheritdoc />
-    public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => StructuredType.FullTypeName();
+    public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters)
+    {
+        Utils.CheckArgumentNull(settings, nameof(settings));
+        string namespaceName = string.Empty;
+        string namespaceAlias = string.Empty;
+
+        if (StructuredType is IEdmSchemaElement element)
+            namespaceName = element.Namespace;
+
+        if (!string.IsNullOrEmpty(namespaceName))
+            namespaceAlias = _model.GetNamespaceAlias(namespaceName);
+
+        if(settings.EnableAliasForTypeCastSegments && !string.IsNullOrEmpty(namespaceAlias))
+        {
+            return namespaceAlias.TrimEnd('.') + "." + StructuredType.FullTypeName().Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries).Last();
+        }           
+
+        return StructuredType.FullTypeName();
+    }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -24,7 +24,7 @@
 - Update key path parameter descriptions #309
 - Skips adding a $count path if a similar count() function path exists #347
 - Checks whether path exists before adding it to the paths dictionary #343
-- Removes base namespace identifier from operation segments #348
+- Strips namespace prefix from operation segments and aliases type cast segments #348
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,13 +15,14 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.3.0-preview1</Version>
+    <Version>1.3.0-preview2</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
 - Update key path parameter descriptions #309
+- Removes base namespace identifier from operation segments #348
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -313,6 +313,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty { get; set; } = false;
 
+        /// <summary>
+        /// The base namespace identifier.
+        /// </summary>
+        public string BaseNamespace{ get; set; }
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -362,7 +367,8 @@ namespace Microsoft.OpenApi.OData
                 IncludeAssemblyInfo = this.IncludeAssemblyInfo,
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
                 EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty,
-                AddAlternateKeyPaths = this.AddAlternateKeyPaths
+                AddAlternateKeyPaths = this.AddAlternateKeyPaths,
+                BaseNamespace = this.BaseNamespace
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -314,7 +314,7 @@ namespace Microsoft.OpenApi.OData
         public bool EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty { get; set; } = false;
 
         /// <summary>
-        /// The base namespace identifier.
+        /// The base namespace.
         /// </summary>
         public string BaseNamespace{ get; set; }
 

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -314,9 +314,9 @@ namespace Microsoft.OpenApi.OData
         public bool EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty { get; set; } = false;
 
         /// <summary>
-        /// The base namespace.
+        /// The default namespace.
         /// </summary>
-        public string BaseNamespace{ get; set; }
+        public string DefaultNamespace{ get; set; }
 
         internal OpenApiConvertSettings Clone()
         {
@@ -368,7 +368,7 @@ namespace Microsoft.OpenApi.OData
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
                 EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty,
                 AddAlternateKeyPaths = this.AddAlternateKeyPaths,
-                BaseNamespace = this.BaseNamespace
+                DefaultNamespace = this.DefaultNamespace
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -314,9 +314,9 @@ namespace Microsoft.OpenApi.OData
         public bool EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty { get; set; } = false;
 
         /// <summary>
-        /// The default namespace.
+        /// The namespace prefix to be stripped from the in method paths.
         /// </summary>
-        public string DefaultNamespace{ get; set; }
+        public string NamespacePrefixToStripForInMethodPaths { get; set; }
 
         internal OpenApiConvertSettings Clone()
         {
@@ -368,7 +368,7 @@ namespace Microsoft.OpenApi.OData
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
                 EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty,
                 AddAlternateKeyPaths = this.AddAlternateKeyPaths,
-                DefaultNamespace = this.DefaultNamespace
+                NamespacePrefixToStripForInMethodPaths = this.NamespacePrefixToStripForInMethodPaths
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -318,6 +318,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public string NamespacePrefixToStripForInMethodPaths { get; set; }
 
+        /// <summary>
+        /// Enables the use of aliases for the type cast segments to shorten the url path.
+        /// </summary>
+        public bool EnableAliasForTypeCastSegments { get; set; } = false;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -368,7 +373,8 @@ namespace Microsoft.OpenApi.OData
                 EnableODataAnnotationReferencesForResponses = this.EnableODataAnnotationReferencesForResponses,
                 EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty,
                 AddAlternateKeyPaths = this.AddAlternateKeyPaths,
-                NamespacePrefixToStripForInMethodPaths = this.NamespacePrefixToStripForInMethodPaths
+                NamespacePrefixToStripForInMethodPaths = this.NamespacePrefixToStripForInMethodPaths,
+                EnableAliasForTypeCastSegments = this.EnableAliasForTypeCastSegments
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -11,8 +11,6 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
-Microsoft.OpenApi.OData.OpenApiConvertSettings.BaseNamespace.get -> string
-Microsoft.OpenApi.OData.OpenApiConvertSettings.BaseNamespace.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool
@@ -27,6 +25,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.get ->
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomXMLAttributesMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.IncludeAssemblyInfo.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.NamespacePrefixToStripForInMethodPaths.get -> string
+Microsoft.OpenApi.OData.OpenApiConvertSettings.NamespacePrefixToStripForInMethodPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -11,6 +11,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.BaseNamespace.get -> string
+Microsoft.OpenApi.OData.OpenApiConvertSettings.BaseNamespace.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -7,12 +7,15 @@ Microsoft.OpenApi.OData.Edm.EdmModelExtensions
 Microsoft.OpenApi.OData.Edm.EdmTypeExtensions
 Microsoft.OpenApi.OData.Edm.ODataKeySegment.IsAlternateKey.get -> bool
 Microsoft.OpenApi.OData.Edm.ODataKeySegment.IsAlternateKey.set -> void
+Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.ODataTypeCastSegment(Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model) -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableAliasForTypeCastSegments.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableAliasForTypeCastSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableCount.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableODataAnnotationReferencesForResponses.get -> bool
@@ -130,7 +133,6 @@ Microsoft.OpenApi.OData.Edm.ODataStreamContentSegment.ODataStreamContentSegment(
 Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment
 Microsoft.OpenApi.OData.Edm.ODataStreamPropertySegment.ODataStreamPropertySegment(string streamPropertyName) -> void
 Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment
-Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.ODataTypeCastSegment(Microsoft.OData.Edm.IEdmStructuredType structuredType) -> void
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.ODataComplexPropertySegment(Microsoft.OData.Edm.IEdmStructuralProperty property) -> void
 Microsoft.OpenApi.OData.Edm.ODataComplexPropertySegment.Property.get -> Microsoft.OData.Edm.IEdmStructuralProperty

--- a/src/OoasGui/MainForm.cs
+++ b/src/OoasGui/MainForm.cs
@@ -52,6 +52,15 @@ namespace OoasGui
 
             csdlRichTextBox.WordWrap = false;
             oasRichTextBox.WordWrap = false;
+
+            Settings.EnableKeyAsSegment = true;
+            Settings.PrefixEntityTypeNameBeforeKey = true;
+            Settings.ShowLinks = true;
+            verifyEdmModelcheckBox.Checked = false;
+            yamlRadioBtn.Checked = true;
+            Settings.ShowLinks = true;
+            Settings.EnableDiscriminatorValue = true;
+            Settings.ExpandDerivedTypesNavigationProperties = false;
         }
 
         private async void jsonRadioBtn_CheckedChanged(object sender, EventArgs e)

--- a/src/OoasGui/MainForm.cs
+++ b/src/OoasGui/MainForm.cs
@@ -52,15 +52,6 @@ namespace OoasGui
 
             csdlRichTextBox.WordWrap = false;
             oasRichTextBox.WordWrap = false;
-
-            Settings.EnableKeyAsSegment = true;
-            Settings.PrefixEntityTypeNameBeforeKey = true;
-            Settings.ShowLinks = true;
-            verifyEdmModelcheckBox.Checked = false;
-            yamlRadioBtn.Checked = true;
-            Settings.ShowLinks = true;
-            Settings.EnableDiscriminatorValue = true;
-            Settings.ExpandDerivedTypesNavigationProperties = false;
         }
 
         private async void jsonRadioBtn_CheckedChanged(object sender, EventArgs e)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             // Arrange & Act
             IEdmEntityTypeReference entityTypeReference = new EdmEntityTypeReference(new EdmEntityType("NS.XY", "Entity"), false);
             IEdmTypeReference parameterType = EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Boolean, isNullable: false);
-            EdmFunction boundFunction = BoundFunction("MyFunction", isBound, entityTypeReference,namespaceIdentifier: "NS.XY");
+            EdmFunction boundFunction = BoundFunction("MyFunction", isBound, entityTypeReference,baseNamespace: "NS.XY");
             boundFunction.AddParameter("param", parameterType);
             boundFunction.AddOptionalParameter("param2", parameterType);
 
@@ -152,10 +152,10 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             bool isBound,
             IEdmTypeReference firstParameterType,
             bool isComposable = false,
-            string namespaceIdentifier = "NS")
+            string baseNamespace = "NS")
         {
             IEdmTypeReference returnType = EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Boolean, isNullable: false);
-            EdmFunction boundFunction = new EdmFunction(namespaceIdentifier, funcName, returnType,
+            EdmFunction boundFunction = new EdmFunction(baseNamespace, funcName, returnType,
                 isBound: isBound, entitySetPathExpression: null, isComposable: isComposable);
             boundFunction.AddParameter("entity", firstParameterType);
             return boundFunction;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
@@ -73,16 +73,16 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         }
 
         [Theory]
-        [InlineData(true, true, "XY.MyFunction(param={param},param2=@param2)")]
-        [InlineData(true, false, "XY.MyFunction(entity={entity},param={param},param2=@param2)")]
-        [InlineData(false, true, "NS.XY.MyFunction(param={param},param2=@param2)")]
-        [InlineData(false, false, "NS.XY.MyFunction(entity={entity},param={param},param2=@param2)")]
-        public void GetPathItemNameReturnsCorrectFunctionLiteral(bool unqualifiedCall, bool isBound, string expected)
+        [InlineData(true, true, "MyFunction(param={param},param2=@param2)", null)]
+        [InlineData(true, false, "MyFunction(entity={entity},param={param},param2=@param2)", null)]
+        [InlineData(false, true, "XY.MyFunction(param={param},param2=@param2)", "NS")]
+        [InlineData(false, false, "XY.MyFunction(entity={entity},param={param},param2=@param2)", "NS")]
+        public void GetPathItemNameReturnsCorrectFunctionLiteral(bool unqualifiedCall, bool isBound, string expected, string namespacePrefixToStrip)
         {
             // Arrange & Act
             IEdmEntityTypeReference entityTypeReference = new EdmEntityTypeReference(new EdmEntityType("NS.XY", "Entity"), false);
             IEdmTypeReference parameterType = EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Boolean, isNullable: false);
-            EdmFunction boundFunction = BoundFunction("MyFunction", isBound, entityTypeReference,baseNamespace: "NS.XY");
+            EdmFunction boundFunction = BoundFunction("MyFunction", isBound, entityTypeReference, namespaceIdentifier: "NS.XY");
             boundFunction.AddParameter("param", parameterType);
             boundFunction.AddOptionalParameter("param2", parameterType);
 
@@ -90,7 +90,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableUnqualifiedCall = unqualifiedCall,
-                BaseNamespace = "NS",
+                NamespacePrefixToStripForInMethodPaths = namespacePrefixToStrip,
             };
 
             // Assert
@@ -152,10 +152,10 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             bool isBound,
             IEdmTypeReference firstParameterType,
             bool isComposable = false,
-            string baseNamespace = "NS")
+            string namespaceIdentifier = "NS")
         {
             IEdmTypeReference returnType = EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Boolean, isNullable: false);
-            EdmFunction boundFunction = new EdmFunction(baseNamespace, funcName, returnType,
+            EdmFunction boundFunction = new EdmFunction(namespaceIdentifier, funcName, returnType,
                 isBound: isBound, entitySetPathExpression: null, isComposable: isComposable);
             boundFunction.AddParameter("entity", firstParameterType);
             return boundFunction;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataOperationSegmentTests.cs
@@ -73,23 +73,24 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         }
 
         [Theory]
-        [InlineData(true, true, "MyFunction(param={param},param2=@param2)")]
-        [InlineData(true, false, "MyFunction(entity={entity},param={param},param2=@param2)")]
-        [InlineData(false, true, "NS.MyFunction(param={param},param2=@param2)")]
-        [InlineData(false, false, "NS.MyFunction(entity={entity},param={param},param2=@param2)")]
+        [InlineData(true, true, "XY.MyFunction(param={param},param2=@param2)")]
+        [InlineData(true, false, "XY.MyFunction(entity={entity},param={param},param2=@param2)")]
+        [InlineData(false, true, "NS.XY.MyFunction(param={param},param2=@param2)")]
+        [InlineData(false, false, "NS.XY.MyFunction(entity={entity},param={param},param2=@param2)")]
         public void GetPathItemNameReturnsCorrectFunctionLiteral(bool unqualifiedCall, bool isBound, string expected)
         {
             // Arrange & Act
-            IEdmEntityTypeReference entityTypeReference = new EdmEntityTypeReference(new EdmEntityType("NS", "Entity"), false);
+            IEdmEntityTypeReference entityTypeReference = new EdmEntityTypeReference(new EdmEntityType("NS.XY", "Entity"), false);
             IEdmTypeReference parameterType = EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Boolean, isNullable: false);
-            EdmFunction boundFunction = BoundFunction("MyFunction", isBound, entityTypeReference);
+            EdmFunction boundFunction = BoundFunction("MyFunction", isBound, entityTypeReference,namespaceIdentifier: "NS.XY");
             boundFunction.AddParameter("param", parameterType);
             boundFunction.AddOptionalParameter("param2", parameterType);
 
             var segment = new ODataOperationSegment(boundFunction);
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
-                EnableUnqualifiedCall = unqualifiedCall
+                EnableUnqualifiedCall = unqualifiedCall,
+                BaseNamespace = "NS",
             };
 
             // Assert
@@ -146,10 +147,15 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             Assert.Equal(expected, segment.GetPathItemName(settings));
         }
 
-        private EdmFunction BoundFunction(string funcName,  bool isBound, IEdmTypeReference firstParameterType, bool isComposable = false)
+        private EdmFunction BoundFunction(
+            string funcName,
+            bool isBound,
+            IEdmTypeReference firstParameterType,
+            bool isComposable = false,
+            string namespaceIdentifier = "NS")
         {
             IEdmTypeReference returnType = EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Boolean, isNullable: false);
-            EdmFunction boundFunction = new EdmFunction("NS", funcName, returnType,
+            EdmFunction boundFunction = new EdmFunction(namespaceIdentifier, funcName, returnType,
                 isBound: isBound, entitySetPathExpression: null, isComposable: isComposable);
             boundFunction.AddParameter("entity", firstParameterType);
             return boundFunction;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataTypeCastSegmentTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
 using Xunit;
 
 namespace Microsoft.OpenApi.OData.Edm.Tests
@@ -12,24 +13,27 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
     public class ODataTypeCastSegmentTests
     {
         private readonly EdmEntityType _person;
+        private readonly EdmModel _model;
 
         public ODataTypeCastSegmentTests()
         {
-            _person = new EdmEntityType("NS", "Person");
+            _model = new EdmModel();
+            _model.SetNamespaceAlias("NS", "N");
+            _person = _model.AddEntityType("NS", "Person");
             _person.AddKeys(_person.AddStructuralProperty("Id", EdmCoreModel.Instance.GetString(false)));
         }
 
         [Fact]
         public void TypeCastSegmentConstructorThrowsArgumentNull()
         {
-            Assert.Throws<ArgumentNullException>("structuredType", () => new ODataTypeCastSegment(null));
+            Assert.Throws<ArgumentNullException>("structuredType", () => new ODataTypeCastSegment(null, null));
         }
 
         [Fact]
         public void TypeCastSegmentEntityTypePropertyReturnsSameEntityType()
         {
             // Arrange & Act
-            var segment = new ODataTypeCastSegment(_person);
+            var segment = new ODataTypeCastSegment(_person, _model);
 
             // Assert
             Assert.Null(segment.EntityType);
@@ -40,7 +44,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         public void KindPropertyReturnsTypeCastEnumMember()
         {
             // Arrange & Act
-            var segment = new ODataTypeCastSegment(_person);
+            var segment = new ODataTypeCastSegment(_person, _model);
 
             // Assert
             Assert.Equal(ODataSegmentKind.TypeCast, segment.Kind);
@@ -50,10 +54,24 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         public void GetPathItemNameReturnsCorrectTypeCastLiteral()
         {
             // Arrange & Act
-            var segment = new ODataTypeCastSegment(_person);
+            var segment = new ODataTypeCastSegment(_person,_model);
 
             // Assert
             Assert.Equal("NS.Person", segment.GetPathItemName(new OpenApiConvertSettings()));
+        }
+
+        [Fact]
+        public void GetPathItemNameReturnsCorrectTypeCastLiteralAsAliased()
+        {
+            // Arrange & Act
+            var segment = new ODataTypeCastSegment(_person, _model);
+            var settings = new OpenApiConvertSettings()
+            {
+                EnableAliasForTypeCastSegments = true
+            };
+
+            // Assert
+            Assert.Equal("N.Person", segment.GetPathItemName(settings));
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             ODataPath path = new ODataPath(new ODataNavigationSourceSegment(customers),
                 new ODataKeySegment(customer),
-                new ODataTypeCastSegment(vipCustomer),
+                new ODataTypeCastSegment(vipCustomer, model),
                 new ODataOperationSegment(action));
 
             // Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             ODataPath path = new ODataPath(new ODataNavigationSourceSegment(customers),
                 new ODataKeySegment(customer),
-                new ODataTypeCastSegment(vipCustomer),
+                new ODataTypeCastSegment(vipCustomer, model),
                 new ODataOperationSegment(function));
           
             // Act

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ODataTypeCastGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ODataTypeCastGetOperationHandlerTests.cs
@@ -40,7 +40,7 @@ public class ODataTypeCastGetOperationHandlerTests
         ODataPath path = new(new ODataNavigationSourceSegment(people),
                                                                     new ODataKeySegment(people.EntityType()),
                                                                     new ODataNavigationPropertySegment(navProperty),
-                                                                    new ODataTypeCastSegment(employee));
+                                                                    new ODataTypeCastSegment(employee, model));
 
         // Act
         var operation = _operationHandler.CreateOperation(context, path);
@@ -99,7 +99,7 @@ public class ODataTypeCastGetOperationHandlerTests
                                                                     new ODataKeySegment(people.EntityType()),
                                                                     new ODataNavigationPropertySegment(navProperty),
                                                                     new ODataKeySegment(people.EntityType()),
-                                                                    new ODataTypeCastSegment(employee));
+                                                                    new ODataTypeCastSegment(employee,model));
 
         // Act
         var operation = _operationHandler.CreateOperation(context, path);
@@ -152,7 +152,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         IEdmEntityType employee = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Employee");
         ODataPath path = new(new ODataNavigationSourceSegment(people),
-                                                                    new ODataTypeCastSegment(employee));
+                                                                    new ODataTypeCastSegment(employee,model));
 
         // Act
         var operation = _operationHandler.CreateOperation(context, path);
@@ -207,7 +207,7 @@ public class ODataTypeCastGetOperationHandlerTests
         IEdmEntityType employee = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Employee");
         ODataPath path = new(new ODataNavigationSourceSegment(people),
                                                                     new ODataKeySegment(people.EntityType()),
-                                                                    new ODataTypeCastSegment(employee));
+                                                                    new ODataTypeCastSegment(employee,model));
 
         // Act
         var operation = _operationHandler.CreateOperation(context, path);
@@ -264,7 +264,7 @@ public class ODataTypeCastGetOperationHandlerTests
         ODataPath path = new(new ODataNavigationSourceSegment(people),
                                                                     new ODataKeySegment(people.EntityType()),
                                                                     new ODataNavigationPropertySegment(navProperty),
-                                                                    new ODataTypeCastSegment(employee));
+                                                                    new ODataTypeCastSegment(employee, model));
 
         // Act
         var operation = _operationHandler.CreateOperation(context, path);
@@ -317,7 +317,7 @@ public class ODataTypeCastGetOperationHandlerTests
 
         IEdmEntityType employee = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Employee");
         ODataPath path = new(new ODataNavigationSourceSegment(me),
-                                                                    new ODataTypeCastSegment(employee));
+                                                                    new ODataTypeCastSegment(employee, model));
 
         // Act
         var operation = _operationHandler.CreateOperation(context, path);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/ODataTypeCastPathItemHandlerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             ODataPath path = new(new ODataNavigationSourceSegment(people),
                                                                     new ODataKeySegment(people.EntityType()),
                                                                     new ODataNavigationPropertySegment(navProperty),
-                                                                    new ODataTypeCastSegment(employee));
+                                                                    new ODataTypeCastSegment(employee, model));
 
             // Act
             var pathItem = _pathItemHandler.CreatePathItem(context, path);


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/348

This PR:
- Removes the base namespace identifier from operation segments.
- To remove the namespace to make unqualified calls, set the convert setting `EnableUnqualifiedCall=true` and set the `BaseNamespace` value to the base namespace value that needs to be stripped.