### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![nuget](https://img.shields.io/nuget/v/Microsoft.OpenApi.OData.svg)](https://www.nuget.org/packages/Microsoft.OpenApi.OData/)
 
-# Convert OData to OpenAPI.NET [Preview]
-
-[**Disclaimer:This library is in a preview state. Feedback and contribution is welcome!**]
+# Convert OData to OpenAPI.NET
 
 ## Introduction
 
@@ -83,11 +81,6 @@ The `GetEdmModel()` method can load a model in 3 ways:
 
 3. Create the Edm model using Web API OData model builder. For details refer to the [web api model builder article](http://odata.github.io/WebApi/#02-01-model-builder-abstract)
 
-## Nightly builds
-
-The nightly build process will upload a Nuget package for OpenAPI.OData.reader to [OpenAPIOData MyGet gallery](https://www.myget.org/gallery/openapiodata).
-
-To connect to OpenAPI.OData.reader feed, use [this](https://www.myget.org/F/openapiodata/api/v3/index.json) URL source.
 
 ## Nuget packages
 
@@ -104,6 +97,8 @@ the rights to use your contribution. For details, visit [https://cla.microsoft.c
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
+
+You can also open an issue directly on this repo via this [link](https://github.com/microsoft/OpenAPI.NET.OData/issues/new?assignees=&labels=&projects=&template=bug_report.md).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -31,6 +31,7 @@
     <DocumentationFile>..\..\bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <Import Project="..\Build.props" />
@@ -46,6 +47,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -22,6 +22,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
 - Resolves operation ids for $count and overloaded functions paths #382, #383
+- Updates README #13, #253, #40
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/OoasUtil/README.md
+++ b/src/OoasUtil/README.md
@@ -72,3 +72,7 @@ Indicate to output file name.
 
 The content of `trip.json` is similar at https://github.com/xuzhg/OData.OpenAPI/blob/master/Microsoft.OData.OpenAPI/Microsoft.OData.OpenAPI.Tests/Resources/TripService.OpenApi.json
 
+# Alternative Tool - Hidi
+
+This OoasUtil Command tool is currently not actively maintained, and an alternative command line tool, Hidi, is available for use in converting CSDL to OpenAPI. You can find the link to its README [here](https://github.com/microsoft/OpenAPI.NET/blob/vnext/src/Microsoft.OpenApi.Hidi/readme.md) which includes setup instructions.
+


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/13, https://github.com/microsoft/OpenAPI.NET.OData/issues/253, https://github.com/microsoft/OpenAPI.NET.OData/issues/40

This PR:

- Updates the README for the main library and the `OoasUtil` tool.
- Update the main library README to show in nuget package releases as well.