### PR TITLE
[Fix] Resolves operation ids for `$count` and overloaded functions paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -320,10 +320,6 @@ namespace Microsoft.OpenApi.OData.Common
                 {
                     listOrGet = !isIndexedCollValuedNavProp && (secondLastSegment as ODataNavigationPropertySegment)?.NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many ? "List" : "Get";
                 }
-                else
-                {
-                    listOrGet = null;
-                }
 
                 operationId = GenerateNavigationPropertyPathOperationId(path, listOrGet);
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -318,15 +318,7 @@ namespace Microsoft.OpenApi.OData.Common
                 string listOrGet = null;
                 if (includeListOrGetPrefix)
                 {
-                    if (!isIndexedCollValuedNavProp &&
-                    (secondLastSegment as ODataNavigationPropertySegment)?.NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
-                    {
-                        listOrGet = "List";
-                    }
-                    else
-                    {
-                        listOrGet = "Get";
-                    }
+                    listOrGet = !isIndexedCollValuedNavProp && (secondLastSegment as ODataNavigationPropertySegment)?.NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many ? "List" : "Get";
                 }
                 else
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -279,7 +279,7 @@ namespace Microsoft.OpenApi.OData.Common
         /// Generates the operation id prefix from an OData type cast path.
         /// </summary>
         /// <param name="path">The target <see cref="ODataPath"/>.</param>
-        /// <param name="includeListOrGetPrefix"></param>
+        /// <param name="includeListOrGetPrefix">Optional: Whether to include the List or Get prefix to the generated operation id.</param>
         /// <returns>The operation id prefix generated from the OData type cast path.</returns>
         internal static string GenerateODataTypeCastPathOperationIdPrefix(ODataPath path, bool includeListOrGetPrefix = true)
         {

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmModelExtensions.cs
@@ -195,7 +195,7 @@ namespace Microsoft.OpenApi.OData.Edm
 
             return model.GetAllElements().OfType<IEdmOperation>()
                 .Where(o => o.IsBound == operation.IsBound && o.FullName() == operation.FullName() &&
-                o.Parameters.First().Type.Definition == operation.Parameters.First().Type.Definition
+                o.Parameters.First().Type.Definition.FullTypeName() == operation.Parameters.First().Type.Definition.FullTypeName()
                 ).Count() > 1;
         }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,19 +15,13 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.4.0</Version>
+    <Version>1.5.0-preview1</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-- DELETE methods should always return response status code #204
-- Aliases or strips namespace prefixes from segment names when and where applicable #365
-- Adds support for all Org.OData.Core.V1.RevisionKind enum values #372
-- Use directly annotated CountRestriction annotations when creating $count segments for collection-valued navigation properties #328
-- Use MediaType annotation to set the content types of operations with Edm.Stream return types #342
-- Retrieves navigation properties from base types #371
-- Adds support for RequiresExplicitBinding and ExplicitOperationBindings annotations for operations #323 #232
+- Resolves operation ids for $count and overloaded functions paths #382, #383
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -134,7 +134,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 else if (SecondLastSegment is ODataTypeCastSegment odataTypeCastSegment)
                 {
                     IEdmNamedElement targetStructuredType = odataTypeCastSegment.StructuredType as IEdmNamedElement;
-                    operation.OperationId = $"{EdmModelHelper.GenerateODataTypeCastPathOperationIdPrefix(Path)}.GetCount.As{Utils.UpperFirstChar(targetStructuredType.Name)}-{Path.GetPathHash(Context.Settings)}";
+                    operation.OperationId = $"{EdmModelHelper.GenerateODataTypeCastPathOperationIdPrefix(Path, false)}.GetCount.As{Utils.UpperFirstChar(targetStructuredType.Name)}-{Path.GetPathHash(Context.Settings)}";
                 }
                 else if (SecondLastSegment is ODataComplexPropertySegment)
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.OData.Operation
             operation.Summary = "Invoke " + (EdmOperation.IsAction() ? "action " : "function ") + EdmOperation.Name;
 
             // Description
-            operation.Description = Context.Model.GetDescriptionAnnotation(EdmOperation);         
+            operation.Description = Context.Model.GetDescriptionAnnotation(EdmOperation);
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -72,7 +72,6 @@ namespace Microsoft.OpenApi.OData.Operation
                 // its EntityType name will be used
                 // in the operationId to avoid potential
                 // duplicates in entity vs entityset functions/actions
-                // Also, use path hash for function overloads
 
                 List<string> identifiers = new();
                 foreach (ODataSegment segment in Path.Segments)
@@ -88,13 +87,6 @@ namespace Microsoft.OpenApi.OData.Operation
                 }
                                 
                 string operationId = string.Join(".", identifiers);
