### PR TITLE
Adds `$value` segment to paths with entity types with base types with `HasStream=true`

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -391,10 +391,10 @@ namespace Microsoft.OpenApi.OData.Edm
                 }
             }
 
-            /* Create a /$value path only if entity has stream and
+            /* Append a $value segment only if entity (or base type) has stream and
              * does not contain a structural property named Content
              */
-            if (createValuePath && entityType.HasStream)
+            if (createValuePath && (entityType.HasStream || ((entityType.BaseType as IEdmEntityType)?.HasStream ?? false)))
             {
                 currentPath.Push(new ODataStreamContentSegment());
                 AppendPath(currentPath.Clone());

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.3.0-preview2</Version>
+    <Version>1.3.0-preview3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -25,6 +25,7 @@
 - Skips adding a $count path if a similar count() function path exists #347
 - Checks whether path exists before adding it to the paths dictionary #343
 - Strips namespace prefix from operation segments and aliases type cast segments #348
+- Adds $value segment to paths with entity types with base types with HasStream=true #314
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,9 +52,18 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
+            Assert.Equal(18054, paths.Count());
+            AssertGraphBetaModelPaths(paths);
+        }
+
+        private void AssertGraphBetaModelPaths(IEnumerable<ODataPath> paths)
+        {
+            // Test that $count and microsoft.graph.count() segments are not both created for the same path.
             Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/drives({id})/items({id1})/workbook/tables/$count")));
             Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/drives({id})/items({id1})/workbook/tables/microsoft.graph.count()")));
-            Assert.Equal(18024, paths.Count());
+
+            // Test that $value segments are created for entity types with base types with HasStream="true"
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/me/chats({id})/messages({id1})/hostedContents({id2})/$value")));
         }
 
         [Fact]
@@ -75,7 +84,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18675, paths.Count());
+            Assert.Equal(18705, paths.Count());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/314

This PR:
- Append a `$value` segment if base type of entity type has stream and does not contain a structural property named `content`
- Updates tests.