### PR TITLE
Adds schema to content types of stream properties that have a collection of acceptable media types

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.5.0-preview5</Version>
+    <Version>1.5.0-preview6</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -26,6 +26,7 @@
 - Fixes casing in default propertyName for `innerError` in the `ErrorMainSchema`
 - Adds support for `x-ms-enum-flags` extension for flagged enums
 - Use containment together with RequiresExplicitBinding annotation to check whether to append bound operations to navigation properties #430
+- Adds schema to content types of stream properties that have a collection of acceptable media types #435
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
@@ -136,14 +136,6 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <returns>The entity content description.</returns>
         protected IDictionary<string, OpenApiMediaType> GetContentDescription()
         {
-            var content = new Dictionary<string, OpenApiMediaType>();
-
-            OpenApiSchema schema = new OpenApiSchema
-            {
-                Type = "string",
-                Format = "binary"
-            };
-
             // Fetch the respective AcceptableMediaTypes
             (_, var property) = GetStreamElements();
             IEnumerable<string> mediaTypes = null;
@@ -153,11 +145,21 @@ namespace Microsoft.OpenApi.OData.Operation
                     CoreConstants.AcceptableMediaTypes);
             }
 
+            OpenApiSchema schema = new()
+            {
+                Type = "string",
+                Format = "binary"
+            };
+
+            var content = new Dictionary<string, OpenApiMediaType>();
             if (mediaTypes != null)
             {
                 foreach (string item in mediaTypes)
                 {
-                    content.Add(item, null);
+                    content.Add(item, new OpenApiMediaType
+                    {
+                        Schema = schema
+                    });
                 }
             }
             else

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -93,6 +93,9 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             var statusCode = useHTTPStatusCodeClass2XX ? Constants.StatusCodeClass2XX : Constants.StatusCode200;
             Assert.Equal(new[] { statusCode, "default" }, getOperation.Responses.Select(r => r.Key));
             Assert.Equal(new[] { statusCode, "default" }, getOperation2.Responses.Select(r => r.Key));
+            Assert.NotNull(getOperation.Responses[statusCode].Content.Values?.Select(x => x.Schema));
+            Assert.Equal(new string[] { "binary" }, getOperation.Responses[statusCode].Content.Values.Select(x => x.Schema.Format));
+            Assert.Equal(new string[] { "string" }, getOperation.Responses[statusCode].Content.Values.Select(x => x.Schema.Type));
 
             if (!string.IsNullOrEmpty(annotation))
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -94,8 +94,12 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal(new[] { statusCode, "default" }, getOperation.Responses.Select(r => r.Key));
             Assert.Equal(new[] { statusCode, "default" }, getOperation2.Responses.Select(r => r.Key));
             Assert.NotNull(getOperation.Responses[statusCode].Content.Values?.Select(x => x.Schema));
-            Assert.Equal(new string[] { "binary" }, getOperation.Responses[statusCode].Content.Values.Select(x => x.Schema.Format));
-            Assert.Equal(new string[] { "string" }, getOperation.Responses[statusCode].Content.Values.Select(x => x.Schema.Type));
+
+            foreach (var item in getOperation.Responses[statusCode].Content)
+            {
+                Assert.Equal("binary", item.Value.Schema.Format);
+                Assert.Equal("string", item.Value.Schema.Type);
+            }
 
             if (!string.IsNullOrEmpty(annotation))
             {


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/435

This PR:
- Adds schema to content types of stream properties when the property is annotated with an `Org.OData.Core.V1.AcceptableMediaTypes` annotation.
- Updates test to validate this.
- Bumps up the version.