### PR TITLE
[Feature] Reads annotations on structural properties of stream types for media entity paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,24 +15,13 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.5.0</Version>
+    <Version>1.6.0-preview.1</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-- Resolves operation ids for $count and overloaded functions paths #382, #383
-- Updates README #13, #253, #40
-- Fixes casing in default propertyName for `innerError` in the `ErrorMainSchema`
-- Adds support for `x-ms-enum-flags` extension for flagged enums
-- Use containment together with RequiresExplicitBinding annotation to check whether to append bound operations to navigation properties #430
-- Adds schema to content types of stream properties that have a collection of acceptable media types #435
-- Adds support for composable functions #431
-- Retrieves complex properties of derived types #437
-- Updates operationIds of navigation property paths with OData type cast segments #442
-- Generate navigation property paths defined in nested complex properties #446
-- Adds support for alternate keys to collection navigation properties #410
-- Ensures only alternate key parameter matching key segment identifier is included in path parameters #414
+- Reads annotations on structural properties of stream types for media entity paths #399
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/EdmModelHelper.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/EdmModelHelper.cs
@@ -408,7 +408,7 @@ namespace Microsoft.OpenApi.OData.Tests
             _output.WriteLine(actual);
 
             // Assert
-            Assert.Equal(expected, actual);
+            Assert.Equal(expected, actual.ChangeLineBreaks());
         }
 
         public static string GetCsdl(IEdmModel model)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/EdmModelHelper.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Common/EdmModelHelper.cs
@@ -408,7 +408,7 @@ namespace Microsoft.OpenApi.OData.Tests
             _output.WriteLine(actual);
 
             // Assert
-            Assert.Equal(expected, actual.ChangeLineBreaks());
+            Assert.Equal(expected, actual);
         }
 
         public static string GetCsdl(IEdmModel model)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -26,15 +26,27 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateMediaEntityGetOperationReturnsCorrectOperation(bool enableOperationId, bool useHTTPStatusCodeClass2XX)
         {
             // Arrange
-            string qualifiedName = CoreConstants.AcceptableMediaTypes;
             string annotation = $@"
-            <Annotation Term=""{qualifiedName}"" >
+            <Annotation Term=""Org.OData.Core.V1.AcceptableMediaTypes"" >
               <Collection>
                 <String>image/png</String>
                 <String>image/jpeg</String>
               </Collection>
             </Annotation>
-            <Annotation Term=""Org.OData.Core.V1.Description"" String=""The logo image."" />";
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""The logo image."" />
+            <Annotation Term=""Org.OData.Capabilities.V1.ReadRestrictions"">
+              <Record>
+                <PropertyValue Property=""CustomQueryOptions"">
+                  <Collection>
+                    <Record>
+                      <PropertyValue Property=""Name"" String=""format"" />
+                      <PropertyValue Property=""Description"" String=""Specify the format the item's content should be downloaded as."" />
+                      <PropertyValue Property=""Required"" Bool=""false"" />
+                    </Record>                
+                  </Collection>
+                </PropertyValue>
+              </Record>
+            </Annotation>";
 
             // Assert
             VerifyMediaEntityGetOperation("", enableOperationId, useHTTPStatusCodeClass2XX);
@@ -107,12 +119,15 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.True(getOperation.Responses[statusCode].Content.ContainsKey("image/png"));
                 Assert.True(getOperation.Responses[statusCode].Content.ContainsKey("image/jpeg"));
                 Assert.Equal("The logo image.", getOperation.Description);
+                Assert.Equal(2, getOperation.Parameters.Count);
+                Assert.NotNull(getOperation.Parameters.FirstOrDefault(x => x.Name.Equals("format")));
 
                 Assert.Single(getOperation2.Responses[statusCode].Content.Keys);
                 Assert.True(getOperation2.Responses[statusCode].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
             }
             else
             {
+                Assert.Single(getOperation.Parameters);
                 Assert.Single(getOperation.Responses[statusCode].Content.Keys);
                 Assert.Single(getOperation2.Responses[statusCode].Content.Keys);
                 Assert.True(getOperation.Responses[statusCode].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -24,15 +24,27 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateMediaEntityPutOperationReturnsCorrectOperation(bool enableOperationId, bool useSuccessStatusCodeRange)
         {
             // Arrange
-            string qualifiedName = CoreConstants.AcceptableMediaTypes;
             string annotation = $@"
-            <Annotation Term=""{qualifiedName}"" >
+            <Annotation Term=""Org.OData.Core.V1.AcceptableMediaTypes"" >
               <Collection>
                 <String>image/png</String>
                 <String>image/jpeg</String>
               </Collection>
             </Annotation>
-            <Annotation Term=""Org.OData.Core.V1.Description"" String=""The logo image."" />";
+            <Annotation Term=""Org.OData.Core.V1.Description"" String=""The logo image."" />
+            <Annotation Term=""Org.OData.Capabilities.V1.UpdateRestrictions"">
+              <Record>
+                <PropertyValue Property=""CustomQueryOptions"">
+                  <Collection>
+                    <Record>
+                      <PropertyValue Property=""Name"" String=""format"" />
+                      <PropertyValue Property=""Description"" String=""Specify the format the item's content should be downloaded as."" />
+                      <PropertyValue Property=""Required"" Bool=""false"" />
+                    </Record>                
+                  </Collection>
+                </PropertyValue>
+              </Record>
+            </Annotation>";
 
             // Assert
             VerifyMediaEntityPutOperation("", enableOperationId, useSuccessStatusCodeRange);
@@ -121,12 +133,15 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.True(putOperation.RequestBody.Content.ContainsKey("image/png"));
                 Assert.True(putOperation.RequestBody.Content.ContainsKey("image/jpeg"));
                 Assert.Equal("The logo image.", putOperation.Description);
+                Assert.Equal(2, putOperation.Parameters.Count);
+                Assert.NotNull(putOperation.Parameters.FirstOrDefault(x => x.Name.Equals("format")));
 
                 Assert.Single(putOperation2.RequestBody.Content.Keys);
                 Assert.True(putOperation2.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
             }
             else
             {
+                Assert.Single(putOperation.Parameters);
                 Assert.Single(putOperation.RequestBody.Content.Keys);
                 Assert.Single(putOperation2.RequestBody.Content.Keys);
                 Assert.True(putOperation.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/399

This PR:
- Enables reading `Org.OData.Capabilities.V1.ReadRestrictions` and `Org.OData.Capabilities.V1.UpdateRestrictions` on structural properties of stream types for media entity paths.
- Updates tests to validate the above.
- Updates release notes.