### PR TITLE
[Fix] Adds support for all `Org.OData.Core.V1.RevisionKind` enum values

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataContext.cs
@@ -173,12 +173,12 @@ namespace Microsoft.OpenApi.OData.Edm
                 yield return path;
             }
         }
-        internal IEnumerable<DeprecatedRevisionsType> GetDeprecationInformations(IEdmVocabularyAnnotatable annotable)
+        internal IEnumerable<RevisionRecord> GetDeprecationInformations(IEdmVocabularyAnnotatable annotable)
         {
             return annotable == null ?
-                Enumerable.Empty<DeprecatedRevisionsType>() :
-                    (Model?.GetCollection<DeprecatedRevisionsType>(annotable, CoreConstants.Revisions) ?? 
-                    Enumerable.Empty<DeprecatedRevisionsType>());
+                Enumerable.Empty<RevisionRecord>() :
+                    (Model?.GetCollection<RevisionRecord>(annotable, CoreConstants.Revisions)?.Where(x => x.Kind == RevisionKind.Deprecated) ?? 
+                    Enumerable.Empty<RevisionRecord>());
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.4.0-preview2</Version>
+    <Version>1.4.0-preview3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -23,6 +23,7 @@
     <PackageReleaseNotes>
 - DELETE methods should always return response status code #204
 - Aliases or strips namespace prefixes from segment names when and where applicable #365
+- Adds support for all Org.OData.Core.V1.RevisionKind enum values #372
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionRecord.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionRecord.cs
@@ -9,34 +9,31 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Core;
 /// Specialized type for Org.OData.Core.V1.Revisions to easily access the additional properties.
 /// </summary>
 [Term("Org.OData.Core.V1.Revisions")]
-internal class DeprecatedRevisionsType : RevisionsType
+internal class RevisionRecord : RevisionType
 {
 	/// <summary>
-	/// The date at which the element has been/will be removed entirely from the service.
+	/// The date at which the element was/will be added, modified or deprecated from the service.
 	/// </summary>
 	public DateTime? RemovalDate { get; private set; }
+    /// <summary>
+    /// The date at which the element was/will be be added, modified or deprecated from.
+    /// </summary>
+    public DateTime? Date { get; private set; }
 	/// <summary>
-	/// The date at which the element has been/will be deprecated.
-	/// </summary>
-	public DateTime? Date { get; private set; }
-	/// <summary>
-	/// Init the <see cref="DeprecatedRevisionsType"/>.
+	/// Init the <see cref="RevisionRecord"/>.
 	/// </summary>
 	/// <param name="record">The input record.</param>
 	public override void Initialize(IEdmRecordExpression record)
 	{
 		base.Initialize(record);
-		if (Kind != RevisionKind.Deprecated)
-		{
-			throw new InvalidOperationException("The kind of the revision must be Deprecated.");
-		}
 		RemovalDate = record.GetDateTime(nameof(RemovalDate));
 		Date = record.GetDateTime(nameof(Date));
 	}
-	/// <summary>
-	/// Gets a <see cref="OpenApiDeprecationExtension"/> from the current annotation.
-	/// </summary>
-	internal OpenApiDeprecationExtension GetOpenApiExtension()
+
+    /// <summary>
+    /// Gets a <see cref="OpenApiDeprecationExtension"/> from the current annotation.
+    /// </summary>
+    internal OpenApiDeprecationExtension GetOpenApiExtension()
 	{
 		return new OpenApiDeprecationExtension
 		{

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/RevisionType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Core;
 /// Complex Type: Org.OData.Core.V1.Revisions
 /// </summary>
 [Term("Org.OData.Core.V1.Revisions")]
-internal class RevisionsType : IRecord
+internal class RevisionType : IRecord
 {
 	/// <summary>
 	/// The version this revision was introduced.
@@ -24,7 +24,7 @@ internal class RevisionsType : IRecord
 	/// </summary>
 	public string Description { get; private set; }
 	/// <summary>
-	/// Init the <see cref="RevisionsType"/>.
+	/// Init the <see cref="RevisionType"/>.
 	/// </summary>
 	/// <param name="record">The input record.</param>
 	public virtual void Initialize(IEdmRecordExpression record)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Vocabulary/Capabilities/RevisionRecordTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Vocabulary/Capabilities/RevisionRecordTests.cs
@@ -11,13 +11,13 @@ using Xunit;
 
 namespace Microsoft.OpenApi.OData.Reader.Vocabulary.Capabilities.Tests;
 
-public class DeprecatedRevisionTypeTests
+public class RevisionRecordTests
 {
     [Fact]
     public void DefaultPropertyAsNull()
     {
         // Arrange & Act
-        DeprecatedRevisionsType revision = new();
+        RevisionRecord revision = new();
 
         // Assert
         Assert.Null(revision.Date);
@@ -30,7 +30,7 @@ public class DeprecatedRevisionTypeTests
     public void InitializeWithNullRecordThrows()
     {
         // Arrange & Act
-        DeprecatedRevisionsType revision = new();
+        RevisionRecord revision = new();
 
         // Assert
         Assert.Throws<ArgumentNullException>("record", () => revision.Initialize(record: null));
@@ -50,7 +50,7 @@ public class DeprecatedRevisionTypeTests
             new EdmPropertyConstructor("Version", new EdmStringConstant("2021-05/test")));
 
         // Act
-        DeprecatedRevisionsType revision = new();
+        RevisionRecord revision = new();
         revision.Initialize(record);
 
         // Assert
@@ -67,20 +67,32 @@ public class DeprecatedRevisionTypeTests
         Assert.Equal(new DateTime(2021, 10, 24), revision.RemovalDate);
     }
     [Fact]
-    public void ThrowsOnWrongKind()
+    public void WorksForAllKinds()
     {
         // Arrange
-        IEdmRecordExpression record = new EdmRecordExpression(
+        IEdmRecordExpression record1 = new EdmRecordExpression(
             new EdmPropertyConstructor("Date", new EdmDateConstant(new Date(2021, 8, 24))),
             new EdmPropertyConstructor("RemovalDate", new EdmDateConstant(new Date(2021, 10, 24))),
             new EdmPropertyConstructor("Kind", new EdmEnumMemberExpression(addedValue)), 
             new EdmPropertyConstructor("Description", new EdmStringConstant("The identityProvider API is deprecated and will stop returning data on March 2023. Please use the new identityProviderBase API.")),
             new EdmPropertyConstructor("Version", new EdmStringConstant("2021-05/test")));
 
+        IEdmRecordExpression record2 = new EdmRecordExpression(
+            new EdmPropertyConstructor("Date", new EdmDateConstant(new Date(2023, 3, 2))),
+            new EdmPropertyConstructor("RemovalDate", new EdmDateConstant(new Date(2023, 05, 30))),
+            new EdmPropertyConstructor("Kind", new EdmEnumMemberExpression(deprecatedValue)),
+            new EdmPropertyConstructor("Description", new EdmStringConstant("Private preview test.")),
+            new EdmPropertyConstructor("Version", new EdmStringConstant("2023-03/test")));
+
         // Act
-        DeprecatedRevisionsType revision = new();
+        RevisionRecord revision1 = new();
+        revision1.Initialize(record1);
+        
+        RevisionRecord revision2 = new();
+        revision2.Initialize(record2);
 
         // Assert
-        Assert.Throws<InvalidOperationException>(() => revision.Initialize(record));
+        Assert.Equal(RevisionKind.Added, revision1.Kind);
+        Assert.Equal(RevisionKind.Deprecated, revision2.Kind);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/372