### PR TITLE
[Fix] Updates `operationId`s of navigation property paths with OData type cast segments

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -168,6 +168,15 @@ namespace Microsoft.OpenApi.OData.Common
             {
                 if (segment == navPropSegments.Last())
                 {
+                    // If there exists an OData type cast segment present in the path,
+                    // this segement identifier needs to be added to the operation id
+                    ODataTypeCastSegment typeCastSegment = path.Segments.OfType<ODataTypeCastSegment>().LastOrDefault();
+                    if (typeCastSegment != null && path.Kind == ODataPathKind.NavigationProperty)
+                    {
+                        IEdmSchemaElement schemaElement = typeCastSegment.StructuredType as IEdmSchemaElement;
+                        items.Add("As" + Utils.UpperFirstChar(schemaElement.Name));
+                    }
+                    
                     items.Add(segment.NavigationProperty.Name);
                     break;
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -161,28 +161,25 @@ namespace Microsoft.OpenApi.OData.Common
                 navigationSource.Name
             };
 
-            IEnumerable<ODataNavigationPropertySegment> navPropSegments = path.Segments.Skip(1).OfType<ODataNavigationPropertySegment>();
-            Utils.CheckArgumentNull(navPropSegments, nameof(navPropSegments));
+            // For navigation property paths with odata type cast segments
+            // the OData type cast segments identifiers will be used in the operation id
+            IEnumerable<ODataSegment> segments = path.Segments.Skip(1).Where(s => s is ODataNavigationPropertySegment || s is ODataTypeCastSegment);
+            Utils.CheckArgumentNull(segments, nameof(segments));
 
-            foreach (var segment in navPropSegments)
+            string previousTypeCastSegmentId = null;
+            foreach (var segment in segments)
             {
-                if (segment == navPropSegments.Last())
+                if (segment is ODataNavigationPropertySegment navPropSegment)
                 {
-                    // If there exists an OData type cast segment present in the path,
-                    // this segement identifier needs to be added to the operation id
-                    ODataTypeCastSegment typeCastSegment = path.Segments.OfType<ODataTypeCastSegment>().LastOrDefault();
-                    if (typeCastSegment != null && path.Kind == ODataPathKind.NavigationProperty)
-                    {
-                        IEdmSchemaElement schemaElement = typeCastSegment.StructuredType as IEdmSchemaElement;
-                        items.Add("As" + Utils.UpperFirstChar(schemaElement.Name));
-                    }
-                    
-                    items.Add(segment.NavigationProperty.Name);
-                    break;
+                    items.Add(navPropSegment.NavigationProperty.Name);
                 }
-                else
+                else if (segment is ODataTypeCastSegment typeCastSegment && path.Kind == ODataPathKind.NavigationProperty)
                 {
-                    items.Add(segment.NavigationProperty.Name);
+                    // Only the last OData type cast segment identifier is added to the operation id
+                    items.Remove(previousTypeCastSegmentId);
+                    IEdmSchemaElement schemaElement = typeCastSegment.StructuredType as IEdmSchemaElement;
+                    previousTypeCastSegmentId = "As" + Utils.UpperFirstChar(schemaElement.Name);
+                    items.Add(previousTypeCastSegmentId);
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -163,7 +163,7 @@ namespace Microsoft.OpenApi.OData.Common
 
             // For navigation property paths with odata type cast segments
             // the OData type cast segments identifiers will be used in the operation id
-            IEnumerable<ODataSegment> segments = path.Segments.Skip(1).Where(s => s is ODataNavigationPropertySegment || s is ODataTypeCastSegment);
+            IEnumerable<ODataSegment> segments = path.Segments.Skip(1).Where(static s => s is ODataNavigationPropertySegment || s is ODataTypeCastSegment);
             Utils.CheckArgumentNull(segments, nameof(segments));
 
             string previousTypeCastSegmentId = null;

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.5.0-preview7</Version>
+    <Version>1.5.0-preview8</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -28,6 +28,7 @@
 - Use containment together with RequiresExplicitBinding annotation to check whether to append bound operations to navigation properties #430
 - Adds schema to content types of stream properties that have a collection of acceptable media types #435
 - Retrieves complex properties of derived types #437
+- Updates operationIds of navigation property paths with OData type cast segments #442
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -4025,7 +4025,7 @@
         ],
         "summary": "Get BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetBestFriend",
+        "operationId": "Me.AsEmployee.GetBestFriend",
         "produces": [
           "application/json"
         ],
@@ -4097,7 +4097,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateBestFriend",
+        "operationId": "Me.AsEmployee.UpdateBestFriend",
         "consumes": [
           "application/json"
         ],
@@ -4678,7 +4678,7 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
-        "operationId": "Me.ListFriends",
+        "operationId": "Me.AsEmployee.ListFriends",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -5777,7 +5777,7 @@
           "Me.Person"
         ],
         "summary": "Get Peers from Me",
-        "operationId": "Me.ListPeers",
+        "operationId": "Me.AsEmployee.ListPeers",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -6526,7 +6526,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "Me.ListTrips",
+        "operationId": "Me.AsEmployee.ListTrips",
         "parameters": [
           {
             "in": "header",
@@ -6633,7 +6633,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "Me.CreateTrips",
+        "operationId": "Me.AsEmployee.CreateTrips",
         "consumes": [
           "application/json"
         ],
@@ -6684,7 +6684,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "Me.GetTrips",
+        "operationId": "Me.AsEmployee.GetTrips",
         "produces": [
           "application/json"
         ],
@@ -6760,7 +6760,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "Me.UpdateTrips",
+        "operationId": "Me.AsEmployee.UpdateTrips",
         "consumes": [
           "application/json"
         ],
@@ -6809,7 +6809,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "Me.DeleteTrips",
+        "operationId": "Me.AsEmployee.DeleteTrips",
         "parameters": [
           {
             "in": "path",
@@ -6989,7 +6989,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from Me",
-        "operationId": "Me.Trips.ListPlanItems",
+        "operationId": "Me.AsEmployee.Trips.ListPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -7848,7 +7848,7 @@
         ],
         "summary": "Get BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetBestFriend",
+        "operationId": "Me.AsManager.GetBestFriend",
         "produces": [
           "application/json"
         ],
@@ -7920,7 +7920,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateBestFriend",
+        "operationId": "Me.AsManager.UpdateBestFriend",
         "consumes": [
           "application/json"
         ],
@@ -8513,7 +8513,7 @@
           "Me.Person"
         ],
         "summary": "Get DirectReports from Me",
-        "operationId": "Me.ListDirectReports",
+        "operationId": "Me.AsManager.ListDirectReports",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -9273,7 +9273,7 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
-        "operationId": "Me.ListFriends",
+        "operationId": "Me.AsManager.ListFriends",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -10419,7 +10419,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "Me.ListTrips",
+        "operationId": "Me.AsManager.ListTrips",
         "parameters": [
           {
             "in": "header",
@@ -10526,7 +10526,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "Me.CreateTrips",
+        "operationId": "Me.AsManager.CreateTrips",
         "consumes": [
           "application/json"
         ],
@@ -10577,7 +10577,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "Me.GetTrips",
+        "operationId": "Me.AsManager.GetTrips",
         "produces": [
           "application/json"
         ],
@@ -10653,7 +10653,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "Me.UpdateTrips",
+        "operationId": "Me.AsManager.UpdateTrips",
         "consumes": [
           "application/json"
         ],
@@ -10702,7 +10702,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "Me.DeleteTrips",
+        "operationId": "Me.AsManager.DeleteTrips",
         "parameters": [
           {
             "in": "path",
@@ -10882,7 +10882,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from Me",
-        "operationId": "Me.Trips.ListPlanItems",
+        "operationId": "Me.AsManager.Trips.ListPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -19476,7 +19476,7 @@
         ],
         "summary": "Get BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetBestFriend",
+        "operationId": "People.AsEmployee.GetBestFriend",
         "produces": [
           "application/json"
         ],
@@ -19556,7 +19556,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateBestFriend",
+        "operationId": "People.AsEmployee.UpdateBestFriend",
         "consumes": [
           "application/json"
         ],
@@ -20255,7 +20255,7 @@
           "People.Person"
         ],
         "summary": "Get Friends from People",
-        "operationId": "People.ListFriends",
+        "operationId": "People.AsEmployee.ListFriends",
         "parameters": [
           {
             "in": "path",
@@ -21516,7 +21516,7 @@
           "People.Person"
         ],
         "summary": "Get Peers from People",
-        "operationId": "People.ListPeers",
+        "operationId": "People.AsEmployee.ListPeers",
         "parameters": [
           {
             "in": "path",
@@ -22377,7 +22377,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "People.ListTrips",
+        "operationId": "People.AsEmployee.ListTrips",
         "parameters": [
           {
             "in": "path",
@@ -22492,7 +22492,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "People.CreateTrips",
+        "operationId": "People.AsEmployee.CreateTrips",
         "consumes": [
           "application/json"
         ],
@@ -22551,7 +22551,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "People.GetTrips",
+        "operationId": "People.AsEmployee.GetTrips",
         "produces": [
           "application/json"
         ],
@@ -22635,7 +22635,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "People.UpdateTrips",
+        "operationId": "People.AsEmployee.UpdateTrips",
         "consumes": [
           "application/json"
         ],
@@ -22692,7 +22692,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "People.DeleteTrips",
+        "operationId": "People.AsEmployee.DeleteTrips",
         "parameters": [
           {
             "in": "path",
@@ -22888,7 +22888,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from People",
-        "operationId": "People.Trips.ListPlanItems",
+        "operationId": "People.AsEmployee.Trips.ListPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -23885,7 +23885,7 @@
         ],
         "summary": "Get BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetBestFriend",
+        "operationId": "People.AsManager.GetBestFriend",
         "produces": [
           "application/json"
         ],
@@ -23965,7 +23965,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateBestFriend",
+        "operationId": "People.AsManager.UpdateBestFriend",
         "consumes": [
           "application/json"
         ],
@@ -24676,7 +24676,7 @@
           "People.Person"
         ],
         "summary": "Get DirectReports from People",
-        "operationId": "People.ListDirectReports",
+        "operationId": "People.AsManager.ListDirectReports",
         "parameters": [
           {
             "in": "path",
@@ -25548,7 +25548,7 @@
           "People.Person"
         ],
         "summary": "Get Friends from People",
-        "operationId": "People.ListFriends",
+        "operationId": "People.AsManager.ListFriends",
         "parameters": [
           {
             "in": "path",
@@ -26864,7 +26864,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "People.ListTrips",
+        "operationId": "People.AsManager.ListTrips",
         "parameters": [
           {
             "in": "path",
@@ -26979,7 +26979,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "People.CreateTrips",
+        "operationId": "People.AsManager.CreateTrips",
         "consumes": [
           "application/json"
         ],
@@ -27038,7 +27038,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "People.GetTrips",
+        "operationId": "People.AsManager.GetTrips",
         "produces": [
           "application/json"
         ],
@@ -27122,7 +27122,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "People.UpdateTrips",
+        "operationId": "People.AsManager.UpdateTrips",
         "consumes": [
           "application/json"
         ],
@@ -27179,7 +27179,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "People.DeleteTrips",
+        "operationId": "People.AsManager.DeleteTrips",
         "parameters": [
           {
             "in": "path",
@@ -27375,7 +27375,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from People",
-        "operationId": "People.Trips.ListPlanItems",
+        "operationId": "People.AsManager.Trips.ListPlanItems",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -2776,7 +2776,7 @@ paths:
         - Me.Person
       summary: Get BestFriend from Me
       description: The best friend.
-      operationId: Me.GetBestFriend
+      operationId: Me.AsEmployee.GetBestFriend
       produces:
         - application/json
       parameters:
@@ -2831,7 +2831,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateBestFriend
+      operationId: Me.AsEmployee.UpdateBestFriend
       consumes:
         - application/json
       parameters:
@@ -3232,7 +3232,7 @@ paths:
       tags:
         - Me.Person
       summary: Get Friends from Me
-      operationId: Me.ListFriends
+      operationId: Me.AsEmployee.ListFriends
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -4003,7 +4003,7 @@ paths:
       tags:
         - Me.Person
       summary: Get Peers from Me
-      operationId: Me.ListPeers
+      operationId: Me.AsEmployee.ListPeers
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -4523,7 +4523,7 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: Me.ListTrips
+      operationId: Me.AsEmployee.ListTrips
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -4599,7 +4599,7 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: Me.CreateTrips
+      operationId: Me.AsEmployee.CreateTrips
       consumes:
         - application/json
       produces:
@@ -4635,7 +4635,7 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: Me.GetTrips
+      operationId: Me.AsEmployee.GetTrips
       produces:
         - application/json
       parameters:
@@ -4692,7 +4692,7 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: Me.UpdateTrips
+      operationId: Me.AsEmployee.UpdateTrips
       consumes:
         - application/json
       parameters:
@@ -4728,7 +4728,7 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: Me.DeleteTrips
+      operationId: Me.AsEmployee.DeleteTrips
       parameters:
         - in: path
           name: TripId
@@ -4861,7 +4861,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get PlanItems from Me
-      operationId: Me.Trips.ListPlanItems
+      operationId: Me.AsEmployee.Trips.ListPlanItems
       parameters:
         - in: path
           name: TripId
@@ -5455,7 +5455,7 @@ paths:
         - Me.Person
       summary: Get BestFriend from Me
       description: The best friend.
-      operationId: Me.GetBestFriend
+      operationId: Me.AsManager.GetBestFriend
       produces:
         - application/json
       parameters:
@@ -5510,7 +5510,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateBestFriend
+      operationId: Me.AsManager.UpdateBestFriend
       consumes:
         - application/json
       parameters:
@@ -5919,7 +5919,7 @@ paths:
       tags:
         - Me.Person
       summary: Get DirectReports from Me
-      operationId: Me.ListDirectReports
+      operationId: Me.AsManager.ListDirectReports
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -6446,7 +6446,7 @@ paths:
       tags:
         - Me.Person
       summary: Get Friends from Me
-      operationId: Me.ListFriends
+      operationId: Me.AsManager.ListFriends
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -7250,7 +7250,7 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: Me.ListTrips
+      operationId: Me.AsManager.ListTrips
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -7326,7 +7326,7 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: Me.CreateTrips
+      operationId: Me.AsManager.CreateTrips
       consumes:
         - application/json
       produces:
@@ -7362,7 +7362,7 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: Me.GetTrips
+      operationId: Me.AsManager.GetTrips
       produces:
         - application/json
       parameters:
@@ -7419,7 +7419,7 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: Me.UpdateTrips
+      operationId: Me.AsManager.UpdateTrips
       consumes:
         - application/json
       parameters:
@@ -7455,7 +7455,7 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: Me.DeleteTrips
+      operationId: Me.AsManager.DeleteTrips
       parameters:
         - in: path
           name: TripId
@@ -7588,7 +7588,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get PlanItems from Me
-      operationId: Me.Trips.ListPlanItems
+      operationId: Me.AsManager.Trips.ListPlanItems
       parameters:
         - in: path
           name: TripId
@@ -13623,7 +13623,7 @@ paths:
         - People.Person
       summary: Get BestFriend from People
       description: The best friend.
-      operationId: People.GetBestFriend
+      operationId: People.AsEmployee.GetBestFriend
       produces:
         - application/json
       parameters:
@@ -13684,7 +13684,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateBestFriend
+      operationId: People.AsEmployee.UpdateBestFriend
       consumes:
         - application/json
       parameters:
@@ -14172,7 +14172,7 @@ paths:
       tags:
         - People.Person
       summary: Get Friends from People
-      operationId: People.ListFriends
+      operationId: People.AsEmployee.ListFriends
       parameters:
         - in: path
           name: UserName
@@ -15064,7 +15064,7 @@ paths:
       tags:
         - People.Person
       summary: Get Peers from People
-      operationId: People.ListPeers
+      operationId: People.AsEmployee.ListPeers
       parameters:
         - in: path
           name: UserName
@@ -15668,7 +15668,7 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: People.ListTrips
+      operationId: People.AsEmployee.ListTrips
       parameters:
         - in: path
           name: UserName
@@ -15750,7 +15750,7 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: People.CreateTrips
+      operationId: People.AsEmployee.CreateTrips
       consumes:
         - application/json
       produces:
@@ -15792,7 +15792,7 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: People.GetTrips
+      operationId: People.AsEmployee.GetTrips
       produces:
         - application/json
       parameters:
@@ -15855,7 +15855,7 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: People.UpdateTrips
+      operationId: People.AsEmployee.UpdateTrips
       consumes:
         - application/json
       parameters:
@@ -15897,7 +15897,7 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: People.DeleteTrips
+      operationId: People.AsEmployee.DeleteTrips
       parameters:
         - in: path
           name: UserName
@@ -16042,7 +16042,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get PlanItems from People
-      operationId: People.Trips.ListPlanItems
+      operationId: People.AsEmployee.Trips.ListPlanItems
       parameters:
         - in: path
           name: UserName
@@ -16738,7 +16738,7 @@ paths:
         - People.Person
       summary: Get BestFriend from People
       description: The best friend.
-      operationId: People.GetBestFriend
+      operationId: People.AsManager.GetBestFriend
       produces:
         - application/json
       parameters:
@@ -16799,7 +16799,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateBestFriend
+      operationId: People.AsManager.UpdateBestFriend
       consumes:
         - application/json
       parameters:
@@ -17295,7 +17295,7 @@ paths:
       tags:
         - People.Person
       summary: Get DirectReports from People
-      operationId: People.ListDirectReports
+      operationId: People.AsManager.ListDirectReports
       parameters:
         - in: path
           name: UserName
@@ -17906,7 +17906,7 @@ paths:
       tags:
         - People.Person
       summary: Get Friends from People
-      operationId: People.ListFriends
+      operationId: People.AsManager.ListFriends
       parameters:
         - in: path
           name: UserName
@@ -18837,7 +18837,7 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: People.ListTrips
+      operationId: People.AsManager.ListTrips
       parameters:
         - in: path
           name: UserName
@@ -18919,7 +18919,7 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: People.CreateTrips
+      operationId: People.AsManager.CreateTrips
       consumes:
         - application/json
       produces:
@@ -18961,7 +18961,7 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: People.GetTrips
+      operationId: People.AsManager.GetTrips
       produces:
         - application/json
       parameters:
@@ -19024,7 +19024,7 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: People.UpdateTrips
+      operationId: People.AsManager.UpdateTrips
       consumes:
         - application/json
       parameters:
@@ -19066,7 +19066,7 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: People.DeleteTrips
+      operationId: People.AsManager.DeleteTrips
       parameters:
         - in: path
           name: UserName
@@ -19211,7 +19211,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get PlanItems from People
-      operationId: People.Trips.ListPlanItems
+      operationId: People.AsManager.Trips.ListPlanItems
       parameters:
         - in: path
           name: UserName

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -4439,7 +4439,7 @@
         ],
         "summary": "Get BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetBestFriend",
+        "operationId": "Me.AsEmployee.GetBestFriend",
         "parameters": [
           {
             "name": "$select",
@@ -4522,7 +4522,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateBestFriend",
+        "operationId": "Me.AsEmployee.UpdateBestFriend",
         "requestBody": {
           "description": "New navigation property values",
           "content": {
@@ -5133,7 +5133,7 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
-        "operationId": "Me.ListFriends",
+        "operationId": "Me.AsEmployee.ListFriends",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -6335,7 +6335,7 @@
           "Me.Person"
         ],
         "summary": "Get Peers from Me",
-        "operationId": "Me.ListPeers",
+        "operationId": "Me.AsEmployee.ListPeers",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -7151,7 +7151,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "Me.ListTrips",
+        "operationId": "Me.AsEmployee.ListTrips",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -7281,7 +7281,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "Me.CreateTrips",
+        "operationId": "Me.AsEmployee.CreateTrips",
         "requestBody": {
           "description": "New navigation property",
           "content": {
@@ -7330,7 +7330,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "Me.GetTrips",
+        "operationId": "Me.AsEmployee.GetTrips",
         "parameters": [
           {
             "name": "TripId",
@@ -7419,7 +7419,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "Me.UpdateTrips",
+        "operationId": "Me.AsEmployee.UpdateTrips",
         "parameters": [
           {
             "name": "TripId",
@@ -7469,7 +7469,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "Me.DeleteTrips",
+        "operationId": "Me.AsEmployee.DeleteTrips",
         "parameters": [
           {
             "name": "TripId",
@@ -7674,7 +7674,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from Me",
-        "operationId": "Me.Trips.ListPlanItems",
+        "operationId": "Me.AsEmployee.Trips.ListPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -8627,7 +8627,7 @@
         ],
         "summary": "Get BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetBestFriend",
+        "operationId": "Me.AsManager.GetBestFriend",
         "parameters": [
           {
             "name": "$select",
@@ -8710,7 +8710,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateBestFriend",
+        "operationId": "Me.AsManager.UpdateBestFriend",
         "requestBody": {
           "description": "New navigation property values",
           "content": {
@@ -9349,7 +9349,7 @@
           "Me.Person"
         ],
         "summary": "Get DirectReports from Me",
-        "operationId": "Me.ListDirectReports",
+        "operationId": "Me.AsManager.ListDirectReports",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -10192,7 +10192,7 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
-        "operationId": "Me.ListFriends",
+        "operationId": "Me.AsManager.ListFriends",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -11446,7 +11446,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "Me.ListTrips",
+        "operationId": "Me.AsManager.ListTrips",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -11576,7 +11576,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "Me.CreateTrips",
+        "operationId": "Me.AsManager.CreateTrips",
         "requestBody": {
           "description": "New navigation property",
           "content": {
@@ -11625,7 +11625,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "Me.GetTrips",
+        "operationId": "Me.AsManager.GetTrips",
         "parameters": [
           {
             "name": "TripId",
@@ -11714,7 +11714,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "Me.UpdateTrips",
+        "operationId": "Me.AsManager.UpdateTrips",
         "parameters": [
           {
             "name": "TripId",
@@ -11764,7 +11764,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "Me.DeleteTrips",
+        "operationId": "Me.AsManager.DeleteTrips",
         "parameters": [
           {
             "name": "TripId",
@@ -11969,7 +11969,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from Me",
-        "operationId": "Me.Trips.ListPlanItems",
+        "operationId": "Me.AsManager.Trips.ListPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -21648,7 +21648,7 @@
         ],
         "summary": "Get BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetBestFriend",
+        "operationId": "People.AsEmployee.GetBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -21741,7 +21741,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateBestFriend",
+        "operationId": "People.AsEmployee.UpdateBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -22506,7 +22506,7 @@
           "People.Person"
         ],
         "summary": "Get Friends from People",
-        "operationId": "People.ListFriends",
+        "operationId": "People.AsEmployee.ListFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -23914,7 +23914,7 @@
           "People.Person"
         ],
         "summary": "Get Peers from People",
-        "operationId": "People.ListPeers",
+        "operationId": "People.AsEmployee.ListPeers",
         "parameters": [
           {
             "name": "UserName",
@@ -24872,7 +24872,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "People.ListTrips",
+        "operationId": "People.AsEmployee.ListTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -25012,7 +25012,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "People.CreateTrips",
+        "operationId": "People.AsEmployee.CreateTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -25073,7 +25073,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "People.GetTrips",
+        "operationId": "People.AsEmployee.GetTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -25172,7 +25172,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "People.UpdateTrips",
+        "operationId": "People.AsEmployee.UpdateTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -25232,7 +25232,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "People.DeleteTrips",
+        "operationId": "People.AsEmployee.DeleteTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -25457,7 +25457,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from People",
-        "operationId": "People.Trips.ListPlanItems",
+        "operationId": "People.AsEmployee.Trips.ListPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -26592,7 +26592,7 @@
         ],
         "summary": "Get BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetBestFriend",
+        "operationId": "People.AsManager.GetBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -26685,7 +26685,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateBestFriend",
+        "operationId": "People.AsManager.UpdateBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -27478,7 +27478,7 @@
           "People.Person"
         ],
         "summary": "Get DirectReports from People",
-        "operationId": "People.ListDirectReports",
+        "operationId": "People.AsManager.ListDirectReports",
         "parameters": [
           {
             "name": "UserName",
@@ -28463,7 +28463,7 @@
           "People.Person"
         ],
         "summary": "Get Friends from People",
-        "operationId": "People.ListFriends",
+        "operationId": "People.AsManager.ListFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -29935,7 +29935,7 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
-        "operationId": "People.ListTrips",
+        "operationId": "People.AsManager.ListTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -30075,7 +30075,7 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
-        "operationId": "People.CreateTrips",
+        "operationId": "People.AsManager.CreateTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -30136,7 +30136,7 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
-        "operationId": "People.GetTrips",
+        "operationId": "People.AsManager.GetTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -30235,7 +30235,7 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
-        "operationId": "People.UpdateTrips",
+        "operationId": "People.AsManager.UpdateTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -30295,7 +30295,7 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
-        "operationId": "People.DeleteTrips",
+        "operationId": "People.AsManager.DeleteTrips",
         "parameters": [
           {
             "name": "UserName",
@@ -30520,7 +30520,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get PlanItems from People",
-        "operationId": "People.Trips.ListPlanItems",
+        "operationId": "People.AsManager.Trips.ListPlanItems",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -3050,7 +3050,7 @@ paths:
         - Me.Person
       summary: Get BestFriend from Me
       description: The best friend.
-      operationId: Me.GetBestFriend
+      operationId: Me.AsEmployee.GetBestFriend
       parameters:
         - name: $select
           in: query
@@ -3113,7 +3113,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateBestFriend
+      operationId: Me.AsEmployee.UpdateBestFriend
       requestBody:
         description: New navigation property values
         content:
@@ -3537,7 +3537,7 @@ paths:
       tags:
         - Me.Person
       summary: Get Friends from Me
-      operationId: Me.ListFriends
+      operationId: Me.AsEmployee.ListFriends
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -4381,7 +4381,7 @@ paths:
       tags:
         - Me.Person
       summary: Get Peers from Me
-      operationId: Me.ListPeers
+      operationId: Me.AsEmployee.ListPeers
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -4947,7 +4947,7 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: Me.ListTrips
+      operationId: Me.AsEmployee.ListTrips
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -5040,7 +5040,7 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: Me.CreateTrips
+      operationId: Me.AsEmployee.CreateTrips
       requestBody:
         description: New navigation property
         content:
@@ -5074,7 +5074,7 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: Me.GetTrips
+      operationId: Me.AsEmployee.GetTrips
       parameters:
         - name: TripId
           in: path
@@ -5140,7 +5140,7 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: Me.UpdateTrips
+      operationId: Me.AsEmployee.UpdateTrips
       parameters:
         - name: TripId
           in: path
@@ -5176,7 +5176,7 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: Me.DeleteTrips
+      operationId: Me.AsEmployee.DeleteTrips
       parameters:
         - name: TripId
           in: path
@@ -5323,7 +5323,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get PlanItems from Me
-      operationId: Me.Trips.ListPlanItems
+      operationId: Me.AsEmployee.Trips.ListPlanItems
       parameters:
         - name: TripId
           in: path
@@ -5984,7 +5984,7 @@ paths:
         - Me.Person
       summary: Get BestFriend from Me
       description: The best friend.
-      operationId: Me.GetBestFriend
+      operationId: Me.AsManager.GetBestFriend
       parameters:
         - name: $select
           in: query
@@ -6047,7 +6047,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateBestFriend
+      operationId: Me.AsManager.UpdateBestFriend
       requestBody:
         description: New navigation property values
         content:
@@ -6489,7 +6489,7 @@ paths:
       tags:
         - Me.Person
       summary: Get DirectReports from Me
-      operationId: Me.ListDirectReports
+      operationId: Me.AsManager.ListDirectReports
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -7072,7 +7072,7 @@ paths:
       tags:
         - Me.Person
       summary: Get Friends from Me
-      operationId: Me.ListFriends
+      operationId: Me.AsManager.ListFriends
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -7950,7 +7950,7 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: Me.ListTrips
+      operationId: Me.AsManager.ListTrips
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -8043,7 +8043,7 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: Me.CreateTrips
+      operationId: Me.AsManager.CreateTrips
       requestBody:
         description: New navigation property
         content:
@@ -8077,7 +8077,7 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: Me.GetTrips
+      operationId: Me.AsManager.GetTrips
       parameters:
         - name: TripId
           in: path
@@ -8143,7 +8143,7 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: Me.UpdateTrips
+      operationId: Me.AsManager.UpdateTrips
       parameters:
         - name: TripId
           in: path
@@ -8179,7 +8179,7 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: Me.DeleteTrips
+      operationId: Me.AsManager.DeleteTrips
       parameters:
         - name: TripId
           in: path
@@ -8326,7 +8326,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get PlanItems from Me
-      operationId: Me.Trips.ListPlanItems
+      operationId: Me.AsManager.Trips.ListPlanItems
       parameters:
         - name: TripId
           in: path
@@ -15064,7 +15064,7 @@ paths:
         - People.Person
       summary: Get BestFriend from People
       description: The best friend.
-      operationId: People.GetBestFriend
+      operationId: People.AsEmployee.GetBestFriend
       parameters:
         - name: UserName
           in: path
@@ -15134,7 +15134,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateBestFriend
+      operationId: People.AsEmployee.UpdateBestFriend
       parameters:
         - name: UserName
           in: path
@@ -15663,7 +15663,7 @@ paths:
       tags:
         - People.Person
       summary: Get Friends from People
-      operationId: People.ListFriends
+      operationId: People.AsEmployee.ListFriends
       parameters:
         - name: UserName
           in: path
@@ -16650,7 +16650,7 @@ paths:
       tags:
         - People.Person
       summary: Get Peers from People
-      operationId: People.ListPeers
+      operationId: People.AsEmployee.ListPeers
       parameters:
         - name: UserName
           in: path
@@ -17315,7 +17315,7 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: People.ListTrips
+      operationId: People.AsEmployee.ListTrips
       parameters:
         - name: UserName
           in: path
@@ -17415,7 +17415,7 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: People.CreateTrips
+      operationId: People.AsEmployee.CreateTrips
       parameters:
         - name: UserName
           in: path
@@ -17457,7 +17457,7 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: People.GetTrips
+      operationId: People.AsEmployee.GetTrips
       parameters:
         - name: UserName
           in: path
@@ -17530,7 +17530,7 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: People.UpdateTrips
+      operationId: People.AsEmployee.UpdateTrips
       parameters:
         - name: UserName
           in: path
@@ -17573,7 +17573,7 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: People.DeleteTrips
+      operationId: People.AsEmployee.DeleteTrips
       parameters:
         - name: UserName
           in: path
@@ -17734,7 +17734,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get PlanItems from People
-      operationId: People.Trips.ListPlanItems
+      operationId: People.AsEmployee.Trips.ListPlanItems
       parameters:
         - name: UserName
           in: path
@@ -18520,7 +18520,7 @@ paths:
         - People.Person
       summary: Get BestFriend from People
       description: The best friend.
-      operationId: People.GetBestFriend
+      operationId: People.AsManager.GetBestFriend
       parameters:
         - name: UserName
           in: path
@@ -18590,7 +18590,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateBestFriend
+      operationId: People.AsManager.UpdateBestFriend
       parameters:
         - name: UserName
           in: path
@@ -19137,7 +19137,7 @@ paths:
       tags:
         - People.Person
       summary: Get DirectReports from People
-      operationId: People.ListDirectReports
+      operationId: People.AsManager.ListDirectReports
       parameters:
         - name: UserName
           in: path
@@ -19819,7 +19819,7 @@ paths:
       tags:
         - People.Person
       summary: Get Friends from People
-      operationId: People.ListFriends
+      operationId: People.AsManager.ListFriends
       parameters:
         - name: UserName
           in: path
@@ -20848,7 +20848,7 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
-      operationId: People.ListTrips
+      operationId: People.AsManager.ListTrips
       parameters:
         - name: UserName
           in: path
@@ -20948,7 +20948,7 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
-      operationId: People.CreateTrips
+      operationId: People.AsManager.CreateTrips
       parameters:
         - name: UserName
           in: path
@@ -20990,7 +20990,7 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
-      operationId: People.GetTrips
+      operationId: People.AsManager.GetTrips
       parameters:
         - name: UserName
           in: path
@@ -21063,7 +21063,7 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
-      operationId: People.UpdateTrips
+      operationId: People.AsManager.UpdateTrips
       parameters:
         - name: UserName
           in: path
@@ -21106,7 +21106,7 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
-      operationId: People.DeleteTrips
+      operationId: People.AsManager.DeleteTrips
       parameters:
         - name: UserName
           in: path
@@ -21267,7 +21267,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get PlanItems from People
-      operationId: People.Trips.ListPlanItems
+      operationId: People.AsManager.Trips.ListPlanItems
       parameters:
         - name: UserName
           in: path


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/442