-                if (EdmOperation.IsFunction() && EdmOperation.Parameters.Any(x => x.Name != "bindingParameter"))
-                {
-                    // Add a hash suffix to operation ids of
-                    // functions with parameters to avoid duplicates 
-                    // in cases of overloaded functions.
-                    operationId += $"-{Path.GetPathHash(Context.Settings)}";
-                }
 
                 if (EdmOperation.IsAction())
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OpenApi.OData.Operation
                         identifiers.Add(segment.EntityType.Name);
                     }
                 }
-                                
+
                 string operationId = string.Join(".", identifiers);
 
                 if (EdmOperation.IsAction())

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.OData.Operation
             operation.Summary = "Invoke " + (EdmOperation.IsAction() ? "action " : "function ") + EdmOperation.Name;
 
             // Description
-            operation.Description = Context.Model.GetDescriptionAnnotation(EdmOperation);
+            operation.Description = Context.Model.GetDescriptionAnnotation(EdmOperation);         
 
             // OperationId
             if (Context.Settings.EnableOperationId)
@@ -72,6 +72,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 // its EntityType name will be used
                 // in the operationId to avoid potential
                 // duplicates in entity vs entityset functions/actions
+                // Also, use path hash for function overloads
 
                 List<string> identifiers = new();
                 foreach (ODataSegment segment in Path.Segments)
@@ -85,8 +86,15 @@ namespace Microsoft.OpenApi.OData.Operation
                         identifiers.Add(segment.EntityType.Name);
                     }
                 }
-
+                                
                 string operationId = string.Join(".", identifiers);
