### PR TITLE
[Fix] Skips adding a `$count` path if a similar `count()` function path exists

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -193,6 +193,6 @@ namespace Microsoft.OpenApi.OData.Common
         /// <summary>
         /// count segment identifier
         /// </summary>
-        public static string CountSegmentIdentifier = "count";
+        public const string CountSegmentIdentifier = "count";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -189,5 +189,10 @@ namespace Microsoft.OpenApi.OData.Common
         /// entity name
         /// </summary>
         public static string EntityName = "entity";
+
+        /// <summary>
+        /// count segment identifier
+        /// </summary>
+        public static string CountSegmentIdentifier = "count";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -206,12 +206,10 @@ namespace Microsoft.OpenApi.OData.Edm
 
             bool DollarCountAndOperationPathsSimilar(ODataPath path1, ODataPath path2)
             {
-                string countIdentifier = "count";
-
                 if ((path1.Kind == ODataPathKind.DollarCount && 
-                    path2.Kind == ODataPathKind.Operation && path2.LastSegment.Identifier.Equals(countIdentifier, StringComparison.OrdinalIgnoreCase)) ||
+                    path2.Kind == ODataPathKind.Operation && path2.LastSegment.Identifier.Equals(Constants.CountSegmentIdentifier, StringComparison.OrdinalIgnoreCase)) ||
                     (path2.Kind == ODataPathKind.DollarCount &&
-                    path1.Kind == ODataPathKind.Operation && path1.LastSegment.Identifier.Equals(countIdentifier, StringComparison.OrdinalIgnoreCase)))
+                    path1.Kind == ODataPathKind.Operation && path1.LastSegment.Identifier.Equals(Constants.CountSegmentIdentifier, StringComparison.OrdinalIgnoreCase)))
                 {
                     return GetModifiedPathItemName(path1).Equals(GetModifiedPathItemName(path2), StringComparison.OrdinalIgnoreCase);
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         
                         if (kind == ODataPathKind.DollarCount)
                         {                          
-                            if (_allOperationPaths.FirstOrDefault(p => DollarCountAndOperationPathsSimilar(p, path)) is ODataPath operationPath)
+                            if (_allOperationPaths.FirstOrDefault(p => DollarCountAndOperationPathsSimilar(p, path)) is ODataPath)
                             {
                                 // Don't add a path for $count if a similar count() function path already exists.                                
                                 return;

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -31,6 +31,9 @@ namespace Microsoft.OpenApi.OData.Edm
 
         private IEdmModel _model;
 
+        private readonly IDictionary<IEdmEntityType, IList<ODataPath>> _dollarCountPaths =
+           new Dictionary<IEdmEntityType, IList<ODataPath>>();
+
         /// <summary>
         /// Can filter the <see cref="IEdmElement"/> or not.
         /// </summary>
@@ -99,6 +102,7 @@ namespace Microsoft.OpenApi.OData.Edm
             _allNavigationSourcePaths.Clear();
             _allNavigationPropertyPaths.Clear();
             _allOperationPaths.Clear();
+            _dollarCountPaths.Clear();
         }
 
        private IEnumerable<ODataPath> MergePaths()
@@ -142,6 +146,27 @@ namespace Microsoft.OpenApi.OData.Edm
                             nsList = new List<ODataPath>();
                             _allNavigationSourcePaths[navigationSourceSegment.EntityType] = nsList;
                         }
+                        
+                        if (kind == ODataPathKind.DollarCount)
+                        {                          
+                            ODataPath operationPath = _allOperationPaths.FirstOrDefault(p => DollarCountAndOperationPathsSimilar(p, path));
+                            
+                            if (operationPath != null)
+                            {
+                                // Don't add a path for $count if a similar count() function path already exists.                                
+                                return;
+                            }
+                            else
+                            {
+                                if (!_dollarCountPaths.TryGetValue(navigationSourceSegment.EntityType, out IList<ODataPath> dollarPathList))
+                                {
+                                    dollarPathList = new List<ODataPath>();
+                                    _dollarCountPaths[navigationSourceSegment.EntityType] = dollarPathList;
+                                }
+                                dollarPathList.Add(path);
+                            }
+                        }
+                        
                         nsList.Add(path);
                     }
                     break;
@@ -161,11 +186,47 @@ namespace Microsoft.OpenApi.OData.Edm
 
                 case ODataPathKind.Operation:
                 case ODataPathKind.OperationImport:
