### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,7 +25,7 @@ jobs:
           # Get default branch
           $repo = 'microsoft/OpenAPI.NET.OData'
           $defaultBranch = Invoke-RestMethod -Method GET -Uri https://api.github.com/repos/$repo | Select-Object -ExpandProperty default_branch
-          Write-Output "::set-output name=default_branch::$(echo $defaultBranch)"
+          Write-Output "default_branch=$(echo $defaultBranch) >> $GITHUB_OUTPUT"
 
       - name: Conditionals handler
         id: conditionals_handler
@@ -37,7 +37,7 @@ jobs:
           if ( $githubRef -like "*$defaultBranch*" ) {
             $isDefaultBranch = 'true'
           }
-          Write-Output "::set-output name=is_default_branch::$(echo $isDefaultBranch)"
+          Write-Output "is_default_branch=$(echo $isDefaultBranch) >> $GITHUB_OUTPUT"
 
       - name: Checkout repository
         id: checkout_repo


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


