### PR TITLE
Fixes casing for innerError property in MainError

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiErrorSchemaGenerator.cs
@@ -155,7 +155,7 @@ namespace Microsoft.OpenApi.OData.Generator
                         }
                     },
                     {
-                        "innererror",
+                        "innerError",
                         new OpenApiSchema
                         {
                             UnresolvedReference = true,

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.5.0-preview1</Version>
+    <Version>1.5.0-preview2</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -23,6 +23,7 @@
     <PackageReleaseNotes>
 - Resolves operation ids for $count and overloaded functions paths #382, #383
 - Updates README #13, #253, #40
+- Fixes casing in default propertyName for `innerError` in the `ErrorMainSchema`
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.json
@@ -1045,7 +1045,7 @@
             "$ref": "#/definitions/DefaultNs.ODataErrors.ErrorDetails"
           }
         },
-        "innererror": {
+        "innerError": {
           "$ref": "#/definitions/DefaultNs.ODataErrors.InnerError"
         }
       }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.V2.yaml
@@ -685,7 +685,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/DefaultNs.ODataErrors.ErrorDetails'
-      innererror:
+      innerError:
         $ref: '#/definitions/DefaultNs.ODataErrors.InnerError'
   DefaultNs.ODataErrors.ErrorDetails:
     required:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.json
@@ -1149,7 +1149,7 @@
               "$ref": "#/components/schemas/DefaultNs.ODataErrors.ErrorDetails"
             }
           },
-          "innererror": {
+          "innerError": {
             "$ref": "#/components/schemas/DefaultNs.ODataErrors.InnerError"
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Basic.OpenApi.yaml
@@ -755,7 +755,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DefaultNs.ODataErrors.ErrorDetails'
-        innererror:
+        innerError:
           $ref: '#/components/schemas/DefaultNs.ODataErrors.InnerError'
     DefaultNs.ODataErrors.ErrorDetails:
       required:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.json
@@ -44,7 +44,7 @@
             "$ref": "#/definitions/ODataErrors.ErrorDetails"
           }
         },
-        "innererror": {
+        "innerError": {
           "$ref": "#/definitions/ODataErrors.InnerError"
         }
       }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.V2.yaml
@@ -31,7 +31,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ODataErrors.ErrorDetails'
-      innererror:
+      innerError:
         $ref: '#/definitions/ODataErrors.InnerError'
   ODataErrors.ErrorDetails:
     required:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.json
@@ -47,7 +47,7 @@
               "$ref": "#/components/schemas/ODataErrors.ErrorDetails"
             }
           },
-          "innererror": {
+          "innerError": {
             "$ref": "#/components/schemas/ODataErrors.InnerError"
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Empty.OpenApi.yaml
@@ -32,7 +32,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ODataErrors.ErrorDetails'
-        innererror:
+        innerError:
           $ref: '#/components/schemas/ODataErrors.InnerError'
     ODataErrors.ErrorDetails:
       required:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -5782,7 +5782,7 @@
             "$ref": "#/definitions/Default.ODataErrors.ErrorDetails"
           }
         },
-        "innererror": {
+        "innerError": {
           "$ref": "#/definitions/Default.ODataErrors.InnerError"
         }
       }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -4207,7 +4207,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Default.ODataErrors.ErrorDetails'
-      innererror:
+      innerError:
         $ref: '#/definitions/Default.ODataErrors.InnerError'
   Default.ODataErrors.ErrorDetails:
     required:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -6517,7 +6517,7 @@
               "$ref": "#/components/schemas/Default.ODataErrors.ErrorDetails"
             }
           },
-          "innererror": {
+          "innerError": {
             "$ref": "#/components/schemas/Default.ODataErrors.InnerError"
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -4696,7 +4696,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Default.ODataErrors.ErrorDetails'
-        innererror:
+        innerError:
           $ref: '#/components/schemas/Default.ODataErrors.InnerError'
     Default.ODataErrors.ErrorDetails:
       required:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -28151,7 +28151,7 @@
             "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails"
           }
         },
-        "innererror": {
+        "innerError": {
           "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError"
         }
       }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -19776,7 +19776,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails'
-      innererror:
+      innerError:
         $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError'
   Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails:
     required:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -31542,7 +31542,7 @@
               "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails"
             }
           },
-          "innererror": {
+          "innerError": {
             "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError"
           }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -21963,7 +21963,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails'
-        innererror:
+        innerError:
           $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.InnerError'
     Microsoft.OData.Service.Sample.TrippinInMemory.Models.ODataErrors.ErrorDetails:
       required:


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1916

This fixes the casing in the default property name for `innerError`. This leads to generation of models with the property as `innererror` causing failing deserialization of the property and therefore the property moved to the additionalData.

Additionally, the [metadata ](https://github.com/microsoftgraph/msgraph-metadata/blob/master/clean_v10_metadata/cleanMetadataWithDescriptionsAndAnnotationsAndErrorsv1.0.xml)defines the property as being camelCased while the generated openApi results in the property name as `innererror`

```xml
<Property Name="innerError" Type="graph.publicInnerError">
  <Annotation Term="Org.OData.Core.V1.Description" String="Details of the inner error." />
</Property>
```