### PR TITLE
Pass Bitwise Enum information

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiSchemaGenerator.cs
@@ -317,6 +317,18 @@ namespace Microsoft.OpenApi.OData.Generator
                 // whose value is the value of the unqualified annotation Core.Description of the enumeration type.
                 Description = context.Model.GetDescriptionAnnotation(enumType)
             };
+            
+            // If the enum is flagged, add the extension info to the description
+            if (context.Settings.AddEnumFlagsExtension && enumType.IsFlags)
+            {
+                var enumFlagsExtension = new OpenApiEnumFlagsExtension
+                {
+                    IsFlags = true,
+                    Style = "simple"
+                };
+                schema.Extensions.Add(enumFlagsExtension.Name, enumFlagsExtension);
+            }
+
             var extension = (context.Settings.OpenApiSpecVersion == OpenApiSpecVersion.OpenApi2_0 ||
                             context.Settings.OpenApiSpecVersion == OpenApiSpecVersion.OpenApi3_0 ) &&
                             context.Settings.AddEnumDescriptionExtension ? 

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.5.0-preview2</Version>
+    <Version>1.5.0-preview3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -24,6 +24,7 @@
 - Resolves operation ids for $count and overloaded functions paths #382, #383
 - Updates README #13, #253, #40
 - Fixes casing in default propertyName for `innerError` in the `ErrorMainSchema`
+- Adds support for `x-ms-enum-flags` extension for flagged enums
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -262,6 +262,11 @@ namespace Microsoft.OpenApi.OData
         public bool AddEnumDescriptionExtension { get; set; } = false;
 
         /// <summary>
+        /// Gets/sets a value indicating whether or not to add a "x-ms-enum-flags" extension to the enum type schema.
+        /// </summary>
+        public bool AddEnumFlagsExtension { get; set; } = true;
+        
+        /// <summary>
         /// Gets/sets a value indicating whether the error responses should be described as a default response or as 4XX and 5XX error responses.
         /// </summary>
         public bool ErrorResponsesAsDefault { get; set; } = true;
@@ -377,6 +382,7 @@ namespace Microsoft.OpenApi.OData
                 RequireDerivedTypesConstraintForODataTypeCastSegments = this.RequireDerivedTypesConstraintForODataTypeCastSegments,
                 EnableDeprecationInformation = this.EnableDeprecationInformation,
                 AddEnumDescriptionExtension = this.AddEnumDescriptionExtension,
