### PR TITLE
[Fix] Returns response status code 2XX for `PUT` operations of stream properties  when `UseSuccessStatusCodeRange` is enabled

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -194,5 +194,10 @@ namespace Microsoft.OpenApi.OData.Common
         /// count segment identifier
         /// </summary>
         public const string CountSegmentIdentifier = "count";
+
+        /// <summary>
+        /// content string identifier
+        /// </summary>
+        public const string Content = "content";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -196,8 +196,23 @@ namespace Microsoft.OpenApi.OData.Common
         public const string CountSegmentIdentifier = "count";
 
         /// <summary>
-        /// content string identifier
+        /// content string
         /// </summary>
         public const string Content = "content";
+
+        /// <summary>
+        /// Success string
+        /// </summary>
+        public const string Success = "Success";
+
+        /// <summary>
+        /// Created string
+        /// </summary>
+        public const string Created = "Created";
+
+        /// <summary>
+        /// error string
+        /// </summary>
+        public const string Error = "error";
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
@@ -41,6 +41,7 @@ public static class OpenApiOperationExtensions
                 {
                     response = new()
                     {
+                        Description = Constants.Success,
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
                             {

--- a/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/OpenApiOperationExtensions.cs
@@ -20,48 +20,48 @@ public static class OpenApiOperationExtensions
     /// </summary>
     /// <param name="operation">The operation.</param>
     /// <param name="settings">The settings.</param>
-    /// <param name="addNoContent">Whether to add a 204 no content response.</param>
+    /// <param name="addNoContent">Optional: Whether to add a 204 no content response.</param>
     /// <param name="schema">Optional: The OpenAPI schema of the response.</param>
     public static void AddErrorResponses(this OpenApiOperation operation, OpenApiConvertSettings settings, bool addNoContent = false, OpenApiSchema schema = null)
     {
-        if (operation == null) {
-            throw Error.ArgumentNull(nameof(operation));
-        }
-        if(settings == null) {
-            throw Error.ArgumentNull(nameof(settings));
-        }
-
-		if(operation.Responses == null)
+        Utils.CheckArgumentNull(operation, nameof(operation));
+        Utils.CheckArgumentNull(settings, nameof(settings));
+        
+		if (operation.Responses == null)
 		{
 			operation.Responses = new();
 		}
 
         if (addNoContent)
-		{
-            if (settings.UseSuccessStatusCodeRange && schema != null)
+        {
+            if (settings.UseSuccessStatusCodeRange)
             {
-                OpenApiResponse response = new()
+                OpenApiResponse response = null;
+                if (schema != null)
                 {
-                    Content = new Dictionary<string, OpenApiMediaType>
+                    response = new()
                     {
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            Constants.ApplicationJsonMediaType,
-                            new OpenApiMediaType
                             {
-                                Schema = schema
+                                Constants.ApplicationJsonMediaType,
+                                new OpenApiMediaType
+                                {
+                                    Schema = schema
+                                }
                             }
                         }
-                    }                       
-                };
-                operation.Responses.Add(Constants.StatusCodeClass2XX, response);
+                    };
+                }
+                operation.Responses.Add(Constants.StatusCodeClass2XX, response ?? Constants.StatusCodeClass2XX.GetResponse());
             }
             else
             {
                 operation.Responses.Add(Constants.StatusCode204, Constants.StatusCode204.GetResponse());
             }
-		}
+        }
 
-        if(settings.ErrorResponsesAsDefault)
+        if (settings.ErrorResponsesAsDefault)
         {
             operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -385,7 +385,7 @@ namespace Microsoft.OpenApi.OData.Edm
                     currentPath.Pop();
                 }
 
-                if (sp.Name.Equals("content", StringComparison.OrdinalIgnoreCase))
+                if (sp.Name.Equals(Constants.Content, StringComparison.OrdinalIgnoreCase))
                 {
                     createValuePath = false;
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -27,21 +27,21 @@ namespace Microsoft.OpenApi.OData.Generator
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Response,
-                            Id = "error"
+                            Id = Constants.Error
                         }
                     }
                 },
 
-                { Constants.StatusCode204, new OpenApiResponse { Description = "Success"} },
-                { Constants.StatusCode201, new OpenApiResponse { Description = "Created"} },
-                { Constants.StatusCodeClass2XX, new OpenApiResponse { Description = "Success"} },
+                { Constants.StatusCode204, new OpenApiResponse { Description = Constants.Success} },
+                { Constants.StatusCode201, new OpenApiResponse { Description = Constants.Created} },
+                { Constants.StatusCodeClass2XX, new OpenApiResponse { Description = Constants.Success} },
                 { Constants.StatusCodeClass4XX, new OpenApiResponse
                     {
                         UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Response,
-                            Id = "error"
+                            Id = Constants.Error
                         }
                     }
                 },
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Response,
-                            Id = "error"
+                            Id = Constants.Error
                         }
                     }
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -33,6 +33,8 @@ namespace Microsoft.OpenApi.OData.Generator
                 },
 
                 { Constants.StatusCode204, new OpenApiResponse { Description = "Success"} },
