### PR TITLE
[Feature] Use `MediaType` annotation to set the content type of operations with `Edm.Stream` return types

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiResponseGenerator.cs
@@ -9,6 +9,7 @@ using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 
 namespace Microsoft.OpenApi.OData.Generator
 {
@@ -271,8 +272,13 @@ namespace Microsoft.OpenApi.OData.Generator
             string mediaType = Constants.ApplicationJsonMediaType;
             if (operation.ReturnType.AsPrimitive()?.PrimitiveKind() == EdmPrimitiveTypeKind.Stream)
             {
-                // Responses of types Edm.Stream should be application/octet-stream
-                mediaType = Constants.ApplicationOctetStreamMediaType;
+                mediaType = context.Model.GetString(operation, CoreConstants.MediaType);
+
+                if (string.IsNullOrEmpty(mediaType))
+                {
+                    // Use default if MediaType annotation is not specified
+                    mediaType = Constants.ApplicationOctetStreamMediaType;
+                }
             }
 
             OpenApiResponse response = new()

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/CoreConstants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/CoreConstants.cs
@@ -26,6 +26,11 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Core
         public const string AcceptableMediaTypes = "Org.OData.Core.V1.AcceptableMediaTypes";
 
         /// <summary>
+        /// Org.OData.Core.V1.MediaType
+        /// </summary>
+        public const string MediaType = "Org.OData.Core.V1.MediaType";
+
+        /// <summary>
         /// Org.OData.Core.V1.Computed
         /// </summary>
         public const string Computed = "Org.OData.Core.V1.Computed";

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -231,26 +231,40 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
         public void CreateResponseForEdmFunctionOfStreamReturnTypeReturnsCorrectResponse()
         {
             // Arrange
-            string operationName = "getMailboxUsageStorage";
+            string operationName1 = "getMailboxUsageStorage";
+            string operationName2 = "incidentReport";
             IEdmModel model = EdmModelHelper.GraphBetaModel;
             ODataContext context = new(model);
 
             // Act
-            OpenApiResponses responses;
-            IEdmOperation operation = model.SchemaElements.OfType<IEdmOperation>().First(o => o.Name == operationName);
-            Assert.NotNull(operation); // guard
-            ODataPath path = new(new ODataOperationSegment(operation));
-            responses = context.CreateResponses(operation);
+            IEdmOperation operation1 = model.SchemaElements.OfType<IEdmOperation>().First(o => o.Name == operationName1);
+            IEdmOperation operation2 = model.SchemaElements.OfType<IEdmOperation>().First(o => o.Name == operationName2);
+            Assert.NotNull(operation1);
+            Assert.NotNull(operation2);
+            ODataPath path1 = new(new ODataOperationSegment(operation1));
+            ODataPath path2 = new(new ODataOperationSegment(operation2));
+            OpenApiResponses responses1 = context.CreateResponses(operation1);
+            OpenApiResponses responses2 = context.CreateResponses(operation2);
 
-            // Assert
-            Assert.NotNull(responses);
-            Assert.NotEmpty(responses);
-            Assert.Equal(2, responses.Count);
-            Assert.Equal(new string[] { "200", "default" }, responses.Select(r => r.Key));
+            // Assert for operation1 --> getMailboxUsageStorage
+            Assert.NotNull(responses1);
+            Assert.NotEmpty(responses1);
+            Assert.Equal(2, responses1.Count);
+            Assert.Equal(new string[] { "200", "default" }, responses1.Select(r => r.Key));
 
-            OpenApiResponse response = responses["200"];
+            OpenApiResponse response = responses1["200"];
             Assert.NotNull(response.Content);
-            OpenApiMediaType mediaType = response.Content["application/octet-stream"];
+            Assert.Equal("application/octet-stream", response.Content.First().Key);
+
+            // Assert for operation2 --> incidentReport
+            Assert.NotNull(responses2);
+            Assert.NotEmpty(responses2);
+            Assert.Equal(2, responses2.Count);
+            Assert.Equal(new string[] { "200", "default" }, responses2.Select(r => r.Key));
+
+            response = responses2["200"];
+            Assert.NotNull(response.Content);
+            Assert.Equal("text/html", response.Content.First().Key);
         }
 
         [Theory]


### PR DESCRIPTION
Closes https://github.com/microsoft/OpenAPI.NET.OData/issues/342

This PR:
- Uses the `MediaType` annotation to set the content type for an operation with `Edm.Stream` return type.
- Updates unit test and integration file to validate the above.
- Updates release notes.