### PR TITLE
Use directly annotated `CountRestriction` annotations when creating `$count` segments for col-valued navigation properties

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.4.0-preview3</Version>
+    <Version>1.4.0-preview4</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -24,6 +24,7 @@
 - DELETE methods should always return response status code #204
 - Aliases or strips namespace prefixes from segment names when and where applicable #365
 - Adds support for all Org.OData.Core.V1.RevisionKind enum values #372
+- Use directly annotated CountRestriction annotations when creating $count segments for collection-valued navigation properties #328
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18054, paths.Count());
+            Assert.Equal(18050, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -64,6 +64,9 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Test that $value segments are created for entity types with base types with HasStream="true"
             Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/me/chats({id})/messages({id1})/hostedContents({id2})/$value")));
+
+            // Test that count restrictions annotations for navigation properties work
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/me/drives/$count")));
         }
 
         [Fact]
@@ -84,7 +87,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18705, paths.Count());
+            Assert.Equal(18701, paths.Count());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/364

This PR:
- Gets the directly annotated `CountRestriction` annotation for navigation properties. Uses this annotation (if exists) to determine whether or not to create $count segments for navigation properties.
- Update integration tests.
- Update release notes.

Related to:
- https://github.com/microsoftgraph/msgraph-metadata/issues/328
- https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/2472