+                { Constants.StatusCode201, new OpenApiResponse { Description = "Created"} },
+                { Constants.StatusCodeClass2XX, new OpenApiResponse { Description = "Success"} },
                 { Constants.StatusCodeClass4XX, new OpenApiResponse
                     {
                         UnresolvedReference = true,

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.3.0-preview2</Version>
+    <Version>1.3.0-preview3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -25,6 +25,7 @@
 - Skips adding a $count path if a similar count() function path exists #347
 - Checks whether path exists before adding it to the paths dictionary #343
 - Strips namespace prefix from operation segments and aliases type cast segments #348
+- Return response status code 2XX for PUT operations of stream properties when UseSuccessStatusCodeRange is enabled #310
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -34,23 +34,23 @@ namespace Microsoft.OpenApi.OData.Operation
             // Description
             if (LastSegmentIsStreamPropertySegment)
             {
-                IEdmVocabularyAnnotatable annotatable = GetAnnotatableElement();
+                (_, var property) = GetStreamElements();
                 string description;
 
-                if (annotatable is IEdmNavigationProperty)
+                if (property is IEdmNavigationProperty)
                 {
-                    ReadRestrictionsType readRestriction = Context.Model.GetRecord<NavigationRestrictionsType>(annotatable, CapabilitiesConstants.NavigationRestrictions)?
+                    ReadRestrictionsType readRestriction = Context.Model.GetRecord<NavigationRestrictionsType>(property, CapabilitiesConstants.NavigationRestrictions)?
                         .RestrictedProperties?.FirstOrDefault()?.ReadRestrictions;
 
                     description = LastSegmentIsKeySegment
                         ? readRestriction?.ReadByKeyRestrictions?.Description
                         : readRestriction?.Description
-                        ?? Context.Model.GetDescriptionAnnotation(annotatable);
+                        ?? Context.Model.GetDescriptionAnnotation(property);
                 }
                 else
                 {
                     // Structural property
-                    description = Context.Model.GetDescriptionAnnotation(annotatable);
+                    description = Context.Model.GetDescriptionAnnotation(property);
                 }
 
                 operation.Description = description;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
@@ -145,11 +145,11 @@ namespace Microsoft.OpenApi.OData.Operation
             };
 
             // Fetch the respective AcceptableMediaTypes
-            IEdmVocabularyAnnotatable annotatableElement = GetAnnotatableElement();
+            (_, var property) = GetStreamElements();
             IEnumerable<string> mediaTypes = null;
-            if (annotatableElement != null)
+            if (property != null)
             {
-                mediaTypes = Context.Model.GetCollection(annotatableElement,
+                mediaTypes = Context.Model.GetCollection(property,
                     CoreConstants.AcceptableMediaTypes);
             }
 
@@ -173,13 +173,13 @@ namespace Microsoft.OpenApi.OData.Operation
         }
 
         /// <summary>
-        /// Gets the annotatable stream property from the path segments.
+        /// Gets the stream property and entity type declaring the stream property.
         /// </summary>
-        /// <returns>The annotatable stream property.</returns>
-        protected IEdmVocabularyAnnotatable GetAnnotatableElement()
+        /// <returns>The stream property and entity type declaring the stream property.</returns>
+        protected (IEdmEntityType entityType, IEdmProperty property) GetStreamElements()
         {
             // Only ODataStreamPropertySegment is annotatable
-            if (!LastSegmentIsStreamPropertySegment) return null;
+            if (!LastSegmentIsStreamPropertySegment) return (null, null);
 
             // Retrieve the entity type of the segment before the stream property segment
             var entityType = Path.Segments.ElementAtOrDefault(Path.Segments.Count - 2).EntityType;
@@ -192,7 +192,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 property = GetNavigationProperty(entityType, lastSegmentProp.Identifier);
             }
 
-            return property;
+            return (entityType, property);
         }
 
         private IEdmStructuralProperty GetStructuralProperty(IEdmEntityType entityType, string identifier)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -135,6 +135,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         </Key>
         <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
         <Property Name=""Logo"" Type=""Edm.Stream""/>
+        <Property Name=""Content"" Type=""Edm.Stream""/>
         <Property Name = ""Description"" Type = ""Edm.String"" />
       </EntityType>
       <EntityType Name=""user"" OpenType=""true"">


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/310

This PR:
- Returns response status code 2XX for `PUT` operations of stream properties  when `UseSuccessStatusCodeRange` = `true`
- Adds schema reference to the content property of the response object of _content_ stream properties when `UseSuccessStatusCodeRange` = `true`.


Response object of the endpoint: `/drives/{drive-id}/items/{driveItem-id}/content` will be:
![image](https://user-images.githubusercontent.com/40403681/226278018-5fe9a34d-c795-41e5-b1d4-74e000bc9959.png)
when `UseSuccessStatusCodeRange` = `true`