+                    if (kind == ODataPathKind.Operation)
+                    {
+                        foreach (var kvp in _dollarCountPaths)
+                        {
+                            ODataPath dollarCountPath = kvp.Value.FirstOrDefault(p => DollarCountAndOperationPathsSimilar(p, path));
+                            if (dollarCountPath != null &&
+                                _allNavigationSourcePaths.TryGetValue(kvp.Key, out IList<ODataPath> dollarPathList))
+                            {
+                                dollarPathList.Remove(dollarCountPath);
+                                break;
+                            }
+                        }
+                    }
+
                     _allOperationPaths.Add(path);
                     break;
 
                 default:
                     return;
+            }
+
+            bool DollarCountAndOperationPathsSimilar(ODataPath path1, ODataPath path2)
+            {
+                string countIdentifier = "count";
+
+                if ((path1.Kind == ODataPathKind.DollarCount && 
+                    path2.Kind == ODataPathKind.Operation && path2.LastSegment.Identifier.Equals(countIdentifier, StringComparison.OrdinalIgnoreCase)) ||
+                    (path2.Kind == ODataPathKind.DollarCount &&
+                    path1.Kind == ODataPathKind.Operation && path1.LastSegment.Identifier.Equals(countIdentifier, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return GetModifiedPathItemName(path1).Equals(GetModifiedPathItemName(path2), StringComparison.OrdinalIgnoreCase);
+                }
+
+                return false;                
+            }
+
+            string GetModifiedPathItemName(ODataPath path)
+            {
+                IEnumerable<ODataSegment> modifiedSegments = path.Take(path.Count - 1);
+                ODataPath modifiedPath = new(modifiedSegments);
+                return modifiedPath.GetPathItemName();
             }
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -211,7 +211,7 @@ namespace Microsoft.OpenApi.OData.Edm
                     (path2.Kind == ODataPathKind.DollarCount &&
                     path1.Kind == ODataPathKind.Operation && path1.LastSegment.Identifier.Equals(Constants.CountSegmentIdentifier, StringComparison.OrdinalIgnoreCase)))
                 {
-                    return GetModifiedPathItemName(path1).Equals(GetModifiedPathItemName(path2), StringComparison.OrdinalIgnoreCase);
+                    return GetModifiedPathItemName(path1)?.Equals(GetModifiedPathItemName(path2), StringComparison.OrdinalIgnoreCase) ?? false;
                 }
 
                 return false;                
@@ -219,6 +219,8 @@ namespace Microsoft.OpenApi.OData.Edm
 
             string GetModifiedPathItemName(ODataPath path)
             {
+                if (!path.Any()) return null;
+
                 IEnumerable<ODataSegment> modifiedSegments = path.Take(path.Count - 1);
                 ODataPath modifiedPath = new(modifiedSegments);
                 return modifiedPath.GetPathItemName();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.OpenApi.OData.Edm
                         
                         if (kind == ODataPathKind.DollarCount)
                         {                          
-                            if (_allOperationPaths.FirstOrDefault(p => DollarCountAndOperationPathsSimilar(p, path)) is ODataPath)
+                            if (_allOperationPaths.FirstOrDefault(p => DollarCountAndOperationPathsSimilar(p, path)) is not null)
                             {
                                 // Don't add a path for $count if a similar count() function path already exists.                                
                                 return;

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,13 +15,14 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.3.0-preview1</Version>
+    <Version>1.3.0-preview2</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
 - Update key path parameter descriptions #309
+- Skips adding a $count path if a similar count() function path exists #347
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/EdmOperationProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/EdmOperationProviderTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             var operations = provider.FindOperations(entitySet.EntityType(), false);
 
             // Assert
-            Assert.Equal(29, operations.Count());
+            Assert.Equal(30, operations.Count());
 
             // Act
             entitySet = model.EntityContainer.FindEntitySet("directoryObjects");
@@ -42,7 +42,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             operations = provider.FindOperations(entitySet.EntityType(), false);
 
             // Assert
-            Assert.Equal(57, operations.Count());
+            Assert.Equal(58, operations.Count());
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -43,7 +43,8 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             ODataPathProvider provider = new();
             OpenApiConvertSettings settings = new()
             {
-                AddAlternateKeyPaths = true
+                AddAlternateKeyPaths = true,
+                PrefixEntityTypeNameBeforeKey = true
             };
 
             // Act
@@ -51,7 +52,9 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18317, paths.Count());
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/drives({id})/items({id1})/workbook/tables/$count")));
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/drives({id})/items({id1})/workbook/tables/microsoft.graph.count()")));
+            Assert.Equal(18024, paths.Count());
         }
 
         [Fact]
@@ -72,7 +75,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(19773, paths.Count());
+            Assert.Equal(18675, paths.Count());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiLinkGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiLinkGeneratorTests.cs
@@ -158,12 +158,27 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
 
             // Assert
             Assert.NotNull(links);
-            Assert.Equal(2, links.Count);
+            Assert.Equal(5, links.Count);
             Assert.Collection(links,
+                item =>
+                {
+                    Assert.Equal("edge", item.Key);
+                    Assert.Equal("admin.GetEdge", item.Value.OperationId);
+                },
+                item =>
+                {
+                Assert.Equal("sharepoint", item.Key);
+                Assert.Equal("admin.GetSharepoint", item.Value.OperationId);
+                },
                 item =>
                 {
                     Assert.Equal("serviceAnnouncement", item.Key);
                     Assert.Equal("admin.GetServiceAnnouncement", item.Value.OperationId);
+                },
+                item =>
+                {
+                Assert.Equal("reportSettings", item.Key);
+                Assert.Equal("admin.GetReportSettings", item.Value.OperationId);
                 },
                 item =>
                 {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -206,6 +206,7 @@ namespace Microsoft.OpenApi.OData.Tests
         ""deletedDateTime"": {
           ""pattern"": ""^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$"",
           ""type"": ""string"",
+          ""description"": ""Date and time when this object was deleted. Always null when the object hasn't been deleted."",
           ""format"": ""date-time"",
           ""nullable"": true
         },
@@ -218,10 +219,11 @@ namespace Microsoft.OpenApi.OData.Tests
         ""propertyName"": ""@odata.type"",
         ""mapping"": {
           ""#microsoft.graph.user"": ""#/components/schemas/microsoft.graph.user"",
+          ""#microsoft.graph.servicePrincipal"": ""#/components/schemas/microsoft.graph.servicePrincipal"",
           ""#microsoft.graph.group"": ""#/components/schemas/microsoft.graph.group"",
           ""#microsoft.graph.device"": ""#/components/schemas/microsoft.graph.device"",
+          ""#microsoft.graph.administrativeUnit"": ""#/components/schemas/microsoft.graph.administrativeUnit"",
           ""#microsoft.graph.application"": ""#/components/schemas/microsoft.graph.application"",
-          ""#microsoft.graph.servicePrincipal"": ""#/components/schemas/microsoft.graph.servicePrincipal"",
           ""#microsoft.graph.policyBase"": ""#/components/schemas/microsoft.graph.policyBase"",
           ""#microsoft.graph.appManagementPolicy"": ""#/components/schemas/microsoft.graph.appManagementPolicy"",
           ""#microsoft.graph.stsPolicy"": ""#/components/schemas/microsoft.graph.stsPolicy"",
@@ -231,14 +233,16 @@ namespace Microsoft.OpenApi.OData.Tests
           ""#microsoft.graph.claimsMappingPolicy"": ""#/components/schemas/microsoft.graph.claimsMappingPolicy"",
           ""#microsoft.graph.activityBasedTimeoutPolicy"": ""#/components/schemas/microsoft.graph.activityBasedTimeoutPolicy"",
           ""#microsoft.graph.authorizationPolicy"": ""#/components/schemas/microsoft.graph.authorizationPolicy"",
+          ""#microsoft.graph.tenantRelationshipAccessPolicyBase"": ""#/components/schemas/microsoft.graph.tenantRelationshipAccessPolicyBase"",
+          ""#microsoft.graph.crossTenantAccessPolicy"": ""#/components/schemas/microsoft.graph.crossTenantAccessPolicy"",
           ""#microsoft.graph.tenantAppManagementPolicy"": ""#/components/schemas/microsoft.graph.tenantAppManagementPolicy"",
+          ""#microsoft.graph.externalIdentitiesPolicy"": ""#/components/schemas/microsoft.graph.externalIdentitiesPolicy"",
           ""#microsoft.graph.permissionGrantPolicy"": ""#/components/schemas/microsoft.graph.permissionGrantPolicy"",
           ""#microsoft.graph.servicePrincipalCreationPolicy"": ""#/components/schemas/microsoft.graph.servicePrincipalCreationPolicy"",
           ""#microsoft.graph.identitySecurityDefaultsEnforcementPolicy"": ""#/components/schemas/microsoft.graph.identitySecurityDefaultsEnforcementPolicy"",
           ""#microsoft.graph.extensionProperty"": ""#/components/schemas/microsoft.graph.extensionProperty"",
           ""#microsoft.graph.endpoint"": ""#/components/schemas/microsoft.graph.endpoint"",
           ""#microsoft.graph.resourceSpecificPermissionGrant"": ""#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant"",
-          ""#microsoft.graph.administrativeUnit"": ""#/components/schemas/microsoft.graph.administrativeUnit"",
           ""#microsoft.graph.contract"": ""#/components/schemas/microsoft.graph.contract"",
           ""#microsoft.graph.directoryObjectPartnerReference"": ""#/components/schemas/microsoft.graph.directoryObjectPartnerReference"",
           ""#microsoft.graph.directoryRole"": ""#/components/schemas/microsoft.graph.directoryRole"",
@@ -285,6 +289,7 @@ namespace Microsoft.OpenApi.OData.Tests
   ""properties"": {
     ""isBackup"": {
       ""type"": ""boolean"",
+      ""description"": ""For a user in an approval stage, this property indicates whether the user is a backup fallback approver."",
       ""nullable"": true
     },
     ""@odata.type"": {
@@ -313,6 +318,7 @@ namespace Microsoft.OpenApi.OData.Tests
   ""properties"": {
     ""isBackup"": {
       ""type"": ""boolean"",
+      ""description"": ""For a user in an approval stage, this property indicates whether the user is a backup fallback approver."",
       ""nullable"": true
     },
     ""@odata.type"": {
@@ -363,11 +369,11 @@ namespace Microsoft.OpenApi.OData.Tests
       ""properties"": {
         ""contributionToContentDiscoveryAsOrganizationDisabled"": {
           ""type"": ""boolean"",
-          ""x-ms-isHidden"": ""true""
+          ""description"": ""Reflects the Office Delve organization level setting. When set to true, the organization doesn't have access to Office Delve. This setting is read-only and can only be changed by administrators in the SharePoint admin center.""
         },
         ""contributionToContentDiscoveryDisabled"": {
           ""type"": ""boolean"",
-          ""x-ms-isHidden"": ""true""
+          ""description"": ""When set to true, documents in the user's Office Delve are disabled. Users can control this setting in Office Delve.""
         },
         ""itemInsights"": {
           ""anyOf"": [
@@ -379,7 +385,20 @@ namespace Microsoft.OpenApi.OData.Tests
               ""nullable"": true
             }
           ],
-          ""x-ms-isHidden"": ""true"",
+          ""description"": ""The user's settings for the visibility of meeting hour insights, and insights derived between a user and other items in Microsoft 365, such as documents or sites. Get userInsightsSettings through this navigation property."",
+          ""x-ms-navigationProperty"": true
+        },
+        ""contactMergeSuggestions"": {
+          ""anyOf"": [
+            {
+              ""$ref"": ""#/components/schemas/microsoft.graph.contactMergeSuggestions""
+            },
+            {
+              ""type"": ""object"",
+              ""nullable"": true
+            }
+          ],
+          ""description"": ""The user's settings for the visibility of merge suggestion for the duplicate contacts in the user's contact list."",
           ""x-ms-navigationProperty"": true
         },
         ""regionalAndLanguageSettings"": {
@@ -392,6 +411,7 @@ namespace Microsoft.OpenApi.OData.Tests
               ""nullable"": true
             }
           ],
+          ""description"": ""The user's preferences for languages, regional locale and date/time formatting."",
           ""x-ms-navigationProperty"": true
         },
         ""shiftPreferences"": {
@@ -404,6 +424,7 @@ namespace Microsoft.OpenApi.OData.Tests
               ""nullable"": true
             }
           ],
+          ""description"": ""The shift preferences for the user."",
           ""x-ms-navigationProperty"": true
         }
       }
@@ -931,6 +952,7 @@ namespace Microsoft.OpenApi.OData.Tests
             {
                 Assert.Equal(@"{
   ""format"": ""duration"",
+  ""description"": ""The length of the appointment, denoted in ISO8601 format."",
   ""pattern"": ""^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$"",
   ""type"": ""string"",
   ""readOnly"": true
@@ -941,6 +963,7 @@ namespace Microsoft.OpenApi.OData.Tests
                 Assert.Equal(@"{
   ""pattern"": ""^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$"",
   ""type"": ""string"",
+  ""description"": ""The length of the appointment, denoted in ISO8601 format."",
   ""format"": ""duration"",
   ""readOnly"": true
 }".ChangeLineBreaks(), json);


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/347