+                if (EdmOperation.IsFunction() && EdmOperation.Parameters.Any(x => x.Name != "bindingParameter"))
+                {
+                    // Add a hash suffix to operation ids of
+                    // functions with parameters to avoid duplicates 
+                    // in cases of overloaded functions.
+                    operationId += $"-{Path.GetPathHash(Context.Settings)}";
+                }
 
                 if (EdmOperation.IsAction())
                 {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1031,7 +1031,7 @@
     "/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Airports.EmergencyAuthority.ListAddressInfo.GetCount.AsEventLocation-e708",
+        "operationId": "Airports.EmergencyAuthority.AddressInfo.GetCount.AsEventLocation-e708",
         "parameters": [
           {
             "in": "path",
@@ -1610,7 +1610,7 @@
     "/Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListAddressInfo.GetCount.AsEventLocation-5575",
+        "operationId": "Me.AddressInfo.GetCount.AsEventLocation-5575",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -2073,7 +2073,7 @@
     "/Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0105",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-0105",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -2800,7 +2800,7 @@
     "/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-42c7",
+        "operationId": "Me.Friends.AddressInfo.GetCount.AsEventLocation-42c7",
         "parameters": [
           {
             "in": "path",
@@ -3399,7 +3399,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsEmployee-884b",
+        "operationId": "Me.Friends.GetCount.AsEmployee-884b",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -3547,7 +3547,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsManager-9376",
+        "operationId": "Me.Friends.GetCount.AsManager-9376",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -4201,7 +4201,7 @@
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -4855,7 +4855,7 @@
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8",
+        "operationId": "Me.Friends.AddressInfo.GetCount.AsEventLocation-feb8",
         "parameters": [
           {
             "in": "path",
@@ -5373,7 +5373,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsManager-85ff",
+        "operationId": "Me.Friends.GetCount.AsManager-85ff",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -5832,7 +5832,7 @@
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Peers.ListAddressInfo.GetCount.AsEventLocation-be1d",
+        "operationId": "Me.Peers.AddressInfo.GetCount.AsEventLocation-be1d",
         "parameters": [
           {
             "in": "path",
@@ -7647,7 +7647,7 @@
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-692e",
         "parameters": [
           {
             "in": "header",
@@ -8309,7 +8309,7 @@
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.DirectReports.ListAddressInfo.GetCount.AsEventLocation-a070",
+        "operationId": "Me.DirectReports.AddressInfo.GetCount.AsEventLocation-a070",
         "parameters": [
           {
             "in": "path",
@@ -9067,7 +9067,7 @@
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69",
+        "operationId": "Me.Friends.AddressInfo.GetCount.AsEventLocation-4d69",
         "parameters": [
           {
             "in": "path",
@@ -9585,7 +9585,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsEmployee-6a35",
+        "operationId": "Me.Friends.GetCount.AsEmployee-6a35",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -11913,7 +11913,7 @@
     "/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.ListAddressInfo.GetCount.AsEventLocation-29d3",
+        "operationId": "NewComePeople.AddressInfo.GetCount.AsEventLocation-29d3",
         "parameters": [
           {
             "in": "path",
@@ -12469,7 +12469,7 @@
     "/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.BestFriend.ListAddressInfo.GetCount.AsEventLocation-ba36",
+        "operationId": "NewComePeople.BestFriend.AddressInfo.GetCount.AsEventLocation-ba36",
         "parameters": [
           {
             "in": "path",
@@ -13261,7 +13261,7 @@
     "/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.Friends.ListAddressInfo.GetCount.AsEventLocation-be92",
+        "operationId": "NewComePeople.Friends.AddressInfo.GetCount.AsEventLocation-be92",
         "parameters": [
           {
             "in": "path",
@@ -13876,7 +13876,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.ListFriends.GetCount.AsEmployee-4069",
+        "operationId": "NewComePeople.Friends.GetCount.AsEmployee-4069",
         "parameters": [
           {
             "in": "path",
@@ -14026,7 +14026,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.ListFriends.GetCount.AsManager-d1d3",
+        "operationId": "NewComePeople.Friends.GetCount.AsManager-d1d3",
         "parameters": [
           {
             "in": "path",
@@ -15915,7 +15915,7 @@
     "/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.ListAddressInfo.GetCount.AsEventLocation-4abd",
+        "operationId": "People.AddressInfo.GetCount.AsEventLocation-4abd",
         "parameters": [
           {
             "in": "path",
@@ -16470,7 +16470,7 @@
     "/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-fe88",
+        "operationId": "People.BestFriend.AddressInfo.GetCount.AsEventLocation-fe88",
         "parameters": [
           {
             "in": "path",
@@ -17303,7 +17303,7 @@
     "/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-2795",
+        "operationId": "People.Friends.AddressInfo.GetCount.AsEventLocation-2795",
         "parameters": [
           {
             "in": "path",
@@ -17982,7 +17982,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsEmployee-a96c",
+        "operationId": "People.Friends.GetCount.AsEmployee-a96c",
         "parameters": [
           {
             "in": "path",
@@ -18146,7 +18146,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsManager-26b3",
+        "operationId": "People.Friends.GetCount.AsManager-26b3",
         "parameters": [
           {
             "in": "path",
@@ -18932,7 +18932,7 @@
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343",
+        "operationId": "People.BestFriend.AddressInfo.GetCount.AsEventLocation-0343",
         "parameters": [
           {
             "in": "path",
@@ -19684,7 +19684,7 @@
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b",
+        "operationId": "People.Friends.AddressInfo.GetCount.AsEventLocation-1f2b",
         "parameters": [
           {
             "in": "path",
@@ -20274,7 +20274,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsManager-b145",
+        "operationId": "People.Friends.GetCount.AsManager-b145",
         "parameters": [
           {
             "in": "path",
@@ -20797,7 +20797,7 @@
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Peers.ListAddressInfo.GetCount.AsEventLocation-ef5e",
+        "operationId": "People.Peers.AddressInfo.GetCount.AsEventLocation-ef5e",
         "parameters": [
           {
             "in": "path",
@@ -22888,7 +22888,7 @@
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3",
+        "operationId": "People.BestFriend.AddressInfo.GetCount.AsEventLocation-5af3",
         "parameters": [
           {
             "in": "path",
@@ -23648,7 +23648,7 @@
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.DirectReports.ListAddressInfo.GetCount.AsEventLocation-5d49",
+        "operationId": "People.DirectReports.AddressInfo.GetCount.AsEventLocation-5d49",
         "parameters": [
           {
             "in": "path",
@@ -24518,7 +24518,7 @@
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count": {
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480",
+        "operationId": "People.Friends.AddressInfo.GetCount.AsEventLocation-4480",
         "parameters": [
           {
             "in": "path",
@@ -25108,7 +25108,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsEmployee-f325",
+        "operationId": "People.Friends.GetCount.AsEmployee-f325",
         "parameters": [
           {
             "in": "path",
@@ -27298,7 +27298,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Person.ListPerson.GetCount.AsEmployee-ef29",
+        "operationId": "People.Person.Person.GetCount.AsEmployee-ef29",
         "parameters": [
           {
             "in": "header",
@@ -27458,7 +27458,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Person.ListPerson.GetCount.AsManager-2d48",
+        "operationId": "People.Person.Person.GetCount.AsManager-2d48",
         "parameters": [
           {
             "in": "header",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -691,7 +691,7 @@ paths:
   '/Airports/{IcaoCode}/Location/EmergencyAuthority/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: Airports.EmergencyAuthority.ListAddressInfo.GetCount.AsEventLocation-e708
+      operationId: Airports.EmergencyAuthority.AddressInfo.GetCount.AsEventLocation-e708
       parameters:
         - in: path
           name: IcaoCode
@@ -1082,7 +1082,7 @@ paths:
   /Me/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
     get:
       summary: Get the number of the resource
-      operationId: Me.ListAddressInfo.GetCount.AsEventLocation-5575
+      operationId: Me.AddressInfo.GetCount.AsEventLocation-5575
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -1402,7 +1402,7 @@ paths:
   /Me/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
     get:
       summary: Get the number of the resource
-      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0105
+      operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-0105
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -1915,7 +1915,7 @@ paths:
   '/Me/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-42c7
+      operationId: Me.Friends.AddressInfo.GetCount.AsEventLocation-42c7
       parameters:
         - in: path
           name: UserName
@@ -2344,7 +2344,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsEmployee-884b
+      operationId: Me.Friends.GetCount.AsEmployee-884b
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -2450,7 +2450,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsManager-9376
+      operationId: Me.Friends.GetCount.AsManager-9376
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -2907,7 +2907,7 @@ paths:
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
     get:
       summary: Get the number of the resource
-      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c
+      operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -3365,7 +3365,7 @@ paths:
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8
+      operationId: Me.Friends.AddressInfo.GetCount.AsEventLocation-feb8
       parameters:
         - in: path
           name: UserName
@@ -3733,7 +3733,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsManager-85ff
+      operationId: Me.Friends.GetCount.AsManager-85ff
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -4051,7 +4051,7 @@ paths:
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: Me.Peers.ListAddressInfo.GetCount.AsEventLocation-be1d
+      operationId: Me.Peers.AddressInfo.GetCount.AsEventLocation-be1d
       parameters:
         - in: path
           name: UserName
@@ -5333,7 +5333,7 @@ paths:
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count:
     get:
       summary: Get the number of the resource
-      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e
+      operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-692e
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -5796,7 +5796,7 @@ paths:
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: Me.DirectReports.ListAddressInfo.GetCount.AsEventLocation-a070
+      operationId: Me.DirectReports.AddressInfo.GetCount.AsEventLocation-a070
       parameters:
         - in: path
           name: UserName
@@ -6322,7 +6322,7 @@ paths:
   '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69
+      operationId: Me.Friends.AddressInfo.GetCount.AsEventLocation-4d69
       parameters:
         - in: path
           name: UserName
@@ -6690,7 +6690,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsEmployee-6a35
+      operationId: Me.Friends.GetCount.AsEmployee-6a35
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -8334,7 +8334,7 @@ paths:
   '/NewComePeople/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: NewComePeople.ListAddressInfo.GetCount.AsEventLocation-29d3
+      operationId: NewComePeople.AddressInfo.GetCount.AsEventLocation-29d3
       parameters:
         - in: path
           name: UserName
@@ -8721,7 +8721,7 @@ paths:
   '/NewComePeople/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: NewComePeople.BestFriend.ListAddressInfo.GetCount.AsEventLocation-ba36
+      operationId: NewComePeople.BestFriend.AddressInfo.GetCount.AsEventLocation-ba36
       parameters:
         - in: path
           name: UserName
@@ -9276,7 +9276,7 @@ paths:
   '/NewComePeople/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: NewComePeople.Friends.ListAddressInfo.GetCount.AsEventLocation-be92
+      operationId: NewComePeople.Friends.AddressInfo.GetCount.AsEventLocation-be92
       parameters:
         - in: path
           name: UserName
@@ -9709,7 +9709,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get the number of the resource
-      operationId: NewComePeople.ListFriends.GetCount.AsEmployee-4069
+      operationId: NewComePeople.Friends.GetCount.AsEmployee-4069
       parameters:
         - in: path
           name: UserName
@@ -9815,7 +9815,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get the number of the resource
-      operationId: NewComePeople.ListFriends.GetCount.AsManager-d1d3
+      operationId: NewComePeople.Friends.GetCount.AsManager-d1d3
       parameters:
         - in: path
           name: UserName
@@ -11132,7 +11132,7 @@ paths:
   '/People/{UserName}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.ListAddressInfo.GetCount.AsEventLocation-4abd
+      operationId: People.AddressInfo.GetCount.AsEventLocation-4abd
       parameters:
         - in: path
           name: UserName
@@ -11520,7 +11520,7 @@ paths:
   '/People/{UserName}/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-fe88
+      operationId: People.BestFriend.AddressInfo.GetCount.AsEventLocation-fe88
       parameters:
         - in: path
           name: UserName
@@ -12112,7 +12112,7 @@ paths:
   '/People/{UserName}/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-2795
+      operationId: People.Friends.AddressInfo.GetCount.AsEventLocation-2795
       parameters:
         - in: path
           name: UserName
@@ -12601,7 +12601,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsEmployee-a96c
+      operationId: People.Friends.GetCount.AsEmployee-a96c
       parameters:
         - in: path
           name: UserName
@@ -12719,7 +12719,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsManager-26b3
+      operationId: People.Friends.GetCount.AsManager-26b3
       parameters:
         - in: path
           name: UserName
@@ -13273,7 +13273,7 @@ paths:
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343
+      operationId: People.BestFriend.AddressInfo.GetCount.AsEventLocation-0343
       parameters:
         - in: path
           name: UserName
@@ -13804,7 +13804,7 @@ paths:
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b
+      operationId: People.Friends.AddressInfo.GetCount.AsEventLocation-1f2b
       parameters:
         - in: path
           name: UserName
@@ -14226,7 +14226,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsManager-b145
+      operationId: People.Friends.GetCount.AsManager-b145
       parameters:
         - in: path
           name: UserName
@@ -14592,7 +14592,7 @@ paths:
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.Peers.ListAddressInfo.GetCount.AsEventLocation-ef5e
+      operationId: People.Peers.AddressInfo.GetCount.AsEventLocation-ef5e
       parameters:
         - in: path
           name: UserName
@@ -16079,7 +16079,7 @@ paths:
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3
+      operationId: People.BestFriend.AddressInfo.GetCount.AsEventLocation-5af3
       parameters:
         - in: path
           name: UserName
@@ -16615,7 +16615,7 @@ paths:
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.DirectReports.ListAddressInfo.GetCount.AsEventLocation-5d49
+      operationId: People.DirectReports.AddressInfo.GetCount.AsEventLocation-5d49
       parameters:
         - in: path
           name: UserName
@@ -17225,7 +17225,7 @@ paths:
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/AddressInfo/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation/$count':
     get:
       summary: Get the number of the resource
-      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480
+      operationId: People.Friends.AddressInfo.GetCount.AsEventLocation-4480
       parameters:
         - in: path
           name: UserName
@@ -17647,7 +17647,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsEmployee-f325
+      operationId: People.Friends.GetCount.AsEmployee-f325
       parameters:
         - in: path
           name: UserName
@@ -19215,7 +19215,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Person.ListPerson.GetCount.AsEmployee-ef29
+      operationId: People.Person.Person.GetCount.AsEmployee-ef29
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -19329,7 +19329,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Person.ListPerson.GetCount.AsManager-2d48
+      operationId: People.Person.Person.GetCount.AsManager-2d48
       parameters:
         - in: header
           name: ConsistencyLevel

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1155,7 +1155,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Airports.EmergencyAuthority.ListAddressInfo.GetCount.AsEventLocation-e708",
+        "operationId": "Airports.EmergencyAuthority.AddressInfo.GetCount.AsEventLocation-e708",
         "parameters": [
           {
             "name": "IcaoCode",
@@ -1817,7 +1817,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListAddressInfo.GetCount.AsEventLocation-5575",
+        "operationId": "Me.AddressInfo.GetCount.AsEventLocation-5575",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -2302,7 +2302,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0105",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-0105",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -3105,7 +3105,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-42c7",
+        "operationId": "Me.Friends.AddressInfo.GetCount.AsEventLocation-42c7",
         "parameters": [
           {
             "name": "UserName",
@@ -3766,7 +3766,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsEmployee-884b",
+        "operationId": "Me.Friends.GetCount.AsEmployee-884b",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -3929,7 +3929,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsManager-9376",
+        "operationId": "Me.Friends.GetCount.AsManager-9376",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -4624,7 +4624,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -5343,7 +5343,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8",
+        "operationId": "Me.Friends.AddressInfo.GetCount.AsEventLocation-feb8",
         "parameters": [
           {
             "name": "UserName",
@@ -5910,7 +5910,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsManager-85ff",
+        "operationId": "Me.Friends.GetCount.AsManager-85ff",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -6415,7 +6415,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Peers.ListAddressInfo.GetCount.AsEventLocation-be1d",
+        "operationId": "Me.Peers.AddressInfo.GetCount.AsEventLocation-be1d",
         "parameters": [
           {
             "name": "UserName",
@@ -8406,7 +8406,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e",
+        "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-692e",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -9149,7 +9149,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.DirectReports.ListAddressInfo.GetCount.AsEventLocation-a070",
+        "operationId": "Me.DirectReports.AddressInfo.GetCount.AsEventLocation-a070",
         "parameters": [
           {
             "name": "UserName",
@@ -9982,7 +9982,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69",
+        "operationId": "Me.Friends.AddressInfo.GetCount.AsEventLocation-4d69",
         "parameters": [
           {
             "name": "UserName",
@@ -10549,7 +10549,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.ListFriends.GetCount.AsEmployee-6a35",
+        "operationId": "Me.Friends.GetCount.AsEmployee-6a35",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -13154,7 +13154,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.ListAddressInfo.GetCount.AsEventLocation-29d3",
+        "operationId": "NewComePeople.AddressInfo.GetCount.AsEventLocation-29d3",
         "parameters": [
           {
             "name": "UserName",
@@ -13776,7 +13776,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.BestFriend.ListAddressInfo.GetCount.AsEventLocation-ba36",
+        "operationId": "NewComePeople.BestFriend.AddressInfo.GetCount.AsEventLocation-ba36",
         "parameters": [
           {
             "name": "UserName",
@@ -14688,7 +14688,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.Friends.ListAddressInfo.GetCount.AsEventLocation-be92",
+        "operationId": "NewComePeople.Friends.AddressInfo.GetCount.AsEventLocation-be92",
         "parameters": [
           {
             "name": "UserName",
@@ -15395,7 +15395,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.ListFriends.GetCount.AsEmployee-4069",
+        "operationId": "NewComePeople.Friends.GetCount.AsEmployee-4069",
         "parameters": [
           {
             "name": "UserName",
@@ -15564,7 +15564,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "NewComePeople.ListFriends.GetCount.AsManager-d1d3",
+        "operationId": "NewComePeople.Friends.GetCount.AsManager-d1d3",
         "parameters": [
           {
             "name": "UserName",
@@ -17706,7 +17706,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.ListAddressInfo.GetCount.AsEventLocation-4abd",
+        "operationId": "People.AddressInfo.GetCount.AsEventLocation-4abd",
         "parameters": [
           {
             "name": "UserName",
@@ -18311,7 +18311,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-fe88",
+        "operationId": "People.BestFriend.AddressInfo.GetCount.AsEventLocation-fe88",
         "parameters": [
           {
             "name": "UserName",
@@ -19248,7 +19248,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-2795",
+        "operationId": "People.Friends.AddressInfo.GetCount.AsEventLocation-2795",
         "parameters": [
           {
             "name": "UserName",
@@ -20011,7 +20011,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsEmployee-a96c",
+        "operationId": "People.Friends.GetCount.AsEmployee-a96c",
         "parameters": [
           {
             "name": "UserName",
@@ -20194,7 +20194,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsManager-26b3",
+        "operationId": "People.Friends.GetCount.AsManager-26b3",
         "parameters": [
           {
             "name": "UserName",
@@ -21067,7 +21067,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343",
+        "operationId": "People.BestFriend.AddressInfo.GetCount.AsEventLocation-0343",
         "parameters": [
           {
             "name": "UserName",
@@ -21910,7 +21910,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b",
+        "operationId": "People.Friends.AddressInfo.GetCount.AsEventLocation-1f2b",
         "parameters": [
           {
             "name": "UserName",
@@ -22569,7 +22569,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsManager-b145",
+        "operationId": "People.Friends.GetCount.AsManager-b145",
         "parameters": [
           {
             "name": "UserName",
@@ -23154,7 +23154,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Peers.ListAddressInfo.GetCount.AsEventLocation-ef5e",
+        "operationId": "People.Peers.AddressInfo.GetCount.AsEventLocation-ef5e",
         "parameters": [
           {
             "name": "UserName",
@@ -25507,7 +25507,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3",
+        "operationId": "People.BestFriend.AddressInfo.GetCount.AsEventLocation-5af3",
         "parameters": [
           {
             "name": "UserName",
@@ -26374,7 +26374,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.DirectReports.ListAddressInfo.GetCount.AsEventLocation-5d49",
+        "operationId": "People.DirectReports.AddressInfo.GetCount.AsEventLocation-5d49",
         "parameters": [
           {
             "name": "UserName",
@@ -27349,7 +27349,7 @@
       "description": "Provides operations to count the resources in the collection.",
       "get": {
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480",
+        "operationId": "People.Friends.AddressInfo.GetCount.AsEventLocation-4480",
         "parameters": [
           {
             "name": "UserName",
@@ -28008,7 +28008,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.ListFriends.GetCount.AsEmployee-f325",
+        "operationId": "People.Friends.GetCount.AsEmployee-f325",
         "parameters": [
           {
             "name": "UserName",
@@ -30506,7 +30506,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Person.ListPerson.GetCount.AsEmployee-ef29",
+        "operationId": "People.Person.Person.GetCount.AsEmployee-ef29",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -30697,7 +30697,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Person.ListPerson.GetCount.AsManager-2d48",
+        "operationId": "People.Person.Person.GetCount.AsManager-2d48",
         "parameters": [
           {
             "name": "ConsistencyLevel",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -771,7 +771,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Airports.EmergencyAuthority.ListAddressInfo.GetCount.AsEventLocation-e708
+      operationId: Airports.EmergencyAuthority.AddressInfo.GetCount.AsEventLocation-e708
       parameters:
         - name: IcaoCode
           in: path
@@ -1205,7 +1205,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.ListAddressInfo.GetCount.AsEventLocation-5575
+      operationId: Me.AddressInfo.GetCount.AsEventLocation-5575
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -1542,7 +1542,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0105
+      operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-0105
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -2108,7 +2108,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-42c7
+      operationId: Me.Friends.AddressInfo.GetCount.AsEventLocation-42c7
       parameters:
         - name: UserName
           in: path
@@ -2582,7 +2582,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsEmployee-884b
+      operationId: Me.Friends.GetCount.AsEmployee-884b
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -2700,7 +2700,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsManager-9376
+      operationId: Me.Friends.GetCount.AsManager-9376
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -3188,7 +3188,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-842c
+      operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -3691,7 +3691,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-feb8
+      operationId: Me.Friends.AddressInfo.GetCount.AsEventLocation-feb8
       parameters:
         - name: UserName
           in: path
@@ -4095,7 +4095,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsManager-85ff
+      operationId: Me.Friends.GetCount.AsManager-85ff
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -4444,7 +4444,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.Peers.ListAddressInfo.GetCount.AsEventLocation-be1d
+      operationId: Me.Peers.AddressInfo.GetCount.AsEventLocation-be1d
       parameters:
         - name: UserName
           in: path
@@ -5848,7 +5848,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.BestFriend.ListAddressInfo.GetCount.AsEventLocation-692e
+      operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-692e
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -6366,7 +6366,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.DirectReports.ListAddressInfo.GetCount.AsEventLocation-a070
+      operationId: Me.DirectReports.AddressInfo.GetCount.AsEventLocation-a070
       parameters:
         - name: UserName
           in: path
@@ -6943,7 +6943,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: Me.Friends.ListAddressInfo.GetCount.AsEventLocation-4d69
+      operationId: Me.Friends.AddressInfo.GetCount.AsEventLocation-4d69
       parameters:
         - name: UserName
           in: path
@@ -7347,7 +7347,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.ListFriends.GetCount.AsEmployee-6a35
+      operationId: Me.Friends.GetCount.AsEmployee-6a35
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -9171,7 +9171,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: NewComePeople.ListAddressInfo.GetCount.AsEventLocation-29d3
+      operationId: NewComePeople.AddressInfo.GetCount.AsEventLocation-29d3
       parameters:
         - name: UserName
           in: path
@@ -9599,7 +9599,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: NewComePeople.BestFriend.ListAddressInfo.GetCount.AsEventLocation-ba36
+      operationId: NewComePeople.BestFriend.AddressInfo.GetCount.AsEventLocation-ba36
       parameters:
         - name: UserName
           in: path
@@ -10231,7 +10231,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: NewComePeople.Friends.ListAddressInfo.GetCount.AsEventLocation-be92
+      operationId: NewComePeople.Friends.AddressInfo.GetCount.AsEventLocation-be92
       parameters:
         - name: UserName
           in: path
@@ -10725,7 +10725,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get the number of the resource
-      operationId: NewComePeople.ListFriends.GetCount.AsEmployee-4069
+      operationId: NewComePeople.Friends.GetCount.AsEmployee-4069
       parameters:
         - name: UserName
           in: path
@@ -10845,7 +10845,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get the number of the resource
-      operationId: NewComePeople.ListFriends.GetCount.AsManager-d1d3
+      operationId: NewComePeople.Friends.GetCount.AsManager-d1d3
       parameters:
         - name: UserName
           in: path
@@ -12321,7 +12321,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.ListAddressInfo.GetCount.AsEventLocation-4abd
+      operationId: People.AddressInfo.GetCount.AsEventLocation-4abd
       parameters:
         - name: UserName
           in: path
@@ -12740,7 +12740,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-fe88
+      operationId: People.BestFriend.AddressInfo.GetCount.AsEventLocation-fe88
       parameters:
         - name: UserName
           in: path
@@ -13399,7 +13399,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-2795
+      operationId: People.Friends.AddressInfo.GetCount.AsEventLocation-2795
       parameters:
         - name: UserName
           in: path
@@ -13944,7 +13944,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsEmployee-a96c
+      operationId: People.Friends.GetCount.AsEmployee-a96c
       parameters:
         - name: UserName
           in: path
@@ -14076,7 +14076,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsManager-26b3
+      operationId: People.Friends.GetCount.AsManager-26b3
       parameters:
         - name: UserName
           in: path
@@ -14685,7 +14685,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-0343
+      operationId: People.BestFriend.AddressInfo.GetCount.AsEventLocation-0343
       parameters:
         - name: UserName
           in: path
@@ -15274,7 +15274,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-1f2b
+      operationId: People.Friends.AddressInfo.GetCount.AsEventLocation-1f2b
       parameters:
         - name: UserName
           in: path
@@ -15742,7 +15742,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsManager-b145
+      operationId: People.Friends.GetCount.AsManager-b145
       parameters:
         - name: UserName
           in: path
@@ -16147,7 +16147,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.Peers.ListAddressInfo.GetCount.AsEventLocation-ef5e
+      operationId: People.Peers.AddressInfo.GetCount.AsEventLocation-ef5e
       parameters:
         - name: UserName
           in: path
@@ -17800,7 +17800,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.BestFriend.ListAddressInfo.GetCount.AsEventLocation-5af3
+      operationId: People.BestFriend.AddressInfo.GetCount.AsEventLocation-5af3
       parameters:
         - name: UserName
           in: path
@@ -18404,7 +18404,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.DirectReports.ListAddressInfo.GetCount.AsEventLocation-5d49
+      operationId: People.DirectReports.AddressInfo.GetCount.AsEventLocation-5d49
       parameters:
         - name: UserName
           in: path
@@ -19080,7 +19080,7 @@ paths:
     description: Provides operations to count the resources in the collection.
     get:
       summary: Get the number of the resource
-      operationId: People.Friends.ListAddressInfo.GetCount.AsEventLocation-4480
+      operationId: People.Friends.AddressInfo.GetCount.AsEventLocation-4480
       parameters:
         - name: UserName
           in: path
@@ -19548,7 +19548,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.ListFriends.GetCount.AsEmployee-f325
+      operationId: People.Friends.GetCount.AsEmployee-f325
       parameters:
         - name: UserName
           in: path
@@ -21308,7 +21308,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Person.ListPerson.GetCount.AsEmployee-ef29
+      operationId: People.Person.Person.GetCount.AsEmployee-ef29
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -21444,7 +21444,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Person.ListPerson.GetCount.AsManager-2d48
+      operationId: People.Person.Person.GetCount.AsManager-2d48
       parameters:
         - name: ConsistencyLevel
           in: header


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/383, https://github.com/microsoft/OpenAPI.NET.OData/issues/382

This PR:
- Updates the operation id generation function for both $count and overloaded function paths.
- Updates the release note.
- Updates integration tests.