### PR TITLE
[Feature] Adds support for `RequiresExplicitBinding` and `ExplicitOperationBindings` annotations for operations

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
@@ -390,6 +391,30 @@ namespace Microsoft.OpenApi.OData.Common
             }
 
             return segmentName;
+        }
+    
+        /// <summary>
+        /// Checks whether an operation is allowed on a model element.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="edmOperation">The target operation.</param>
+        /// <param name="annotatable">The model element.</param>
+        /// <returns>true if the operation is allowed, otherwise false.</returns>
+        internal static bool IsOperationAllowed(IEdmModel model, IEdmOperation edmOperation, IEdmVocabularyAnnotatable annotatable)
+        {
+            Utils.CheckArgumentNull(model, nameof(model));
+            Utils.CheckArgumentNull(edmOperation, nameof(edmOperation));
+            Utils.CheckArgumentNull(annotatable, nameof(annotatable));
+
+            var requiresExplicitBinding = model.FindVocabularyAnnotations(edmOperation).FirstOrDefault(x => x.Term.Name == CapabilitiesConstants.RequiresExplicitBindingName);
+
+            if (requiresExplicitBinding == null)
+            {
+                return true;
+            }
+            
+            var boundOperations = model.GetCollection(annotatable, CapabilitiesConstants.ExplicitOperationBindings)?.ToList();
+            return boundOperations != null && boundOperations.Contains(edmOperation.FullName());
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -798,7 +798,12 @@ namespace Microsoft.OpenApi.OData.Edm
                         
                         if (annotatable != null && !EdmModelHelper.IsOperationAllowed(_model, edmOperation, annotatable))
                         {
-                            continue;
+                            // Check whether the navigation source is allowed to have an operation on the entity type
+                            annotatable = (secondLastPathSegment as ODataNavigationSourceSegment)?.NavigationSource as IEdmVocabularyAnnotatable;
+                            if (annotatable != null && !EdmModelHelper.IsOperationAllowed(_model, edmOperation, annotatable))
+                            {
+                                continue;
+                            }                            
                         }
 
                         ODataPath newPath = subPath.Clone();

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -34,7 +34,6 @@ namespace Microsoft.OpenApi.OData.Edm
         private readonly IDictionary<IEdmEntityType, IList<ODataPath>> _dollarCountPaths =
            new Dictionary<IEdmEntityType, IList<ODataPath>>();
 
-        private Dictionary<string, IList<string>> _explicitOperationBindings = new();
 
         /// <summary>
         /// Can filter the <see cref="IEdmElement"/> or not.

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.4.0-preview6</Version>
+    <Version>1.4.0-preview7</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -27,6 +27,7 @@
 - Use directly annotated CountRestriction annotations when creating $count segments for collection-valued navigation properties #328
 - Use MediaType annotation to set the content types of operations with Edm.Stream return types #342
 - Retrieves navigation properties from base types #371
+- Adds support for RequiresExplicitBinding and ExplicitOperationBindings annotations for operations #323 #232
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/CapabilitiesConstants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/CapabilitiesConstants.cs
@@ -94,5 +94,15 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// Org.OData.Capabilities.V1.KeyAsSegmentSupported
         /// </summary>
         public const string KeyAsSegmentSupported = "Org.OData.Capabilities.V1.KeyAsSegmentSupported";
+
+        /// <summary>
+        /// RequiresExplicitBinding
+        /// </summary>
+        public const string RequiresExplicitBindingName = "RequiresExplicitBinding";
+
+        /// <summary>
+        /// Org.OData.Capabilities.V1.ExplicitOperationBindings
+        /// </summary>
+        public const string ExplicitOperationBindings = "Org.OData.Core.V1.ExplicitOperationBindings";
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18315, paths.Count());
+            Assert.Equal(18264, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18966, paths.Count());
+            Assert.Equal(18915, paths.Count());
         }
 
         [Theory]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18050, paths.Count());
+            Assert.Equal(18048, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -67,6 +67,12 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Test that count restrictions annotations for navigation properties work
             Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/me/drives/$count")));
+
+            // Test that RequiresExplicitBinding and ExplicitOperationBindings annotations work
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.applyDecisions")));
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.resetDecisions")));
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.sendReminder")));
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.stop")));            
         }
 
         [Fact]
@@ -87,7 +93,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18701, paths.Count());
+            Assert.Equal(18699, paths.Count());
         }
 
         [Theory]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18407, paths.Count());
