### PR TITLE
Uses `SemVerVersion` in place of `Version` to Get or Set the metadata version in the OpenAPI document

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiInfoGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiInfoGenerator.cs
@@ -75,7 +75,7 @@ namespace Microsoft.OpenApi.OData.Generator
             // If no Core.SchemaVersion is present, a default version has to be provided as this is a required OpenAPI field.
             // TODO: https://github.com/Microsoft/OpenAPI.NET.OData/issues/2
 
-            return context.Settings.Version.ToString();
+            return context.Settings.SemVerVersion;
         }
 
         private static string GetDescription(this ODataContext context)

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.3.0-preview3</Version>
+    <Version>1.3.0-preview4</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -27,6 +27,7 @@
 - Strips namespace prefix from operation segments and aliases type cast segments #348
 - Return response status code 2XX for PUT operations of stream properties when UseSuccessStatusCodeRange is enabled #310
 - Adds $value segment to paths with entity types with base types with HasStream=true #314
+- Uses SemVerVersion in place of Version to Get or Set the metadata version in the OpenAPI document #346
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -17,15 +17,29 @@ namespace Microsoft.OpenApi.OData
     /// </summary>
     public class OpenApiConvertSettings
     {
+        private Version _version = new(1, 0, 1);
         /// <summary>
         /// Gets/sets the service root.
         /// </summary>
         public Uri ServiceRoot { get; set; } = new Uri("http://localhost");
 
         /// <summary>
-        /// Gets/sets the metadata version.
+        /// [Obsolete] Use <see cref="SemVerVersion"/> to Get/set the metadata version.
         /// </summary>
-        public Version Version { get; set; } = new Version(1, 0, 1);
+        public Version Version 
+        { 
+            get => _version; 
+            set 
+            {
+                _version = value;
+                SemVerVersion = _version.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Get/set the metadata version.
+        /// </summary>
+        public string SemVerVersion { get; set; } = "1.0.0";
 
         /// <summary>
         /// Gets/set a value indicating whether to output key as segment path.
@@ -374,7 +388,8 @@ namespace Microsoft.OpenApi.OData
                 EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = this.EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty,
                 AddAlternateKeyPaths = this.AddAlternateKeyPaths,
                 NamespacePrefixToStripForInMethodPaths = this.NamespacePrefixToStripForInMethodPaths,
-                EnableAliasForTypeCastSegments = this.EnableAliasForTypeCastSegments
+                EnableAliasForTypeCastSegments = this.EnableAliasForTypeCastSegments,
+                SemVerVersion = this.SemVerVersion
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -24,8 +24,9 @@ namespace Microsoft.OpenApi.OData
         public Uri ServiceRoot { get; set; } = new Uri("http://localhost");
 
         /// <summary>
-        /// [Obsolete] Use <see cref="SemVerVersion"/> to Get/set the metadata version.
+        /// Get/set the metadata version.
         /// </summary>
+        [Obsolete("Use SemVerVersion to Get or Set the metadata version.")]
         public Version Version 
         { 
             get => _version; 

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -33,6 +33,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.NamespacePrefixToStripForInMethod
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RefBaseCollectionPaginationCountResponse.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.SemVerVersion.get -> string
+Microsoft.OpenApi.OData.OpenApiConvertSettings.SemVerVersion.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.UseSuccessStatusCodeRange.get -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
@@ -211,7 +211,7 @@ namespace Microsoft.OpenApi.OData.Tests
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableKeyAsSegment = true,
-                Version = new Version(1, 0, 1),
+                SemVerVersion = "1.0.1",
                 ServiceRoot = new Uri("http://services.odata.org/TrippinRESTierService"),
                 IEEE754Compatible = true,
                 OpenApiSpecVersion = specVersion,
@@ -246,7 +246,7 @@ namespace Microsoft.OpenApi.OData.Tests
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableKeyAsSegment = true,
-                Version = new Version(1, 0, 1),
+                Version = new Version(1, 2, 3), // test that the obsolete property still works
                 ServiceRoot = new Uri("http://services.odata.org/TrippinRESTierService"),
                 IEEE754Compatible = true,
                 OpenApiSpecVersion = specVersion,

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OData Service for namespace DefaultNs",
     "description": "This OData service is located at http://localhost",
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "host": "localhost",
   "schemes": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: OData Service for namespace DefaultNs
   description: This OData service is located at http://localhost
-  version: 1.0.1
+  version: 1.0.0
 host: localhost
 schemes:
   - http

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OData Service for namespace DefaultNs",
     "description": "This OData service is located at http://localhost",
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "servers": [
     {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: OData Service for namespace DefaultNs
   description: This OData service is located at http://localhost
-  version: 1.0.1
+  version: 1.0.0
 servers:
   - url: http://localhost
 paths:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OData Service for namespace ",
     "description": "This OData service is located at http://localhost",
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "host": "localhost",
   "schemes": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: 'OData Service for namespace '
   description: This OData service is located at http://localhost
-  version: 1.0.1
+  version: 1.0.0
 host: localhost
 schemes:
   - http

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OData Service for namespace ",
     "description": "This OData service is located at http://localhost",
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "servers": [
     {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: 'OData Service for namespace '
   description: This OData service is located at http://localhost
-  version: 1.0.1
+  version: 1.0.0
 servers:
   - url: http://localhost
 paths: { }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OData Service for namespace Default",
     "description": "This OData service is located at http://localhost",
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "host": "localhost",
   "schemes": [

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: OData Service for namespace Default
   description: This OData service is located at http://localhost
-  version: 1.0.1
+  version: 1.0.0
 host: localhost
 schemes:
   - http

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OData Service for namespace Default",
     "description": "This OData service is located at http://localhost",
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "servers": [
     {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: OData Service for namespace Default
   description: This OData service is located at http://localhost
-  version: 1.0.1
+  version: 1.0.0
 servers:
   - url: http://localhost
 paths:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
   description: This OData service is located at http://services.odata.org/TrippinRESTierService
-  version: 1.0.1
+  version: '1.2.3'
 host: services.odata.org
 basePath: /TrippinRESTierService
 schemes:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: OData Service for namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
   description: This OData service is located at http://services.odata.org/TrippinRESTierService
-  version: 1.0.1
+  version: '1.2.3'
 servers:
   - url: http://services.odata.org/TrippinRESTierService
 paths:


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/346