+                AddEnumFlagsExtension = this.AddEnumFlagsExtension,
                 ErrorResponsesAsDefault = this.ErrorResponsesAsDefault,
                 InnerErrorComplexTypeName = this.InnerErrorComplexTypeName,
                 RequireRestrictionAnnotationsToGenerateComplexPropertyPaths = this.RequireRestrictionAnnotationsToGenerateComplexPropertyPaths,

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiEnumFlagsExtension.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiExtensions/OpenApiEnumFlagsExtension.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.Writers;
+
+namespace Microsoft.OpenApi.OData.OpenApiExtensions;
+
+/// <summary>
+/// Extension element for OpenAPI to add deprecation information. x-ms-enum-flags
+/// </summary>
+public class OpenApiEnumFlagsExtension : IOpenApiExtension
+{
+    /// <summary>
+    /// Name of the extension as used in the description.
+    /// </summary>
+    public string Name => "x-ms-enum-flags";
+    /// <summary>
+    /// Whether the enum is a flagged enum.
+    /// </summary>
+    public bool IsFlags { get; set; }
+    /// <summary>
+    /// The serialization style of the flagged enum.
+    /// </summary>
+    public string Style { get; set; }
+	/// <inheritdoc />
+    public void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+    {
+        if(writer == null)
+            throw new ArgumentNullException(nameof(writer));
+        
+        writer.WriteStartObject();
+        writer.WriteProperty(nameof(IsFlags).ToFirstCharacterLowerCase(), IsFlags);
+        writer.WriteProperty(nameof(Style).ToFirstCharacterLowerCase(),Style);
+        writer.WriteEndObject();
+    } 
+}

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -17,6 +17,8 @@ Microsoft.OpenApi.OData.Edm.ODataSegment.GetPathItemName(Microsoft.OpenApi.OData
 Microsoft.OpenApi.OData.Edm.ODataTypeCastSegment.ODataTypeCastSegment(Microsoft.OData.Edm.IEdmStructuredType structuredType, Microsoft.OData.Edm.IEdmModel model) -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddAlternateKeyPaths.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumFlagsExtension.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumFlagsExtension.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>
@@ -48,6 +50,14 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.UseSuccessStatusCodeRange.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.UseSuccessStatusCodeRange.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension.IsFlags.get -> bool
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension.IsFlags.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension.Name.get -> string
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension.OpenApiEnumFlagsExtension() -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension.Style.get -> string
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension.Style.set -> void
+Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension.Write(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.OpenApiSpecVersion specVersion) -> void
 Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey
 Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey.Action = 6 -> Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey
 Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey.Create = 2 -> Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
@@ -243,6 +243,7 @@ namespace Microsoft.OpenApi.OData.Tests
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
                 EnableKeyAsSegment = true,
@@ -255,6 +256,7 @@ namespace Microsoft.OpenApi.OData.Tests
                 AppendBoundOperationsOnDerivedTypeCastSegments = true,
                 IncludeAssemblyInfo = false
             };
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Act
             string yaml = WriteEdmModelAsOpenApi(model, OpenApiFormat.Yaml, settings);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
@@ -299,7 +299,7 @@ schema:
 
             // Assert
             Assert.NotNull(parameters);
