### PR TITLE
Adds support for alternate keys to collection navigation properties

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -597,6 +597,8 @@ namespace Microsoft.OpenApi.OData.Edm
                     // append a navigation property key.
                     if (targetsMany)
                     {
+                        CreateAlternateKeyPath(currentPath, navEntityType);
+
                         currentPath.Push(new ODataKeySegment(navEntityType));
                         AppendPath(currentPath.Clone());
 

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.5.0-preview10</Version>
+    <Version>1.5.0-preview11</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -31,6 +31,7 @@
 - Retrieves complex properties of derived types #437
 - Updates operationIds of navigation property paths with OData type cast segments #442
 - Generate navigation property paths defined in nested complex properties #446
+- Adds support for alternate keys to collection navigation properties #410
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(16967, paths.Count());
+            Assert.Equal(16976, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -93,6 +93,10 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
             // Test that navigation properties within nested complex properties are appended
             Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals(
                 "/identity/authenticationEventsFlows({id})/conditions/applications/includeApplications")));
+
+            // Test that alternate keys are appended for collection navigation properties
+            Assert.NotNull(paths.FirstOrDefault(p => p.GetPathItemName().Equals(
+                "/employeeExperience/learningProviders({id})/learningContents(externalId='{externalId}')")));
         }
 
         [Fact]
@@ -113,7 +117,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17618, paths.Count());
+            Assert.Equal(17627, paths.Count());
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/410

This PR:
- Appends alternate keys to collection navigation properties
- Updates tests
- Updates release notes