### PR TITLE
Ensures only alternate key parameter matching key segment identifier is included in path parameters

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -289,7 +289,7 @@ namespace Microsoft.OpenApi.OData.Generator
             foreach (ODataKeySegment keySegment in path.OfType<ODataKeySegment>())
             {
                 IDictionary<string, string> mapping = parameterMappings[keySegment];
-                pathParameters.AddRange(context.CreateKeyParameters(keySegment, mapping));                    
+                pathParameters.AddRange(context.CreateKeyParameters(keySegment, mapping));
             }
 
             // Add the route prefix parameter v1{data}

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -12,6 +12,8 @@ using Microsoft.OpenApi.OData.Common;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using System.Diagnostics;
+using System;
 
 namespace Microsoft.OpenApi.OData.Generator
 {
@@ -151,19 +153,20 @@ namespace Microsoft.OpenApi.OData.Generator
         /// <param name="context">The OData context.</param>
         /// <param name="keySegment">The key segment.</param>
         /// <param name="parameterNameMapping">The parameter name mapping.</param>
-        /// <returns>The created the list of <see cref="OpenApiParameter"/>.</returns>
+        /// <returns>The created list of <see cref="OpenApiParameter"/>.</returns>
         public static IList<OpenApiParameter> CreateKeyParameters(this ODataContext context, ODataKeySegment keySegment,
             IDictionary<string, string> parameterNameMapping = null)
         {
             Utils.CheckArgumentNull(context, nameof(context));
             Utils.CheckArgumentNull(keySegment, nameof(keySegment));
+            
+            if (keySegment.IsAlternateKey)
+                return CreateAlternateKeyParameters(context, keySegment);
 
             IEdmEntityType entityType = keySegment.EntityType;
-            if (keySegment.IsAlternateKey)
-                return CreateAlternateKeyParameters(context, entityType);
+            IList<IEdmStructuralProperty> keys = entityType.Key().ToList();
 
             List<OpenApiParameter> parameters = new();
-            IList<IEdmStructuralProperty> keys = entityType.Key().ToList();
             if (keys.Count() == 1)
             {
                 string keyName = keys.First().Name;
@@ -177,7 +180,7 @@ namespace Microsoft.OpenApi.OData.Generator
 
                 OpenApiParameter parameter = new OpenApiParameter
                 {
-                    Name = parameterNameMapping == null ? keyName: parameterNameMapping[keyName],
+                    Name = parameterNameMapping == null ? keyName : parameterNameMapping[keyName],
                     In = ParameterLocation.Path,
                     Required = true,
                     Description = $"The unique identifier of {entityType.Name}",
@@ -195,7 +198,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     OpenApiParameter parameter = new OpenApiParameter
                     {
                         Name = parameterNameMapping == null ?
-                            keyProperty.Name:
+                            keyProperty.Name :
                             parameterNameMapping[keyProperty.Name],// By design: not prefix with type name if enable type name prefix
                         In = ParameterLocation.Path,
                         Required = true,
@@ -216,15 +219,28 @@ namespace Microsoft.OpenApi.OData.Generator
             return parameters;
         }
 
-        private static IList<OpenApiParameter> CreateAlternateKeyParameters(ODataContext context, IEdmEntityType entityType)
+
+        /// <summary>
+        /// Create alternate key parameters for the <see cref="ODataKeySegment"/>.
+        /// </summary>
+        /// <param name="context">The OData context.</param>
+        /// <param name="keySegment">The key segment.</param>
+        /// <returns>A list of <see cref="OpenApiParameter"/> of alternate key parameters.</returns>
+        private static IList<OpenApiParameter> CreateAlternateKeyParameters(ODataContext context, ODataSegment keySegment)
         {
+            Debug.Assert(keySegment.Kind == ODataSegmentKind.Key);
+            
             IList<OpenApiParameter> parameters = new List<OpenApiParameter>();
-            IEnumerable<IDictionary<string, IEdmProperty>> alternateKeys = context.Model.GetAlternateKeysAnnotation(entityType);
+            IEdmEntityType entityType = keySegment.EntityType;
+            IEnumerable<IDictionary<string, IEdmProperty>> alternateKeys = context.Model.GetAlternateKeysAnnotation(entityType);            
+            
             foreach (var alternateKey in alternateKeys)
             {
                 if (alternateKey.Count() == 1)
                 {
-                    parameters.Add(
+                    if (keySegment.Identifier.Equals(alternateKey.First().Key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        parameters.Add(
                         new OpenApiParameter
                         {
                             Name = alternateKey.First().Key,
@@ -234,12 +250,15 @@ namespace Microsoft.OpenApi.OData.Generator
                             Required = true
                         }
                      );
+                    }                    
                 }
                 else
                 {
                     foreach (var compositekey in alternateKey)
                     {
-                        parameters.Add(
+                        if (keySegment.Identifier.Contains(compositekey.Key))
+                        {
+                            parameters.Add(
                             new OpenApiParameter
                             {
                                 Name = compositekey.Key,
@@ -248,7 +267,8 @@ namespace Microsoft.OpenApi.OData.Generator
                                 Schema = context.CreateEdmTypeSchema(compositekey.Value.Type),
                                 Required = true
                             }
-                        );
+                         );
+                        }                        
                     }
                 }
             }
@@ -269,7 +289,7 @@ namespace Microsoft.OpenApi.OData.Generator
             foreach (ODataKeySegment keySegment in path.OfType<ODataKeySegment>())
             {
                 IDictionary<string, string> mapping = parameterMappings[keySegment];
-                pathParameters.AddRange(context.CreateKeyParameters(keySegment, mapping));
+                pathParameters.AddRange(context.CreateKeyParameters(keySegment, mapping));                    
             }
 
             // Add the route prefix parameter v1{data}

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.5.0-preview11</Version>
+    <Version>1.5.0-preview12</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -32,6 +32,7 @@
 - Updates operationIds of navigation property paths with OData type cast segments #442
 - Generate navigation property paths defined in nested complex properties #446
 - Adds support for alternate keys to collection navigation properties #410
+- Ensures only alternate key parameter matching key segment identifier is included in path parameters #414
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiParameterGeneratorTests.cs
@@ -283,12 +283,15 @@ schema:
             EdmEntityType customer = new("NS", "Customer");
             customer.AddKeys(customer.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String));
 
-            IEdmProperty alternateId = customer.AddStructuralProperty("AlternateId", EdmPrimitiveTypeKind.String);
-            model.AddAlternateKeyAnnotation(customer, new Dictionary<string, IEdmProperty> { { "AltId", alternateId } });
+            IEdmProperty alternateId1 = customer.AddStructuralProperty("AlternateId1", EdmPrimitiveTypeKind.String);
+            IEdmProperty alternateId2 = customer.AddStructuralProperty("AlternateId2", EdmPrimitiveTypeKind.String);
+            model.AddAlternateKeyAnnotation(customer, new Dictionary<string, IEdmProperty> { { "AltId1", alternateId1 } });
+            model.AddAlternateKeyAnnotation(customer, new Dictionary<string, IEdmProperty> { { "AltId2", alternateId2 } });
+            IDictionary<string, string> keyMappings = new Dictionary<string, string> { { "AltId1", "AltId1" } };
 
             model.AddElement(customer);
             ODataContext context = new(model);
-            ODataKeySegment keySegment = new(customer)
+            ODataKeySegment keySegment = new(customer, keyMappings)
             {
                 IsAlternateKey = true
             };
@@ -302,7 +305,7 @@ schema:
             Assert.Single(parameters);
             string json = altParameter.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
             Assert.Equal(@"{
-  ""name"": ""AltId"",
+  ""name"": ""AltId1"",
   ""in"": ""path"",
   ""description"": ""Alternate key of Customer"",
   ""required"": true,
@@ -330,9 +333,11 @@ schema:
                     { "AltId2", alternateId2 }
                 });
 
+            IDictionary<string, string> keyMappings = new Dictionary<string, string> { { "AltId1", "AltId1" }, { "AltId2", "AltId2" } };
+
             model.AddElement(customer);
             ODataContext context = new(model);
-            ODataKeySegment keySegment = new(customer)
+            ODataKeySegment keySegment = new(customer, keyMappings)
             {
                 IsAlternateKey = true
             };


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/414

This PR:
- Resolves the issue of all annotated alternate key parameters on an entity being included in the parameters list.
- Updates tests to validate the above fix
- Updates release notes.