-            Assert.Equal(1, parameters.Count);
+            Assert.Single(parameters);
             string json = altParameter.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
             Assert.Equal(@"{
   ""name"": ""AltId"",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -523,7 +523,7 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Null(declaredSchema.OneOf);
 
             Assert.NotNull(declaredSchema.Properties);
-            Assert.Equal(1, declaredSchema.Properties.Count);
+            Assert.Single(declaredSchema.Properties);
             var property = Assert.Single(declaredSchema.Properties);
             Assert.Equal("Price", property.Key);
             Assert.Equal("decimal", property.Value.OneOf.FirstOrDefault(x => !string.IsNullOrEmpty(x.Format))?.Format);
@@ -674,7 +674,7 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Null(declaredSchema.OneOf);
 
             Assert.NotNull(declaredSchema.Properties);
-            Assert.Equal(1, declaredSchema.Properties.Count);
+            Assert.Single(declaredSchema.Properties);
             var property = Assert.Single(declaredSchema.Properties);
             Assert.Equal("Name", property.Key);
             Assert.Equal("string", property.Value.Type);
@@ -750,7 +750,7 @@ namespace Microsoft.OpenApi.OData.Tests
             Assert.Null(declaredSchema.OneOf);
 
             Assert.NotNull(declaredSchema.Properties);
-            Assert.Equal(1, declaredSchema.Properties.Count);
+            Assert.Single(declaredSchema.Properties);
             var property = Assert.Single(declaredSchema.Properties);
             Assert.Equal("Extra", property.Key);
             Assert.Equal("integer", property.Value.Type);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/OpenApiExtensions/OpenApiEnumFlagsExtensionTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/OpenApiExtensions/OpenApiEnumFlagsExtensionTests.cs
@@ -1,0 +1,89 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.IO;
+using Microsoft.OpenApi.Writers;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.OpenApiExtensions.Tests;
+
+public class OpenApiEnumFlagsExtensionTests
+{
+    [Fact]
+    public void ExtensionNameMatchesExpected()
+    {
+        // Arrange
+        OpenApiEnumFlagsExtension extension = new();
+
+        // Act
+        string name = extension.Name;
+        string expectedName = "x-ms-enum-flags";
+
+        // Assert
+        Assert.Equal(expectedName, name);
+    }
+
+    [Fact]
+    public void WritesDefaultValues()
+    {
+        // Arrange
+        OpenApiEnumFlagsExtension extension = new();
+        using TextWriter sWriter = new StringWriter();
+        OpenApiJsonWriter writer = new(sWriter);
+
+        // Act
+        extension.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+        string result = sWriter.ToString();
+
+        // Assert
+        Assert.False(extension.IsFlags);
+        Assert.Null(extension.Style);
+        Assert.Contains("\"isFlags\": false", result);
+        Assert.DoesNotContain("\"style\"", result);
+    }
+    
+    [Fact]
+    public void WritesAllDefaultValues()
+    {
+        // Arrange
+        OpenApiEnumFlagsExtension extension = new() {
+            IsFlags = true
+        };
+        using TextWriter sWriter = new StringWriter();
+        OpenApiJsonWriter writer = new(sWriter);
+
+        // Act
+        extension.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+        string result = sWriter.ToString();
+
+        // Assert
+        Assert.True(extension.IsFlags);
+        Assert.Null(extension.Style);
+        Assert.Contains("\"isFlags\": true", result);
+        Assert.DoesNotContain("\"style\":", result);
+    }
+
+    [Fact]
+    public void WritesAllValues()
+    {
+        // Arrange
+        OpenApiEnumFlagsExtension extension = new() {
+            IsFlags = true,
+            Style = "simple"
+        };
+        using TextWriter sWriter = new StringWriter();
+        OpenApiJsonWriter writer = new(sWriter);
+
+        // Act
+        extension.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+        string result = sWriter.ToString();
+
+        // Assert
+        Assert.True(extension.IsFlags);
+        Assert.NotNull(extension.Style);
+        Assert.Contains("\"isFlags\": true", result);
+        Assert.Contains("\"style\": \"simple\"", result);
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPatchOperationHandlerTests.cs
@@ -41,7 +41,7 @@ public class ComplexPropertyPatchOperationHandlerTests
 		Assert.Equal("Update the BillingAddress value.", patch.Description);
 
 		Assert.NotNull(patch.Parameters);
-		Assert.Equal(1, patch.Parameters.Count); //id
+		Assert.Single(patch.Parameters); //id
 
 		Assert.NotNull(patch.Responses);
 		Assert.Equal(2, patch.Responses.Count);
@@ -85,7 +85,7 @@ public class ComplexPropertyPatchOperationHandlerTests
         Assert.Equal("Update the BillingAddress value.", patch.Description);
 
 		Assert.NotNull(patch.Parameters);
-		Assert.Equal(1, patch.Parameters.Count); //id
+		Assert.Single(patch.Parameters); //id
 
 		Assert.NotNull(patch.Responses);
 		Assert.Equal(2, patch.Responses.Count);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPutOperationHandlerTests.cs
@@ -44,7 +44,7 @@ public class ComplexPropertyPutOperationHandlerTests
 		Assert.Equal("Update the BillingAddress value.", put.Description);
 
 		Assert.NotNull(put.Parameters);
-		Assert.Equal(1, put.Parameters.Count); //id
+		Assert.Single(put.Parameters); //id
 
 		Assert.NotNull(put.Responses);
 		Assert.Equal(2, put.Responses.Count);
@@ -95,7 +95,7 @@ public class ComplexPropertyPutOperationHandlerTests
 		Assert.Equal("Update the BillingAddress value.", put.Description);
 
 		Assert.NotNull(put.Parameters);
-		Assert.Equal(1, put.Parameters.Count); //id
+		Assert.Single(put.Parameters); //id
 
 		Assert.NotNull(put.Responses);
 		Assert.Equal(2, put.Responses.Count);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmActionOperationHandlerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("People.Actions", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(1, operation.Parameters.Count);
+            Assert.Single(operation.Parameters);
             Assert.Equal(new string[] { "UserName" }, operation.Parameters.Select(p => p.Name));
 
             Assert.NotNull(operation.RequestBody);
@@ -82,7 +82,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal($"{entitySetName}.Actions", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(1, operation.Parameters.Count);
+            Assert.Single(operation.Parameters);
             Assert.Equal(new string[] { "id" }, operation.Parameters.Select(p => p.Name));
 
             Assert.NotNull(operation.RequestBody);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EdmFunctionOperationHandlerTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("People.Functions", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(1, operation.Parameters.Count);
+            Assert.Single(operation.Parameters);
             Assert.Equal(new string[] { "UserName" }, operation.Parameters.Select(p => p.Name));
 
             Assert.Null(operation.RequestBody);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPatchOperationHandlerTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("Customers.Customer", tag.Name);
 
             Assert.NotNull(patch.Parameters);
-            Assert.Equal(1, patch.Parameters.Count);
+            Assert.Single(patch.Parameters);
 
             Assert.NotNull(patch.RequestBody);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("Customers.Customer", tag.Name);
 
             Assert.NotNull(putOperation.Parameters);
-            Assert.Equal(1, putOperation.Parameters.Count);
+            Assert.Single(putOperation.Parameters);
 
             Assert.NotNull(putOperation.RequestBody);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -105,11 +105,11 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             {
                 // RequestBody
                 Assert.NotNull(post.RequestBody);
-                Assert.Equal(1, post.RequestBody.Content.Keys.Count);
+                Assert.Single(post.RequestBody.Content.Keys);
                 Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationJsonMediaType));
 
                 // Response
-                Assert.Equal(1, post.Responses[Constants.StatusCode201].Content.Keys.Count);
+                Assert.Single(post.Responses[Constants.StatusCode201].Content.Keys);
                 Assert.True(post.Responses[Constants.StatusCode201].Content.ContainsKey(Constants.ApplicationJsonMediaType));
             }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -101,13 +101,13 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.True(getOperation.Responses[statusCode].Content.ContainsKey("image/jpeg"));
                 Assert.Equal("The logo image.", getOperation.Description);
 
-                Assert.Equal(1, getOperation2.Responses[statusCode].Content.Keys.Count);
+                Assert.Single(getOperation2.Responses[statusCode].Content.Keys);
                 Assert.True(getOperation2.Responses[statusCode].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
             }
             else
             {
-                Assert.Equal(1, getOperation.Responses[statusCode].Content.Keys.Count);
-                Assert.Equal(1, getOperation2.Responses[statusCode].Content.Keys.Count);
+                Assert.Single(getOperation.Responses[statusCode].Content.Keys);
+                Assert.Single(getOperation2.Responses[statusCode].Content.Keys);
                 Assert.True(getOperation.Responses[statusCode].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
                 Assert.True(getOperation2.Responses[statusCode].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -122,13 +122,13 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.True(putOperation.RequestBody.Content.ContainsKey("image/jpeg"));
                 Assert.Equal("The logo image.", putOperation.Description);
 
-                Assert.Equal(1, putOperation2.RequestBody.Content.Keys.Count);
+                Assert.Single(putOperation2.RequestBody.Content.Keys);
                 Assert.True(putOperation2.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
             }
             else
             {
-                Assert.Equal(1, putOperation.RequestBody.Content.Keys.Count);
-                Assert.Equal(1, putOperation2.RequestBody.Content.Keys.Count);
+                Assert.Single(putOperation.RequestBody.Content.Keys);
+                Assert.Single(putOperation2.RequestBody.Content.Keys);
                 Assert.True(putOperation.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
                 Assert.True(putOperation2.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("People.Person", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(1, operation.Parameters.Count);
+            Assert.Single(operation.Parameters);
 
             Assert.NotNull(operation.RequestBody);
             Assert.Equal("New navigation property values", operation.RequestBody.Description);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("People.Person", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(1, operation.Parameters.Count);
+            Assert.Single(operation.Parameters);
 
             Assert.NotNull(operation.RequestBody);
             Assert.Equal("New navigation property values", operation.RequestBody.Description);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPutOperationHandlerTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal("People.Person", tag.Name);
 
             Assert.NotNull(operation.Parameters);
-            Assert.Equal(1, operation.Parameters.Count);
+            Assert.Single(operation.Parameters);
 
             Assert.Equal(Models.ReferenceType.RequestBody, operation.RequestBody.Reference.Type);
             Assert.Equal(Common.Constants.ReferencePutRequestBodyName, operation.RequestBody.Reference.Id);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/SingletonGetOperationHandlerTests.cs
@@ -304,7 +304,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             }
             else
             {
-                Assert.Equal(1, get.Parameters.Count);
+                Assert.Single(get.Parameters);
                 Assert.DoesNotContain(queryOption, get.Parameters.Select(p => p.Name));
             }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/EntityPathItemHandlerTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             if (declarePathParametersOnPathItem)
             {
                 Assert.NotEmpty(pathItem.Parameters);
-                Assert.Equal(1, pathItem.Parameters.Count);
+                Assert.Single(pathItem.Parameters);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/NavigationPropertyPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/NavigationPropertyPathItemHandlerTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
                 }
                 else
                 {
-                    Assert.Equal(1, pathItem.Parameters.Count); // Customer ID
+                    Assert.Single(pathItem.Parameters); // Customer ID
                 }
             }
             else

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -249,11 +249,11 @@
           <Annotation Term="Org.OData.Core.V1.Description" String="Unknown gender or prefers not to say." />
       </Member>
     </EnumType>
-      <EnumType Name="Feature">
+      <EnumType Name="Feature" IsFlags="true">
         <Member Name="Feature1" Value="0" />
         <Member Name="Feature2" Value="1" />
         <Member Name="Feature3" Value="2" />
-        <Member Name="Feature4" Value="3" />
+        <Member Name="Feature4" Value="4" />
       </EnumType>
       <Function Name="GetPersonWithMostFriends">
         <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -27922,7 +27922,11 @@
         "Feature3",
         "Feature4"
       ],
-      "type": "string"
+      "type": "string",
+      "x-ms-enum-flags": {
+        "isFlags": true,
+        "style": "simple"
+      }
     },
     "Edm.Geography": {
       "$ref": "#/definitions/Edm.Geometry"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -19625,6 +19625,9 @@ definitions:
       - Feature3
       - Feature4
     type: string
+    x-ms-enum-flags:
+      isFlags: true
+      style: simple
   Edm.Geography:
     $ref: '#/definitions/Edm.Geometry'
   Edm.GeographyPoint:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -31294,7 +31294,11 @@
           "Feature3",
           "Feature4"
         ],
-        "type": "string"
+        "type": "string",
+        "x-ms-enum-flags": {
+          "isFlags": true,
+          "style": "simple"
+        }
       },
       "Edm.Geography": {
         "$ref": "#/components/schemas/Edm.Geometry"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -21805,6 +21805,9 @@ components:
         - Feature3
         - Feature4
       type: string
+      x-ms-enum-flags:
+        isFlags: true
+        style: simple
     Edm.Geography:
       $ref: '#/components/schemas/Edm.Geometry'
     Edm.GeographyPoint:


### PR DESCRIPTION
Closes https://github.com/microsoft/OpenAPI.NET.OData/issues/416 Closes #258

Related to 
Adds the `x-ms-enum-flags` extension to description to enable generation of bitwise enums(https://github.com/microsoft/OpenAPI/pull/8). 

Also fixes XUnit warnings in tests related to using `Assert.Single` for checking collections with only one item.