+            Assert.Equal(18313, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -72,10 +72,17 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/print/printers({id})/jobs")));
 
             // Test that RequiresExplicitBinding and ExplicitOperationBindings annotations work
-            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.applyDecisions")));
-            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.resetDecisions")));
-            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.sendReminder")));
-            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/accessReviews({id})/microsoft.graph.stop")));            
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directory/deletedItems({id})/microsoft.graph.checkMemberGroups")));
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directory/deletedItems({id})/microsoft.graph.checkMemberObjects")));
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directory/deletedItems({id})/microsoft.graph.getMemberGroups")));
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directory/deletedItems({id})/microsoft.graph.getMemberObjects")));
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directory/deletedItems({id})/microsoft.graph.restore")));
+
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directoryObjects({id})/microsoft.graph.checkMemberGroups")));
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directoryObjects({id})/microsoft.graph.checkMemberObjects")));
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directoryObjects({id})/microsoft.graph.getMemberGroups")));
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directoryObjects({id})/microsoft.graph.getMemberObjects")));
+            Assert.Null(paths.FirstOrDefault(p => p.GetPathItemName().Equals("/directoryObjects({id})/microsoft.graph.restore")));
         }
 
         [Fact]
@@ -96,7 +103,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(19058, paths.Count());
+            Assert.Equal(18964, paths.Count());
         }
 
         [Theory]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18313, paths.Count());
+            Assert.Equal(18315, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(18964, paths.Count());
+            Assert.Equal(18966, paths.Count());
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/323, https://github.com/microsoft/OpenAPI.NET.OData/issues/232

**This PR:**
- Uses the annotations `Org.OData.Core.V1.RequiresExplicitBinding` in operations and `Org.OData.Core.V1.ExplicitOperationBindings` in model elements to associate which operations are to be generated for which elements.
- Updates the unit and integration tests.
- Updates the release notes.


**How it works**

Take for example the operation:
```XML
<Action Name="getMemberObjects" IsBound="true">
  <Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding"/>
  <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false" />
  <Parameter Name="securityEnabledOnly" Type="Edm.Boolean" />
  <ReturnType Type="Collection(Edm.String)" Nullable="false" Unicode="false" />
</Action>
```
The `bindingParameter` is of type `graph.directoryObject`. This means that all model elements of this type (including all of its derived types) will have the operation `getMemberObjects` appended to their paths. In order to restrict the generation of this operation only to certain instances of the binding type - `directoryObject`, we append the `<Annotation Term="Org.OData.Core.V1.RequiresExplicitBinding"/>` annotation to the operation (as shown above). 
> All the operations which bind to `directoryObject`, for example, may need to be annotated with this annotation to avoid generating irrelevant operations to all of its derived types..

The navigation property `deletedItems` is an instance of type `Collection(graph.directoryObject)`:
`<NavigationProperty Name="deletedItems" Type="Collection(graph.directoryObject)" ContainsTarget="true" />` 
Ordinarily it would have the path `/directory/deletedItems/{directoryObject-id}/microsoft.graph.getMemberGroups` which is invalid. The only valid operation for this navigation property path would be `/directory/deletedItems/{directoryObject-id}/microsoft.graph.restore`.

To restrict all the operations bound to instances of `directoryObject` from being generated as operations on the `deletedItems` navigation property and only allow the `restore` operation, we would create an `ExplicitOperationBindings` to the navigation property as such:

```XML
<NavigationProperty Name="deletedItems" Type="Collection(graph.directoryObject)" ContainsTarget="true">
  <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings">
    <Collection>
      <String>microsoft.graph.restore</String>
    </Collection>
  </Annotation>
</NavigationProperty>
```

The entity type `directoryObject` will need to invoke all the operations that are bound to it and since all the operations which bind to `directoryObject` have been annotated with the annotation `Org.OData.Core.V1.RequiresExplicitBinding`, a corresponding `Org.OData.Core.V1.ExplicitOperationBindings` annotations with the collection of allowable operations need to be specified. Specifying this annotation on the entity type itself would automatically propagate to all its derived types. Which is not what we want. Therefore, this corresponding annotation will need to be annotated on the navigation source instance of this entity type. For example:

```XML
<Annotations Target="microsoft.graph.GraphService/directoryObjects">
  <Annotation Term="Org.OData.Core.V1.ExplicitOperationBindings">
    <Collection>
      <String>microsoft.graph.checkMemberGroups</String>
      <String>microsoft.graph.checkMemberObjects</String>
      <String>microsoft.graph.getMemberGroups</String>
      <String>microsoft.graph.getMemberObjects</String>
    </Collection>
  </Annotation>
</Annotations>
```
The above will yield the paths:
```
/directoryObjects/{directoryObject-id}/microsoft.graph.checkMemberGroups
/directoryObjects/{directoryObject-id}/microsoft.graph.checkMemberObjects
/directoryObjects/{directoryObject-id}/microsoft.graph.getMemberGroups
/directoryObjects/{directoryObject-id}/microsoft.graph.getMemberObjects
```

Unless a corresponding derived type of `directoryObject` gets annotated with the `Org.OData.Core.V1.ExplicitOperationBindings`, these operations will not be created for paths of this derived type.

The net result from all this should be a significant reduction in the number of invalid operation paths and a reduction in the size of the OpenAPI document and consequently our SDKs. The appropriate annotations will need to be added to the CSDL through XSLT initially and later by workload teams to realise this.

**NB:** The default behaviour is preserved (all operations generated for the bound entity types) when none of these annotations are specified anywhere.