### PR TITLE
[Fix] Retrieves navigation properties from base types

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -274,7 +274,7 @@ namespace Microsoft.OpenApi.OData.Edm
             RetrieveComplexPropertyPaths(entityType, path, convertSettings);
 
             // navigation property
-            foreach (IEdmNavigationProperty np in entityType.DeclaredNavigationProperties())
+            foreach (IEdmNavigationProperty np in entityType.NavigationProperties())
             {
                 if (CanFilter(np))
                 {
@@ -553,7 +553,7 @@ namespace Microsoft.OpenApi.OData.Edm
                     if (shouldExpand)
                     {
                         // expand to sub navigation properties
-                        foreach (IEdmNavigationProperty subNavProperty in navEntityType.DeclaredNavigationProperties())
+                        foreach (IEdmNavigationProperty subNavProperty in navEntityType.NavigationProperties())
                         {
                             if (CanFilter(subNavProperty))
                             {
@@ -693,7 +693,7 @@ namespace Microsoft.OpenApi.OData.Edm
                             continue;
                         }
 
-                        foreach (var declaredNavigationProperty in targetType.DeclaredNavigationProperties())
+                        foreach (var declaredNavigationProperty in targetType.NavigationProperties())
                         {
                             RetrieveNavigationPropertyPaths(declaredNavigationProperty, null, castPath, convertSettings);
                         }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.4.0-preview5</Version>
+    <Version>1.4.0-preview6</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -25,7 +25,8 @@
 - Aliases or strips namespace prefixes from segment names when and where applicable #365
 - Adds support for all Org.OData.Core.V1.RevisionKind enum values #372
 - Use directly annotated CountRestriction annotations when creating $count segments for collection-valued navigation properties #328
-- Use MediaType annotation to set the content types of operations with Edm.Stream return types #342 
+- Use MediaType annotation to set the content types of operations with Edm.Stream return types #342
+- Retrieves navigation properties from base types #371
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18050, paths.Count());
+            Assert.Equal(18409, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -87,7 +87,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18701, paths.Count());
+            Assert.Equal(19060, paths.Count());
         }
 
         [Theory]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -67,6 +67,9 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Test that count restrictions annotations for navigation properties work
             Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/me/drives/$count")));
+
+            // Test that navigation properties on base types are created
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/print/printers({id})/jobs")));
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1748,7 +1748,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
     },
     "/Me/BestFriend/$ref": {
       "get": {
@@ -2474,7 +2478,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
     },
     "/Me/Friends/{UserName}/$ref": {
       "delete": {
@@ -3757,6 +3765,1641 @@
       },
       "x-description": "Casts the previous resource to Employee."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateBestFriend",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/BestFriend",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetRefBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateRefBestFriend",
+        "parameters": [
+          {
+            "$ref": "#/parameters/refPutBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for Me",
+        "operationId": "Me.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.BestFriend.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount-81de",
+        "parameters": [
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.ListAddressInfo.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c",
+        "parameters": [
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.BestFriend.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.GetHomeAddress.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "Me.GetBestFriend.AsManager",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to Manager."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Friends from Me",
+        "operationId": "Me.ListFriends",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Friends",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/$ref": {
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.Friends.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.Friends.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.AddressInfo.GetCount-660e",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.Friends.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.Friends.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "Me.GetFriends.AsManager",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to Manager."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.GetCount-0cb7",
+        "parameters": [
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of Friends from Me",
+        "operationId": "Me.ListRefFriends",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for Me",
+        "operationId": "Me.CreateRefFriends",
+        "parameters": [
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "Me.ListFriends.AsManager",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to Manager."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.ListFriends.GetCount.AsManager-85ff",
+        "parameters": [
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
         "tags": [
@@ -4505,6 +6148,836 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "Me.ListTrips",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "Me.CreateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips",
+        "/Me/Trips"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "Me.GetTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "Me.UpdateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "Me.DeleteTrips",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}",
+        "/Me/Trips/{TripId}"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-description": "Provides operations to call the GetInvolvedPeople method.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems": {
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from Me",
+        "operationId": "Me.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "ConfirmationCode",
+                "StartsAt",
+                "EndsAt",
+                "Duration"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems",
+        "/Me/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "path",
+            "name": "PlanItemId",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.PlanItems.GetCount-a822",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref": {
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from Me",
+        "operationId": "Me.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for Me",
+        "operationId": "Me.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.GetCount-5aa2",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
       "get": {
         "tags": [
@@ -4731,6 +7204,672 @@
         }
       },
       "x-description": "Casts the previous resource to Manager."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateBestFriend",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/BestFriend",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetRefBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateRefBestFriend",
+        "parameters": [
+          {
+            "$ref": "#/parameters/refPutBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for Me",
+        "operationId": "Me.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.BestFriend.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount-6ea6",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.ListAddressInfo.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.BestFriend.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.GetHomeAddress.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "Me.GetBestFriend.AsEmployee",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -5102,6 +8241,12 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -5173,6 +8318,12 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
           },
           {
             "$ref": "#/parameters/search"
@@ -5480,6 +8631,987 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Friends from Me",
+        "operationId": "Me.ListFriends",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Friends",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/$ref": {
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.Friends.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.Friends.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.AddressInfo.GetCount-b7db",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.Friends.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.Friends.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "Me.GetFriends.AsEmployee",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to Employee."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.GetCount-60a7",
+        "parameters": [
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of Friends from Me",
+        "operationId": "Me.ListRefFriends",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for Me",
+        "operationId": "Me.CreateRefFriends",
+        "parameters": [
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "Me.ListFriends.AsEmployee",
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Casts the previous resource to Employee."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.ListFriends.GetCount.AsEmployee-6a35",
+        "parameters": [
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire": {
       "post": {
         "tags": [
@@ -5525,6 +9657,836 @@
         "x-ms-docs-operation-type": "action"
       },
       "x-description": "Provides operations to call the Hire method."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "Me.ListTrips",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "Me.CreateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/Me/Trips"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "Me.GetTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "Me.UpdateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "Me.DeleteTrips",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/Me/Trips/{TripId}"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-description": "Provides operations to call the GetInvolvedPeople method.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems": {
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from Me",
+        "operationId": "Me.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "ConfirmationCode",
+                "StartsAt",
+                "EndsAt",
+                "Duration"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/Me/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "path",
+            "name": "PlanItemId",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.PlanItems.GetCount-5ad2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref": {
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from Me",
+        "operationId": "Me.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for Me",
+        "operationId": "Me.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count": {
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.GetCount-f3f4",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
       "post": {
@@ -5745,7 +10707,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips"
+      ]
     },
     "/Me/Trips/{TripId}": {
       "get": {
@@ -5916,7 +10882,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}"
+      ]
     },
     "/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
       "get": {
@@ -6043,7 +11013,11 @@
         },
         "x-ms-docs-operation-type": "function"
       },
-      "x-description": "Provides operations to call the GetInvolvedPeople method."
+      "x-description": "Provides operations to call the GetInvolvedPeople method.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
     },
     "/Me/Trips/{TripId}/PlanItems": {
       "get": {
@@ -6146,7 +11120,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity."
+      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems"
+      ]
     },
     "/Me/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
       "delete": {
@@ -11099,7 +16077,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
     },
     "/People/{UserName}/BestFriend/$ref": {
       "get": {
@@ -11951,7 +16933,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
     },
     "/People/{UserName}/Friends/{UserName1}/$ref": {
       "delete": {
@@ -13426,6 +18412,1903 @@
       },
       "x-description": "Casts the previous resource to Employee."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateBestFriend",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/BestFriend",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetRefBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateRefBestFriend",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/refPutBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for People",
+        "operationId": "People.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.BestFriend.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.AddressInfo.GetCount-cb8a",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.BestFriend.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "People.GetBestFriend.AsManager",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to Manager."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Friends from People",
+        "operationId": "People.ListFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Friends",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/$ref": {
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.Friends.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.Friends.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.AddressInfo.GetCount-1e8b",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.Friends.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.Friends.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "People.GetFriends.AsManager",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to Manager."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.GetCount-4db4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of Friends from People",
+        "operationId": "People.ListRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for People",
+        "operationId": "People.CreateRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "People.ListFriends.AsManager",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to Manager."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.ListFriends.GetCount.AsManager-b145",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "get": {
         "tags": [
@@ -14286,6 +21169,932 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "People.ListTrips",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "People.CreateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips",
+        "/People/{UserName}/Trips"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "People.GetTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "People.UpdateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "People.DeleteTrips",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}",
+        "/People/{UserName}/Trips/{TripId}"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-description": "Provides operations to call the GetInvolvedPeople method.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems": {
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from People",
+        "operationId": "People.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "ConfirmationCode",
+                "StartsAt",
+                "EndsAt",
+                "Duration"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems",
+        "/People/{UserName}/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "path",
+            "name": "PlanItemId",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.PlanItems.GetCount-7df9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref": {
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from People",
+        "operationId": "People.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for People",
+        "operationId": "People.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.GetCount-c760",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
       "get": {
         "tags": [
@@ -14552,6 +22361,798 @@
         }
       },
       "x-description": "Casts the previous resource to Manager."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateBestFriend",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/BestFriend",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetRefBestFriend",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateRefBestFriend",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/refPutBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for People",
+        "operationId": "People.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.BestFriend.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.AddressInfo.GetCount-5a39",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.BestFriend.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "People.GetBestFriend.AsEmployee",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to Employee."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
@@ -14971,6 +23572,12 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -15058,6 +23665,12 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
           },
           {
             "$ref": "#/parameters/search"
@@ -15413,6 +24026,1123 @@
       },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Friends from People",
+        "operationId": "People.ListFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Friends",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/$ref": {
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "Address desc",
+                "City",
+                "City desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.Friends.UpdateAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.Friends.SetAddressInfo",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/$count": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.AddressInfo.GetCount-f486",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.Friends.GetHomeAddress",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "Address",
+                "City"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.Friends.UpdateHomeAddress",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "People.GetFriends.AsEmployee",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to Employee."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.GetCount-1c0c",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of Friends from People",
+        "operationId": "People.ListRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for People",
+        "operationId": "People.CreateRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "People.ListFriends.AsEmployee",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Casts the previous resource to Employee."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.ListFriends.GetCount.AsEmployee-f325",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire": {
       "post": {
         "tags": [
@@ -15466,6 +25196,932 @@
         "x-ms-docs-operation-type": "action"
       },
       "x-description": "Provides operations to call the Hire method."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "People.ListTrips",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "Description",
+                "Description desc",
+                "Tags",
+                "Tags desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "People.CreateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/People/{UserName}/Trips"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "People.GetTrips",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Name",
+                "Budget",
+                "Description",
+                "Tags",
+                "StartsAt",
+                "EndsAt",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "People.UpdateTrips",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New navigation property values",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "People.DeleteTrips",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/People/{UserName}/Trips/{TripId}"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "MiddleName",
+                "Gender",
+                "Age",
+                "Emails",
+                "AddressInfo",
+                "HomeAddress",
+                "FavoriteFeature",
+                "Features",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "MiddleName",
+                "MiddleName desc",
+                "Gender",
+                "Gender desc",
+                "Age",
+                "Age desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "HomeAddress",
+                "HomeAddress desc",
+                "FavoriteFeature",
+                "FavoriteFeature desc",
+                "Features",
+                "Features desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-description": "Provides operations to call the GetInvolvedPeople method.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems": {
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from People",
+        "operationId": "People.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$select",
+            "description": "Select properties to be returned",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "ConfirmationCode",
+                "StartsAt",
+                "EndsAt",
+                "Duration"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/People/{UserName}/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "path",
+            "name": "PlanItemId",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "Delete Uri",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count": {
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.PlanItems.GetCount-fa08",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref": {
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from People",
+        "operationId": "People.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "in": "query",
+            "name": "$orderby",
+            "description": "Order items by property values",
+            "type": "array",
+            "items": {
+              "enum": [
+                "PlanItemId",
+                "PlanItemId desc",
+                "ConfirmationCode",
+                "ConfirmationCode desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Duration",
+                "Duration desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for People",
+        "operationId": "People.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-description": "Provides operations to manage the collection of Person entities."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count": {
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.GetCount-1f8c",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "$ref": "#/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to count the resources in the collection."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
       "post": {
@@ -15718,7 +26374,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}": {
       "get": {
@@ -15913,7 +26573,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity."
+      "x-description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
       "get": {
@@ -16048,7 +26712,11 @@
         },
         "x-ms-docs-operation-type": "function"
       },
-      "x-description": "Provides operations to call the GetInvolvedPeople method."
+      "x-description": "Provides operations to call the GetInvolvedPeople method.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}/PlanItems": {
       "get": {
@@ -16159,7 +26827,11 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity."
+      "x-description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
       "delete": {
@@ -17962,20 +28634,20 @@
       "x-ms-docs-toc-type": "page"
     },
     {
-      "name": "Me.Functions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
-      "name": "Me.Actions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
       "name": "Me.Trip",
       "x-ms-docs-toc-type": "page"
     },
     {
+      "name": "Me.Functions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
       "name": "Me.Trips.PlanItem",
       "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Me.Actions",
+      "x-ms-docs-toc-type": "container"
     },
     {
       "name": "NewComePeople.Person",
@@ -18018,20 +28690,20 @@
       "x-ms-docs-toc-type": "page"
     },
     {
-      "name": "People.Functions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
-      "name": "People.Actions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
       "name": "People.Trip",
       "x-ms-docs-toc-type": "page"
     },
     {
+      "name": "People.Functions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
       "name": "People.Trips.PlanItem",
       "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "People.Actions",
+      "x-ms-docs-toc-type": "container"
     },
     {
       "name": "ResetDataSource",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1182,6 +1182,9 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend
   /Me/BestFriend/$ref:
     get:
       tags:
@@ -1693,6 +1696,9 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends
   '/Me/Friends/{UserName}/$ref':
     delete:
       tags:
@@ -2597,6 +2603,1152 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Employee.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend:
+    get:
+      tags:
+        - Me.Person
+      summary: Get BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateBestFriend
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/BestFriend
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref:
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetRefBestFriend
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateRefBestFriend
+      parameters:
+        - $ref: '#/parameters/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property BestFriend for Me
+      operationId: Me.DeleteRefBestFriend
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.BestFriend.ListAddressInfo
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.BestFriend.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.BestFriend.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.AddressInfo.GetCount-81de
+      parameters:
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.ListAddressInfo.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c
+      parameters:
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.BestFriend.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.BestFriend.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.GetHomeAddress.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: Me.GetBestFriend.AsManager
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Manager.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Friends from Me
+      operationId: Me.ListFriends
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/Friends
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/$ref':
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.Friends.ListAddressInfo
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.Friends.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.Friends.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/$count':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.Friends.AddressInfo.GetCount-660e
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.Friends.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.Friends.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: Me.GetFriends.AsManager
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Manager.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.Friends.GetCount-0cb7
+      parameters:
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref:
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of Friends from Me
+      operationId: Me.ListRefFriends
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Person
+      summary: Create new navigation property ref to Friends for Me
+      operationId: Me.CreateRefFriends
+      parameters:
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: Me.ListFriends.AsManager
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Manager.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.ListFriends.GetCount.AsManager-85ff
+      parameters:
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers:
     get:
       tags:
@@ -3116,6 +4268,599 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips:
+    get:
+      tags:
+        - Me.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: Me.ListTrips
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: Me.CreateTrips
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New navigation property
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '201':
+          description: Created navigation property.
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips
+      - /Me/Trips
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}':
+    get:
+      tags:
+        - Me.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: Me.GetTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: Me.UpdateTrips
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: Me.DeleteTrips
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
+      - '/Me/Trips/{TripId}'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            title: Collection of Person
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: function
+    x-description: Provides operations to call the GetInvolvedPeople method.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems':
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get PlanItems from Me
+      operationId: Me.Trips.ListPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - ConfirmationCode
+              - StartsAt
+              - EndsAt
+              - Duration
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
+      - '/Me/Trips/{TripId}/PlanItems'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: path
+          name: PlanItemId
+          description: The unique identifier of PlanItem
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: PlanItem
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count':
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: Me.Trips.PlanItems.GetCount-a822
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref':
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get ref of PlanItems from Me
+      operationId: Me.Trips.ListRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for Me
+      operationId: Me.Trips.CreateRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count:
+    get:
+      tags:
+        - Me.Trip
+      summary: Get the number of the resource
+      operationId: Me.Trips.GetCount-5aa2
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline():
     get:
       tags:
@@ -3280,6 +5025,471 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Manager.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend:
+    get:
+      tags:
+        - Me.Person
+      summary: Get BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateBestFriend
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/BestFriend
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref:
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetRefBestFriend
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateRefBestFriend
+      parameters:
+        - $ref: '#/parameters/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property BestFriend for Me
+      operationId: Me.DeleteRefBestFriend
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.BestFriend.ListAddressInfo
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.BestFriend.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.BestFriend.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.AddressInfo.GetCount-6ea6
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.ListAddressInfo.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    get:
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.BestFriend.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.BestFriend.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.GetHomeAddress.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: Me.GetBestFriend.AsEmployee
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Employee.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     get:
       tags:
@@ -3540,6 +5750,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3590,6 +5804,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3799,6 +6017,695 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Friends from Me
+      operationId: Me.ListFriends
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/Friends
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/$ref':
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.Friends.ListAddressInfo
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.Friends.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.Friends.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/$count':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.Friends.AddressInfo.GetCount-b7db
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.Friends.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.Friends.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: Me.GetFriends.AsEmployee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Employee.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.Friends.GetCount-60a7
+      parameters:
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref:
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of Friends from Me
+      operationId: Me.ListRefFriends
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Person
+      summary: Create new navigation property ref to Friends for Me
+      operationId: Me.CreateRefFriends
+      parameters:
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: Me.ListFriends.AsEmployee
+      parameters:
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Casts the previous resource to Employee.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count:
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.ListFriends.GetCount.AsEmployee-6a35
+      parameters:
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire:
     post:
       tags:
@@ -3831,6 +6738,599 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the Hire method.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips:
+    get:
+      tags:
+        - Me.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: Me.ListTrips
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: Me.CreateTrips
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: New navigation property
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '201':
+          description: Created navigation property.
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips
+      - /Me/Trips
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}':
+    get:
+      tags:
+        - Me.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: Me.GetTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: Me.UpdateTrips
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: Me.DeleteTrips
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/Me/Trips/{TripId}'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            title: Collection of Person
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: function
+    x-description: Provides operations to call the GetInvolvedPeople method.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems':
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get PlanItems from Me
+      operationId: Me.Trips.ListPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - ConfirmationCode
+              - StartsAt
+              - EndsAt
+              - Duration
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/Me/Trips/{TripId}/PlanItems'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: path
+          name: PlanItemId
+          description: The unique identifier of PlanItem
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: PlanItem
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count':
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: Me.Trips.PlanItems.GetCount-5ad2
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref':
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get ref of PlanItems from Me
+      operationId: Me.Trips.ListRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for Me
+      operationId: Me.Trips.CreateRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count:
+    get:
+      tags:
+        - Me.Trip
+      summary: Get the number of the resource
+      operationId: Me.Trips.GetCount-f3f4
+      parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to count the resources in the collection.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip:
     post:
       tags:
@@ -3987,6 +7487,9 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips
   '/Me/Trips/{TripId}':
     get:
       tags:
@@ -4114,6 +7617,9 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
   '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
     get:
       tags:
@@ -4208,6 +7714,9 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetInvolvedPeople method.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
   '/Me/Trips/{TripId}/PlanItems':
     get:
       tags:
@@ -4279,6 +7788,9 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
   '/Me/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
     delete:
       tags:
@@ -7738,6 +11250,9 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend'
   '/People/{UserName}/BestFriend/$ref':
     get:
       tags:
@@ -8342,6 +11857,9 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends'
   '/People/{UserName}/Friends/{UserName1}/$ref':
     delete:
       tags:
@@ -9389,6 +12907,1347 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Employee.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend':
+    get:
+      tags:
+        - People.Person
+      summary: Get BestFriend from People
+      description: The best friend.
+      operationId: People.GetBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateBestFriend
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/BestFriend'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref':
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of BestFriend from People
+      description: The best friend.
+      operationId: People.GetRefBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateRefBestFriend
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property BestFriend for People
+      operationId: People.DeleteRefBestFriend
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.BestFriend.ListAddressInfo
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.BestFriend.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.BestFriend.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.BestFriend.AddressInfo.GetCount-cb8a
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.ListAddressInfo.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.BestFriend.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.BestFriend.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.GetHomeAddress.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: People.GetBestFriend.AsManager
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends':
+    get:
+      tags:
+        - People.Person
+      summary: Get Friends from People
+      operationId: People.ListFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Friends'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/$ref':
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.Friends.ListAddressInfo
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.Friends.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.Friends.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/$count':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.Friends.AddressInfo.GetCount-1e8b
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.Friends.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.Friends.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: People.GetFriends.AsManager
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count':
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.Friends.GetCount-4db4
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref':
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of Friends from People
+      operationId: People.ListRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Person
+      summary: Create new navigation property ref to Friends for People
+      operationId: People.CreateRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    get:
+      tags:
+        - People.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: People.ListFriends.AsManager
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count':
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.ListFriends.GetCount.AsManager-b145
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     get:
       tags:
@@ -9992,6 +14851,671 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips':
+    get:
+      tags:
+        - People.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: People.ListTrips
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: People.CreateTrips
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '201':
+          description: Created navigation property.
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips'
+      - '/People/{UserName}/Trips'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}':
+    get:
+      tags:
+        - People.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: People.GetTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: People.UpdateTrips
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: People.DeleteTrips
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
+      - '/People/{UserName}/Trips/{TripId}'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            title: Collection of Person
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: function
+    x-description: Provides operations to call the GetInvolvedPeople method.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems':
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get PlanItems from People
+      operationId: People.Trips.ListPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - ConfirmationCode
+              - StartsAt
+              - EndsAt
+              - Duration
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
+      - '/People/{UserName}/Trips/{TripId}/PlanItems'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: path
+          name: PlanItemId
+          description: The unique identifier of PlanItem
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: PlanItem
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count':
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: People.Trips.PlanItems.GetCount-7df9
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref':
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get ref of PlanItems from People
+      operationId: People.Trips.ListRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for People
+      operationId: People.Trips.CreateRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count':
+    get:
+      tags:
+        - People.Trip
+      summary: Get the number of the resource
+      operationId: People.Trips.GetCount-c760
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
     get:
       tags:
@@ -10185,6 +15709,564 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend':
+    get:
+      tags:
+        - People.Person
+      summary: Get BestFriend from People
+      description: The best friend.
+      operationId: People.GetBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateBestFriend
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/BestFriend'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref':
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of BestFriend from People
+      description: The best friend.
+      operationId: People.GetRefBestFriend
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          schema:
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateRefBestFriend
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property BestFriend for People
+      operationId: People.DeleteRefBestFriend
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.BestFriend.ListAddressInfo
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.BestFriend.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.BestFriend.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.BestFriend.AddressInfo.GetCount-5a39
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.ListAddressInfo.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.BestFriend.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.BestFriend.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.GetHomeAddress.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: People.GetBestFriend.AsEmployee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -10481,6 +16563,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -10543,6 +16629,10 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -10788,6 +16878,797 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends':
+    get:
+      tags:
+        - People.Person
+      summary: Get Friends from People
+      operationId: People.ListFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Friends'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/$ref':
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.Friends.ListAddressInfo
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - Address
+              - Address desc
+              - City
+              - City desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.Friends.UpdateAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.Friends.SetAddressInfo
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/$count':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.Friends.AddressInfo.GetCount-f486
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    get:
+      summary: Get the number of the resource
+      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.Friends.GetHomeAddress
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - Address
+              - City
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.Friends.UpdateHomeAddress
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: People.GetFriends.AsEmployee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          description: Result entities
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count':
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.Friends.GetCount-1c0c
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref':
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of Friends from People
+      operationId: People.ListRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Person
+      summary: Create new navigation property ref to Friends for People
+      operationId: People.CreateRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    get:
+      tags:
+        - People.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: People.ListFriends.AsEmployee
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Casts the previous resource to Employee.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count':
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.ListFriends.GetCount.AsEmployee-f325
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire':
     post:
       tags:
@@ -10826,6 +17707,671 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
     x-description: Provides operations to call the Hire method.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips':
+    get:
+      tags:
+        - People.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: People.ListTrips
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - TripId
+              - TripId desc
+              - ShareId
+              - ShareId desc
+              - Name
+              - Name desc
+              - Budget
+              - Budget desc
+              - Description
+              - Description desc
+              - Tags
+              - Tags desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: People.CreateTrips
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New navigation property
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '201':
+          description: Created navigation property.
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips'
+      - '/People/{UserName}/Trips'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}':
+    get:
+      tags:
+        - People.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: People.GetTrips
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - TripId
+              - ShareId
+              - Name
+              - Budget
+              - Description
+              - Tags
+              - StartsAt
+              - EndsAt
+              - PlanItems
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: People.UpdateTrips
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: body
+          name: body
+          description: New navigation property values
+          required: true
+          schema:
+            $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: People.DeleteTrips
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/People/{UserName}/Trips/{TripId}'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - UserName
+              - FirstName
+              - LastName
+              - MiddleName
+              - Gender
+              - Age
+              - Emails
+              - AddressInfo
+              - HomeAddress
+              - FavoriteFeature
+              - Features
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - UserName
+              - UserName desc
+              - FirstName
+              - FirstName desc
+              - LastName
+              - LastName desc
+              - MiddleName
+              - MiddleName desc
+              - Gender
+              - Gender desc
+              - Age
+              - Age desc
+              - Emails
+              - Emails desc
+              - AddressInfo
+              - AddressInfo desc
+              - HomeAddress
+              - HomeAddress desc
+              - FavoriteFeature
+              - FavoriteFeature desc
+              - Features
+              - Features desc
+            type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            title: Collection of Person
+            type: object
+            properties:
+              value:
+                type: array
+                items:
+                  $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: function
+    x-description: Provides operations to call the GetInvolvedPeople method.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems':
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get PlanItems from People
+      operationId: People.Trips.ListPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+        - in: query
+          name: $select
+          description: Select properties to be returned
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - ConfirmationCode
+              - StartsAt
+              - EndsAt
+              - Duration
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/People/{UserName}/Trips/{TripId}/PlanItems'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: path
+          name: PlanItemId
+          description: The unique identifier of PlanItem
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: PlanItem
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: Delete Uri
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count':
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: People.Trips.PlanItems.GetCount-fa08
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref':
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get ref of PlanItems from People
+      operationId: People.Trips.ListRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/top'
+        - $ref: '#/parameters/skip'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+        - $ref: '#/parameters/count'
+        - in: query
+          name: $orderby
+          description: Order items by property values
+          type: array
+          items:
+            enum:
+              - PlanItemId
+              - PlanItemId desc
+              - ConfirmationCode
+              - ConfirmationCode desc
+              - StartsAt
+              - StartsAt desc
+              - EndsAt
+              - EndsAt desc
+              - Duration
+              - Duration desc
+            type: string
+      responses:
+        '200':
+          $ref: '#/responses/StringCollectionResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for People
+      operationId: People.Trips.CreateRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-description: Provides operations to manage the collection of Person entities.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count':
+    get:
+      tags:
+        - People.Trip
+      summary: Get the number of the resource
+      operationId: People.Trips.GetCount-1f8c
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          type: string
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/responses/ODataCountResponse'
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to count the resources in the collection.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
     post:
       tags:
@@ -11006,6 +18552,9 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips'
   '/People/{UserName}/Trips/{TripId}':
     get:
       tags:
@@ -11151,6 +18700,9 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
   '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
     get:
       tags:
@@ -11251,6 +18803,9 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the GetInvolvedPeople method.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
   '/People/{UserName}/Trips/{TripId}/PlanItems':
     get:
       tags:
@@ -11328,6 +18883,9 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
   '/People/{UserName}/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
     delete:
       tags:
@@ -12542,14 +20100,14 @@ tags:
     x-ms-docs-toc-type: page
   - name: Me.Person.Location
     x-ms-docs-toc-type: page
-  - name: Me.Functions
-    x-ms-docs-toc-type: container
-  - name: Me.Actions
-    x-ms-docs-toc-type: container
   - name: Me.Trip
     x-ms-docs-toc-type: page
+  - name: Me.Functions
+    x-ms-docs-toc-type: container
   - name: Me.Trips.PlanItem
     x-ms-docs-toc-type: page
+  - name: Me.Actions
+    x-ms-docs-toc-type: container
   - name: NewComePeople.Person
     x-ms-docs-toc-type: page
   - name: NewComePeople.Location
@@ -12570,13 +20128,13 @@ tags:
     x-ms-docs-toc-type: page
   - name: People.Person.Location
     x-ms-docs-toc-type: page
-  - name: People.Functions
-    x-ms-docs-toc-type: container
-  - name: People.Actions
-    x-ms-docs-toc-type: container
   - name: People.Trip
     x-ms-docs-toc-type: page
+  - name: People.Functions
+    x-ms-docs-toc-type: container
   - name: People.Trips.PlanItem
     x-ms-docs-toc-type: page
+  - name: People.Actions
+    x-ms-docs-toc-type: container
   - name: ResetDataSource
     x-ms-docs-toc-type: container

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1962,7 +1962,11 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
     },
     "/Me/BestFriend/$ref": {
       "description": "Provides operations to manage the collection of Person entities.",
@@ -2747,7 +2751,11 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
     },
     "/Me/Friends/{UserName}/$ref": {
       "description": "Provides operations to manage the collection of Person entities.",
@@ -4157,6 +4165,1777 @@
         }
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend": {
+      "description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetBestFriend",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateBestFriend",
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/BestFriend",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetRefBestFriend",
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateRefBestFriend",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPutBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for Me",
+        "operationId": "Me.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.BestFriend.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount-81de",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.ListAddressInfo.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.BestFriend.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.GetHomeAddress.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "Me.GetBestFriend.AsManager",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
+      "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Friends from Me",
+        "operationId": "Me.ListFriends",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Friends",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.Friends.UpdateAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.Friends.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.AddressInfo.GetCount-660e",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.Friends.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.Friends.UpdateHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "Me.GetFriends.AsManager",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.GetCount-0cb7",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of Friends from Me",
+        "operationId": "Me.ListRefFriends",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for Me",
+        "operationId": "Me.CreateRefFriends",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "Me.ListFriends.AsManager",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.ListFriends.GetCount.AsManager-85ff",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
       "get": {
@@ -4972,6 +6751,940 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "Me.ListTrips",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "Description",
+                  "Description desc",
+                  "Tags",
+                  "Tags desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "Me.CreateTrips",
+        "requestBody": {
+          "description": "New navigation property",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips",
+        "/Me/Trips"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "Me.GetTrips",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "Me.UpdateTrips",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "Me.DeleteTrips",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}",
+        "/Me/Trips/{TripId}"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "description": "Provides operations to call the GetInvolvedPeople method.",
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Person",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                          },
+                          {
+                            "type": "object",
+                            "nullable": true
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems": {
+      "description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from Me",
+        "operationId": "Me.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "ConfirmationCode",
+                  "StartsAt",
+                  "EndsAt",
+                  "Duration"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems",
+        "/Me/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "PlanItemId",
+            "in": "path",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.PlanItems.GetCount-a822",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from Me",
+        "operationId": "Me.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for Me",
+        "operationId": "Me.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.GetCount-5aa2",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
       "description": "Provides operations to call the GetFavoriteAirline method.",
       "get": {
@@ -5203,6 +7916,729 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend": {
+      "description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetBestFriend",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateBestFriend",
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/BestFriend",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of BestFriend from Me",
+        "description": "The best friend.",
+        "operationId": "Me.GetRefBestFriend",
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "Me.UpdateRefBestFriend",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPutBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for Me",
+        "operationId": "Me.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.BestFriend.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount-6ea6",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.ListAddressInfo.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.BestFriend.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.BestFriend.GetHomeAddress.AsEventLocation",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "Me.GetBestFriend.AsEmployee",
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
                 }
               }
             }
@@ -5635,6 +9071,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -5710,6 +9160,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -6035,6 +9499,1082 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
+      "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Friends from Me",
+        "operationId": "Me.ListFriends",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Friends",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "Me.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "Me.Friends.UpdateAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "post": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "Me.Friends.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.AddressInfo.GetCount-b7db",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress": {
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "Me.Friends.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "Me.Friends.UpdateHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "Me.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "Me.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "Me.GetFriends.AsEmployee",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Friends.GetCount-60a7",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get ref of Friends from Me",
+        "operationId": "Me.ListRefFriends",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for Me",
+        "operationId": "Me.CreateRefFriends",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "Me.ListFriends.AsEmployee",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.ListFriends.GetCount.AsEmployee-6a35",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire": {
       "description": "Provides operations to call the Hire method.",
       "post": {
@@ -6084,6 +10624,940 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "Me.ListTrips",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "Description",
+                  "Description desc",
+                  "Tags",
+                  "Tags desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "Me.CreateTrips",
+        "requestBody": {
+          "description": "New navigation property",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/Me/Trips"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "Me.GetTrips",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "Me.UpdateTrips",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "Me.DeleteTrips",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/Me/Trips/{TripId}"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "description": "Provides operations to call the GetInvolvedPeople method.",
+      "get": {
+        "tags": [
+          "Me.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Person",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                          },
+                          {
+                            "type": "object",
+                            "nullable": true
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems": {
+      "description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from Me",
+        "operationId": "Me.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "ConfirmationCode",
+                  "StartsAt",
+                  "EndsAt",
+                  "Duration"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/Me/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "PlanItemId",
+            "in": "path",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.PlanItems.GetCount-5ad2",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from Me",
+        "operationId": "Me.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for Me",
+        "operationId": "Me.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "Me.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "Me.Trips.GetCount-f3f4",
+        "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
@@ -6326,7 +11800,11 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips"
+      ]
     },
     "/Me/Trips/{TripId}": {
       "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
@@ -6515,7 +11993,11 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}"
+      ]
     },
     "/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
       "description": "Provides operations to call the GetInvolvedPeople method.",
@@ -6663,7 +12145,11 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "function"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
     },
     "/Me/Trips/{TripId}/PlanItems": {
       "description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
@@ -6783,7 +12269,11 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems"
+      ]
     },
     "/Me/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
       "description": "Provides operations to manage the collection of Person entities.",
@@ -12393,7 +17883,11 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
     },
     "/People/{UserName}/BestFriend/$ref": {
       "description": "Provides operations to manage the collection of Person entities.",
@@ -13340,7 +18834,11 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
     },
     "/People/{UserName}/Friends/{UserName1}/$ref": {
       "description": "Provides operations to manage the collection of Person entities.",
@@ -15000,6 +20498,2113 @@
         }
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend": {
+      "description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/BestFriend",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetRefBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateRefBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPutBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for People",
+        "operationId": "People.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.BestFriend.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.AddressInfo.GetCount-cb8a",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.BestFriend.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "People.GetBestFriend.AsManager",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
+      "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Friends from People",
+        "operationId": "People.ListFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Friends",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.Friends.UpdateAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.Friends.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.AddressInfo.GetCount-1e8b",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.Friends.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.Friends.UpdateHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "operationId": "People.GetFriends.AsManager",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.GetCount-4db4",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of Friends from People",
+        "operationId": "People.ListRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for People",
+        "operationId": "People.CreateRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
+      "description": "Casts the previous resource to Manager.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "People.ListFriends.AsManager",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.ListFriends.GetCount.AsManager-b145",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers": {
       "description": "Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.",
       "get": {
@@ -15957,6 +23562,1062 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "People.ListTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "Description",
+                  "Description desc",
+                  "Tags",
+                  "Tags desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "People.CreateTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips",
+        "/People/{UserName}/Trips"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "People.GetTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "People.UpdateTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "People.DeleteTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}",
+        "/People/{UserName}/Trips/{TripId}"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "description": "Provides operations to call the GetInvolvedPeople method.",
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Person",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                          },
+                          {
+                            "type": "object",
+                            "nullable": true
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems": {
+      "description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from People",
+        "operationId": "People.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "ConfirmationCode",
+                  "StartsAt",
+                  "EndsAt",
+                  "Duration"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems",
+        "/People/{UserName}/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "PlanItemId",
+            "in": "path",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.PlanItems.GetCount-7df9",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from People",
+        "operationId": "People.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for People",
+        "operationId": "People.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.GetCount-c760",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()": {
       "description": "Provides operations to call the GetFavoriteAirline method.",
       "get": {
@@ -16246,6 +24907,893 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend": {
+      "description": "Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/BestFriend",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of BestFriend from People",
+        "description": "The best friend.",
+        "operationId": "People.GetRefBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property link",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update the best friend.",
+        "description": "Update an instance of a best friend.",
+        "operationId": "People.UpdateRefBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPutBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property BestFriend for People",
+        "operationId": "People.DeleteRefBestFriend",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.BestFriend.ListAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.BestFriend.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.AddressInfo.GetCount-5a39",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.BestFriend.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.BestFriend.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "People.GetBestFriend.AsEmployee",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
                 }
               }
             }
@@ -16738,6 +26286,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -16833,6 +26395,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -17220,6 +26796,1254 @@
         "x-ms-docs-operation-type": "operation"
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
+      "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Friends from People",
+        "operationId": "People.ListFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Friends",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get AddressInfo property value",
+        "operationId": "People.Friends.ListAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "Address desc",
+                  "City",
+                  "City desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property AddressInfo value.",
+        "operationId": "People.Friends.UpdateAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "post": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Sets a new value for the collection of Location.",
+        "operationId": "People.Friends.SetAddressInfo",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.AddressInfo.GetCount-f486",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.ListAddressInfo.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress": {
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get HomeAddress property value",
+        "operationId": "People.Friends.GetHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Address",
+                  "City"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "patch": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Update property HomeAddress value.",
+        "operationId": "People.Friends.UpdateHomeAddress",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation": {
+      "description": "Casts the previous resource to EventLocation.",
+      "get": {
+        "tags": [
+          "People.Person.Location"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection",
+        "operationId": "People.Friends.GetHomeAddress.AsEventLocation",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+        "operationId": "People.GetFriends.AsEmployee",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Result entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Friends.GetCount-1c0c",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get ref of Friends from People",
+        "operationId": "People.ListRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Create new navigation property ref to Friends for People",
+        "operationId": "People.CreateRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee": {
+      "description": "Casts the previous resource to Employee.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
+        "operationId": "People.ListFriends.AsEmployee",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.ListFriends.GetCount.AsEmployee-f325",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire": {
       "description": "Provides operations to call the Hire method.",
       "post": {
@@ -17281,6 +28105,1062 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "action"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "List trips.",
+        "description": "Retrieve a list of trips.",
+        "operationId": "People.ListTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "Description",
+                  "Description desc",
+                  "Tags",
+                  "Tags desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Create a trip.",
+        "description": "Create a new trip.",
+        "operationId": "People.CreateTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created navigation property.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/People/{UserName}/Trips"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}": {
+      "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get a trip.",
+        "description": "Retrieve the properties of a trip.",
+        "operationId": "People.GetTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Name",
+                  "Budget",
+                  "Description",
+                  "Tags",
+                  "StartsAt",
+                  "EndsAt",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved navigation property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "patch": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Update a trip.",
+        "description": "Update an instance of a trip.",
+        "operationId": "People.UpdateTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "description": "New navigation property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Delete a trip.",
+        "description": "Delete an instance of a trip.",
+        "operationId": "People.DeleteTrips",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/People/{UserName}/Trips/{TripId}"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
+      "description": "Provides operations to call the GetInvolvedPeople method.",
+      "get": {
+        "tags": [
+          "People.Functions"
+        ],
+        "summary": "Invoke function GetInvolvedPeople",
+        "operationId": "People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "MiddleName",
+                  "Gender",
+                  "Age",
+                  "Emails",
+                  "AddressInfo",
+                  "HomeAddress",
+                  "FavoriteFeature",
+                  "Features",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "MiddleName",
+                  "MiddleName desc",
+                  "Gender",
+                  "Gender desc",
+                  "Age",
+                  "Age desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "HomeAddress",
+                  "HomeAddress desc",
+                  "FavoriteFeature",
+                  "FavoriteFeature desc",
+                  "Features",
+                  "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Person",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
+                          },
+                          {
+                            "type": "object",
+                            "nullable": true
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "function"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems": {
+      "description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get PlanItems from People",
+        "operationId": "People.Trips.ListPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "ConfirmationCode",
+                  "StartsAt",
+                  "EndsAt",
+                  "Duration"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/People/{UserName}/Trips/{TripId}/PlanItems"
+      ]
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "PlanItemId",
+            "in": "path",
+            "description": "The unique identifier of PlanItem",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "PlanItem"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "Delete Uri",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.PlanItems.GetCount-fa08",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref": {
+      "description": "Provides operations to manage the collection of Person entities.",
+      "get": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Get ref of PlanItems from People",
+        "operationId": "People.Trips.ListRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "PlanItemId",
+                  "PlanItemId desc",
+                  "ConfirmationCode",
+                  "ConfirmationCode desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Duration",
+                  "Duration desc"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/StringCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "post": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Create new navigation property ref to PlanItems for People",
+        "operationId": "People.Trips.CreateRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/refPostBody"
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count": {
+      "description": "Provides operations to count the resources in the collection.",
+      "get": {
+        "tags": [
+          "People.Trip"
+        ],
+        "summary": "Get the number of the resource",
+        "operationId": "People.Trips.GetCount-1f8c",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ODataCountResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000",
+          "date": "2021-08-24T00:00:00.0000000",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip": {
@@ -17567,7 +29447,11 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}": {
       "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
@@ -17786,7 +29670,11 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()": {
       "description": "Provides operations to call the GetInvolvedPeople method.",
@@ -17944,7 +29832,11 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "function"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}/PlanItems": {
       "description": "Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.",
@@ -18074,7 +29966,11 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
-      }
+      },
+      "x-ms-docs-grouped-path": [
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems",
+        "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems"
+      ]
     },
     "/People/{UserName}/Trips/{TripId}/PlanItems/{PlanItemId}/$ref": {
       "description": "Provides operations to manage the collection of Person entities.",
@@ -20435,20 +32331,20 @@
       "x-ms-docs-toc-type": "page"
     },
     {
-      "name": "Me.Functions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
-      "name": "Me.Actions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
       "name": "Me.Trip",
       "x-ms-docs-toc-type": "page"
     },
     {
+      "name": "Me.Functions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
       "name": "Me.Trips.PlanItem",
       "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "Me.Actions",
+      "x-ms-docs-toc-type": "container"
     },
     {
       "name": "NewComePeople.Person",
@@ -20491,20 +32387,20 @@
       "x-ms-docs-toc-type": "page"
     },
     {
-      "name": "People.Functions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
-      "name": "People.Actions",
-      "x-ms-docs-toc-type": "container"
-    },
-    {
       "name": "People.Trip",
       "x-ms-docs-toc-type": "page"
     },
     {
+      "name": "People.Functions",
+      "x-ms-docs-toc-type": "container"
+    },
+    {
       "name": "People.Trips.PlanItem",
       "x-ms-docs-toc-type": "page"
+    },
+    {
+      "name": "People.Actions",
+      "x-ms-docs-toc-type": "container"
     },
     {
       "name": "ResetDataSource",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -1310,6 +1310,9 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend
   /Me/BestFriend/$ref:
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -1866,6 +1869,9 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends
   '/Me/Friends/{UserName}/$ref':
     description: Provides operations to manage the collection of Person entities.
     delete:
@@ -2860,6 +2866,1250 @@ paths:
         date: '2021-08-24T00:00:00.0000000'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend:
+    description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetBestFriend
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateBestFriend
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/BestFriend
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref:
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetRefBestFriend
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateRefBestFriend
+      requestBody:
+        $ref: '#/components/requestBodies/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property BestFriend for Me
+      operationId: Me.DeleteRefBestFriend
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.BestFriend.ListAddressInfo
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.BestFriend.UpdateAddressInfo
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.BestFriend.SetAddressInfo
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.AddressInfo.GetCount-81de
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.ListAddressInfo.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.BestFriend.GetHomeAddress
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.BestFriend.UpdateHomeAddress
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.GetHomeAddress.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    description: Casts the previous resource to Manager.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: Me.GetBestFriend.AsManager
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends:
+    description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Friends from Me
+      operationId: Me.ListFriends
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/Friends
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.Friends.ListAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.Friends.UpdateAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.Friends.SetAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.Friends.AddressInfo.GetCount-660e
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.Friends.GetHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.Friends.UpdateHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: Me.GetFriends.AsManager
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.Friends.GetCount-0cb7
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref:
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of Friends from Me
+      operationId: Me.ListRefFriends
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Person
+      summary: Create new navigation property ref to Friends for Me
+      operationId: Me.CreateRefFriends
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
+    description: Casts the previous resource to Manager.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: Me.ListFriends.AsManager
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.ListFriends.GetCount.AsManager-85ff
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers:
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -3425,6 +4675,667 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips:
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: Me.ListTrips
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - TripId desc
+                - ShareId
+                - ShareId desc
+                - Name
+                - Name desc
+                - Budget
+                - Budget desc
+                - Description
+                - Description desc
+                - Tags
+                - Tags desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: Me.CreateTrips
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '201':
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips
+      - /Me/Trips
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}':
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: Me.GetTrips
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: Me.UpdateTrips
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: Me.DeleteTrips
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
+      - '/Me/Trips/{TripId}'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    description: Provides operations to call the GetInvolvedPeople method.
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of Person
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+                        - type: object
+                          nullable: true
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: function
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems':
+    description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get PlanItems from Me
+      operationId: Me.Trips.ListPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - ConfirmationCode
+                - StartsAt
+                - EndsAt
+                - Duration
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
+      - '/Me/Trips/{TripId}/PlanItems'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: PlanItemId
+          in: path
+          description: The unique identifier of PlanItem
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: PlanItem
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: Me.Trips.PlanItems.GetCount-a822
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get ref of PlanItems from Me
+      operationId: Me.Trips.ListRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for Me
+      operationId: Me.Trips.CreateRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Trip
+      summary: Get the number of the resource
+      operationId: Me.Trips.GetCount-5aa2
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline():
     description: Provides operations to call the GetFavoriteAirline method.
     get:
@@ -3598,6 +5509,512 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend:
+    description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetBestFriend
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateBestFriend
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/BestFriend
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref:
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of BestFriend from Me
+      description: The best friend.
+      operationId: Me.GetRefBestFriend
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - Me.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: Me.UpdateRefBestFriend
+      requestBody:
+        $ref: '#/components/requestBodies/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property BestFriend for Me
+      operationId: Me.DeleteRefBestFriend
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.BestFriend.ListAddressInfo
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.BestFriend.UpdateAddressInfo
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.BestFriend.SetAddressInfo
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.AddressInfo.GetCount-6ea6
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.ListAddressInfo.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress:
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.BestFriend.GetHomeAddress
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.BestFriend.UpdateHomeAddress
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation:
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.BestFriend.GetHomeAddress.AsEventLocation
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    description: Casts the previous resource to Employee.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: Me.GetBestFriend.AsEmployee
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -3897,6 +6314,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -3949,6 +6375,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -4171,6 +6606,762 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends:
+    description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Friends from Me
+      operationId: Me.ListFriends
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/Friends
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get AddressInfo property value
+      operationId: Me.Friends.ListAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: Me.Friends.UpdateAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    post:
+      tags:
+        - Me.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: Me.Friends.SetAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the number of the resource
+      operationId: Me.Friends.AddressInfo.GetCount-b7db
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress':
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get HomeAddress property value
+      operationId: Me.Friends.GetHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    patch:
+      tags:
+        - Me.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: Me.Friends.UpdateHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - Me.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: Me.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: Me.GetFriends.AsEmployee
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.Friends.GetCount-60a7
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref:
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.Person
+      summary: Get ref of Friends from Me
+      operationId: Me.ListRefFriends
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Person
+      summary: Create new navigation property ref to Friends for Me
+      operationId: Me.CreateRefFriends
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee:
+    description: Casts the previous resource to Employee.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: Me.ListFriends.AsEmployee
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Person
+      summary: Get the number of the resource
+      operationId: Me.ListFriends.GetCount.AsEmployee-6a35
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire:
     description: Provides operations to call the Hire method.
     post:
@@ -4204,6 +7395,667 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: action
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips:
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: Me.ListTrips
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - TripId desc
+                - ShareId
+                - ShareId desc
+                - Name
+                - Name desc
+                - Budget
+                - Budget desc
+                - Description
+                - Description desc
+                - Tags
+                - Tags desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: Me.CreateTrips
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '201':
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips
+      - /Me/Trips
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}':
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - Me.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: Me.GetTrips
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - Me.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: Me.UpdateTrips
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: Me.DeleteTrips
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/Me/Trips/{TripId}'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    description: Provides operations to call the GetInvolvedPeople method.
+    get:
+      tags:
+        - Me.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: Me.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of Person
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+                        - type: object
+                          nullable: true
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: function
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems':
+    description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get PlanItems from Me
+      operationId: Me.Trips.ListPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - ConfirmationCode
+                - StartsAt
+                - EndsAt
+                - Duration
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/Me/Trips/{TripId}/PlanItems'
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: PlanItemId
+          in: path
+          description: The unique identifier of PlanItem
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: PlanItem
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: Me.Trips.PlanItems.GetCount-5ad2
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Get ref of PlanItems from Me
+      operationId: Me.Trips.ListRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for Me
+      operationId: Me.Trips.CreateRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count:
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - Me.Trip
+      summary: Get the number of the resource
+      operationId: Me.Trips.GetCount-f3f4
+      parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip:
     description: Provides operations to call the ShareTrip method.
     post:
@@ -4376,6 +8228,9 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips
+      - /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips
   '/Me/Trips/{TripId}':
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -4514,6 +8369,9 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
   '/Me/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
     description: Provides operations to call the GetInvolvedPeople method.
     get:
@@ -4620,6 +8478,9 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
   '/Me/Trips/{TripId}/PlanItems':
     description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
     get:
@@ -4704,6 +8565,9 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
   '/Me/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
     description: Provides operations to manage the collection of Person entities.
     delete:
@@ -8584,6 +12448,9 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend'
   '/People/{UserName}/BestFriend/$ref':
     description: Provides operations to manage the collection of Person entities.
     get:
@@ -9251,6 +13118,9 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends'
   '/People/{UserName}/Friends/{UserName1}/$ref':
     description: Provides operations to manage the collection of Person entities.
     delete:
@@ -10418,6 +14288,1482 @@ paths:
         date: '2021-08-24T00:00:00.0000000'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend':
+    description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get BestFriend from People
+      description: The best friend.
+      operationId: People.GetBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/BestFriend'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of BestFriend from People
+      description: The best friend.
+      operationId: People.GetRefBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateRefBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        $ref: '#/components/requestBodies/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property BestFriend for People
+      operationId: People.DeleteRefBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.BestFriend.ListAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.BestFriend.UpdateAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.BestFriend.SetAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.BestFriend.AddressInfo.GetCount-cb8a
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.ListAddressInfo.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.BestFriend.GetHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.BestFriend.UpdateHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.GetHomeAddress.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: People.GetBestFriend.AsManager
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends':
+    description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Friends from People
+      operationId: People.ListFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Friends'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.Friends.ListAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.Friends.UpdateAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.Friends.SetAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.Friends.AddressInfo.GetCount-1e8b
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.Friends.GetHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.Friends.UpdateHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      operationId: People.GetFriends.AsManager
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.Friends.GetCount-4db4
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of Friends from People
+      operationId: People.ListRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Person
+      summary: Create new navigation property ref to Friends for People
+      operationId: People.CreateRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
+    description: Casts the previous resource to Manager.
+    get:
+      tags:
+        - People.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: People.ListFriends.AsManager
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ManagerCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.ListFriends.GetCount.AsManager-b145
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers':
     description: Provides operations to manage the Peers property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee entity.
     get:
@@ -11082,6 +16428,752 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips':
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: People.ListTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - TripId desc
+                - ShareId
+                - ShareId desc
+                - Name
+                - Name desc
+                - Budget
+                - Budget desc
+                - Description
+                - Description desc
+                - Tags
+                - Tags desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: People.CreateTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '201':
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips'
+      - '/People/{UserName}/Trips'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}':
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: People.GetTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: People.UpdateTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: People.DeleteTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
+      - '/People/{UserName}/Trips/{TripId}'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    description: Provides operations to call the GetInvolvedPeople method.
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee.Trips.Trip.GetInvolvedPeople
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of Person
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+                        - type: object
+                          nullable: true
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: function
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems':
+    description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get PlanItems from People
+      operationId: People.Trips.ListPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - ConfirmationCode
+                - StartsAt
+                - EndsAt
+                - Duration
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
+      - '/People/{UserName}/Trips/{TripId}/PlanItems'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: PlanItemId
+          in: path
+          description: The unique identifier of PlanItem
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: PlanItem
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: People.Trips.PlanItems.GetCount-7df9
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get ref of PlanItems from People
+      operationId: People.Trips.ListRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for People
+      operationId: People.Trips.CreateRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Trip
+      summary: Get the number of the resource
+      operationId: People.Trips.GetCount-c760
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFavoriteAirline()':
     description: Provides operations to call the GetFavoriteAirline method.
     get:
@@ -11294,6 +17386,624 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend':
+    description: Provides operations to manage the BestFriend property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get BestFriend from People
+      description: The best friend.
+      operationId: People.GetBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/BestFriend'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of BestFriend from People
+      description: The best friend.
+      operationId: People.GetRefBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved navigation property link
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - People.Person
+      summary: Update the best friend.
+      description: Update an instance of a best friend.
+      operationId: People.UpdateRefBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        $ref: '#/components/requestBodies/refPutBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property BestFriend for People
+      operationId: People.DeleteRefBestFriend
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.BestFriend.ListAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.BestFriend.UpdateAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.BestFriend.SetAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.BestFriend.AddressInfo.GetCount-5a39
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.ListAddressInfo.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.BestFriend.GetHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.BestFriend.UpdateHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.BestFriend.GetHomeAddress.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: People.GetBestFriend.AsEmployee
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -11635,6 +18345,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -11701,6 +18420,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -11966,6 +18694,882 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends':
+    description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Friends from People
+      operationId: People.ListFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Friends'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get AddressInfo property value
+      operationId: People.Friends.ListAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - Address desc
+                - City
+                - City desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.LocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property AddressInfo value.
+      operationId: People.Friends.UpdateAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    post:
+      tags:
+        - People.Person.Location
+      summary: Sets a new value for the collection of Location.
+      operationId: People.Friends.SetAddressInfo
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the number of the resource
+      operationId: People.Friends.AddressInfo.GetCount-f486
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.ListAddressInfo.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      summary: Get the number of the resource
+      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress':
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get HomeAddress property value
+      operationId: People.Friends.GetHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - Address
+                - City
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    patch:
+      tags:
+        - People.Person.Location
+      summary: Update property HomeAddress value.
+      operationId: People.Friends.UpdateHomeAddress
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/HomeAddress/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation':
+    description: Casts the previous resource to EventLocation.
+    get:
+      tags:
+        - People.Person.Location
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location collection
+      operationId: People.Friends.GetHomeAddress.AsEventLocation
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
+    get:
+      tags:
+        - People.Person
+      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee
+      operationId: People.GetFriends.AsEmployee
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          description: Result entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.Friends.GetCount-1c0c
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.Person
+      summary: Get ref of Friends from People
+      operationId: People.ListRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Person
+      summary: Create new navigation property ref to Friends for People
+      operationId: People.CreateRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee':
+    description: Casts the previous resource to Employee.
+    get:
+      tags:
+        - People.Person
+      summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
+      operationId: People.ListFriends.AsEmployee
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Person
+      summary: Get the number of the resource
+      operationId: People.ListFriends.GetCount.AsEmployee-f325
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Hire':
     description: Provides operations to call the Hire method.
     post:
@@ -12007,6 +19611,752 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: action
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips':
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Trip
+      summary: List trips.
+      description: Retrieve a list of trips.
+      operationId: People.ListTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - TripId desc
+                - ShareId
+                - ShareId desc
+                - Name
+                - Name desc
+                - Budget
+                - Budget desc
+                - Description
+                - Description desc
+                - Tags
+                - Tags desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trip
+      summary: Create a trip.
+      description: Create a new trip.
+      operationId: People.CreateTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '201':
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips'
+      - '/People/{UserName}/Trips'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}':
+    description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
+    get:
+      tags:
+        - People.Trip
+      summary: Get a trip.
+      description: Retrieve the properties of a trip.
+      operationId: People.GetTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - TripId
+                - ShareId
+                - Name
+                - Budget
+                - Description
+                - Tags
+                - StartsAt
+                - EndsAt
+                - PlanItems
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
+      responses:
+        '200':
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - People.Trip
+      summary: Update a trip.
+      description: Update an instance of a trip.
+      operationId: People.UpdateTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trip
+      summary: Delete a trip.
+      description: Delete an instance of a trip.
+      operationId: People.DeleteTrips
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/People/{UserName}/Trips/{TripId}'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
+    description: Provides operations to call the GetInvolvedPeople method.
+    get:
+      tags:
+        - People.Functions
+      summary: Invoke function GetInvolvedPeople
+      operationId: People.Person.Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager.Trips.Trip.GetInvolvedPeople
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - FirstName
+                - LastName
+                - MiddleName
+                - Gender
+                - Age
+                - Emails
+                - AddressInfo
+                - HomeAddress
+                - FavoriteFeature
+                - Features
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - UserName
+                - UserName desc
+                - FirstName
+                - FirstName desc
+                - LastName
+                - LastName desc
+                - MiddleName
+                - MiddleName desc
+                - Gender
+                - Gender desc
+                - Age
+                - Age desc
+                - Emails
+                - Emails desc
+                - AddressInfo
+                - AddressInfo desc
+                - HomeAddress
+                - HomeAddress desc
+                - FavoriteFeature
+                - FavoriteFeature desc
+                - Features
+                - Features desc
+              type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of Person
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+                        - type: object
+                          nullable: true
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: function
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems':
+    description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get PlanItems from People
+      operationId: People.Trips.ListPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - ConfirmationCode
+                - StartsAt
+                - EndsAt
+                - Duration
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItemCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/People/{UserName}/Trips/{TripId}/PlanItems'
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: PlanItemId
+          in: path
+          description: The unique identifier of PlanItem
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: PlanItem
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: Delete Uri
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get the number of the resource
+      operationId: People.Trips.PlanItems.GetCount-fa08
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems/$ref':
+    description: Provides operations to manage the collection of Person entities.
+    get:
+      tags:
+        - People.Trips.PlanItem
+      summary: Get ref of PlanItems from People
+      operationId: People.Trips.ListRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - PlanItemId
+                - PlanItemId desc
+                - ConfirmationCode
+                - ConfirmationCode desc
+                - StartsAt
+                - StartsAt desc
+                - EndsAt
+                - EndsAt desc
+                - Duration
+                - Duration desc
+              type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/StringCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - People.Trips.PlanItem
+      summary: Create new navigation property ref to PlanItems for People
+      operationId: People.Trips.CreateRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+      requestBody:
+        $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/$count':
+    description: Provides operations to count the resources in the collection.
+    get:
+      tags:
+        - People.Trip
+      summary: Get the number of the resource
+      operationId: People.Trips.GetCount-1f8c
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.tripservice.com/advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000'
+        date: '2021-08-24T00:00:00.0000000'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip':
     description: Provides operations to call the ShareTrip method.
     post:
@@ -12209,6 +20559,9 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips'
   '/People/{UserName}/Trips/{TripId}':
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -12368,6 +20721,9 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}'
   '/People/{UserName}/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()':
     description: Provides operations to call the GetInvolvedPeople method.
     get:
@@ -12481,6 +20837,9 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetInvolvedPeople()'
   '/People/{UserName}/Trips/{TripId}/PlanItems':
     description: Provides operations to manage the PlanItems property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip entity.
     get:
@@ -12572,6 +20931,9 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    x-ms-docs-grouped-path:
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips/{TripId}/PlanItems'
+      - '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Trips/{TripId}/PlanItems'
   '/People/{UserName}/Trips/{TripId}/PlanItems/{PlanItemId}/$ref':
     description: Provides operations to manage the collection of Person entities.
     delete:
@@ -14099,14 +22461,14 @@ tags:
     x-ms-docs-toc-type: page
   - name: Me.Person.Location
     x-ms-docs-toc-type: page
-  - name: Me.Functions
-    x-ms-docs-toc-type: container
-  - name: Me.Actions
-    x-ms-docs-toc-type: container
   - name: Me.Trip
     x-ms-docs-toc-type: page
+  - name: Me.Functions
+    x-ms-docs-toc-type: container
   - name: Me.Trips.PlanItem
     x-ms-docs-toc-type: page
+  - name: Me.Actions
+    x-ms-docs-toc-type: container
   - name: NewComePeople.Person
     x-ms-docs-toc-type: page
   - name: NewComePeople.Location
@@ -14127,13 +22489,13 @@ tags:
     x-ms-docs-toc-type: page
   - name: People.Person.Location
     x-ms-docs-toc-type: page
-  - name: People.Functions
-    x-ms-docs-toc-type: container
-  - name: People.Actions
-    x-ms-docs-toc-type: container
   - name: People.Trip
     x-ms-docs-toc-type: page
+  - name: People.Functions
+    x-ms-docs-toc-type: container
   - name: People.Trips.PlanItem
     x-ms-docs-toc-type: page
+  - name: People.Actions
+    x-ms-docs-toc-type: container
   - name: ResetDataSource
     x-ms-docs-toc-type: container


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/371

This PR:
- Fetches navigation properties from base types of the entity type targeting a given navigation property.
- Updates tests.
- Updates release notes.