### PR TITLE
[Fix] Adds a `delete` operation and a required `@id` query parameter to collection-valued nav. property paths with `$ref`

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.2</Version>
+    <Version>1.6.0-preview.3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -23,6 +23,7 @@
     <PackageReleaseNotes>
 - Reads annotations on structural properties of stream types for media entity paths #399
 - Updates the format of the request body schema of a collection of complex property #423
+- Adds delete operations to collection-valued navigation property paths with $ref and a required @id query parameter #453
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -23,7 +23,7 @@
     <PackageReleaseNotes>
 - Reads annotations on structural properties of stream types for media entity paths #399
 - Updates the format of the request body schema of a collection of complex property #423
-- Adds delete operations to collection-valued navigation property paths with $ref and a required @id query parameter #453
+- Adds a delete operation and a required @id query parameter to collection-valued navigation property paths with $ref #453
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
@@ -62,13 +62,15 @@ namespace Microsoft.OpenApi.OData.Operation
             });
 
             // for collection, we should have @id in query
-            if (NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
+            if (NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many &&
+                Path.Segments.Reverse().Skip(1).First() is ODataNavigationPropertySegment)
             {
                 operation.Parameters.Add(new OpenApiParameter
                 {
                     Name = "@id",
                     In = ParameterLocation.Query,
-                    Description = "Delete Uri",
+                    Description = "The Delete Uri",
+                    Required = true,
                     Schema = new OpenApiSchema
                     {
                         Type = "string"

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefDeleteOperationHandler.cs
@@ -69,7 +69,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 {
                     Name = "@id",
                     In = ParameterLocation.Query,
-                    Description = "The Delete Uri",
+                    Description = "The delete Uri",
                     Required = true,
                     Schema = new OpenApiSchema
                     {

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -65,22 +65,21 @@ namespace Microsoft.OpenApi.OData.PathItem
                 }
             }
 
-            // So far, we only consider the non-containment
-            Debug.Assert(!NavigationProperty.ContainsTarget);
-
             // Create the ref
             if (NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
             {
                 ODataSegment penultimateSegment = Path.Segments.Reverse().Skip(1).First();
                 if (penultimateSegment is ODataKeySegment)
                 {
-                    // Collection-valued: DELETE ~/entityset/{key}/collection-valued-Nav/{key}/$ref
+                    // Collection-valued indexed: DELETE ~/entityset/{key}/collection-valued-Nav/{key}/$ref
                     AddDeleteOperation(item, restriction);
                 }
                 else
                 {
                     AddReadOperation(item, restriction);
                     AddInsertOperation(item, restriction);
+                    // Collection-valued: DELETE ~/entityset/{key}/collection-valued-Nav/$ref?$id='{navKey}'
+                    AddDeleteOperation(item, restriction);
                 }
             }
             else

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
@@ -57,10 +57,10 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Theory]
-        [InlineData(true, new OperationType[] { OperationType.Delete})]
-        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Post})]
+        [InlineData(true, new OperationType[] { OperationType.Delete}, true)]
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Post, OperationType.Delete })]
         [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
-        public void CreateNavigationPropertyRefPathItemReturnsCorrectPathItem(bool collectionNav, OperationType[] expected)
+        public void CreateNavigationPropertyRefPathItemReturnsCorrectPathItem(bool collectionNav, OperationType[] expected, bool indexedColNav = false)
         {
             // Arrange
             IEdmModel model = GetEdmModel("");
@@ -75,7 +75,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             Assert.NotNull(property);
 
             ODataPath path;
-            if (collectionNav && expected.Contains(OperationType.Delete))
+            if (collectionNav && indexedColNav)
             {
                 // DELETE ~/entityset/{key}/collection-valued-Nav/{key}/$ref
                 path = new ODataPath(new ODataNavigationSourceSegment(entitySet),

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -789,12 +789,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -956,6 +950,48 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Documents.RevisionDto"
+        ],
+        "summary": "Delete ref of navigation property Revisions for Documents",
+        "operationId": "Documents.DeleteRefRevisions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "The unique identifier of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -1666,12 +1702,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -2079,6 +2109,48 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Libraries.DocumentDto"
+        ],
+        "summary": "Delete ref of navigation property Documents for Libraries",
+        "operationId": "Libraries.DeleteRefDocuments",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "The unique identifier of LibraryDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -3645,12 +3717,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -3812,6 +3878,48 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Tasks.RevisionDto"
+        ],
+        "summary": "Delete ref of navigation property Revisions for Tasks",
+        "operationId": "Tasks.DeleteRefRevisions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "Id",
+            "description": "The unique identifier of DocumentDto",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -565,10 +565,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -684,6 +680,36 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: DocumentDto
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Documents.RevisionDto
+      summary: Delete ref of navigation property Revisions for Documents
+      operationId: Documents.DeleteRefRevisions
+      parameters:
+        - in: path
+          name: Id
+          description: The unique identifier of DocumentDto
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -1183,10 +1209,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -1466,6 +1488,36 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: LibraryDto
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Libraries.DocumentDto
+      summary: Delete ref of navigation property Documents for Libraries
+      operationId: Libraries.DeleteRefDocuments
+      parameters:
+        - in: path
+          name: Id
+          description: The unique identifier of LibraryDto
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: LibraryDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -2595,10 +2647,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -2714,6 +2762,36 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: DocumentDto
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Tasks.RevisionDto
+      summary: Delete ref of navigation property Revisions for Tasks
+      operationId: Tasks.DeleteRefRevisions
+      parameters:
+        - in: path
+          name: Id
+          description: The unique identifier of DocumentDto
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: DocumentDto
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -886,14 +886,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1068,6 +1060,54 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Documents.RevisionDto"
+        ],
+        "summary": "Delete ref of navigation property Revisions for Documents",
+        "operationId": "Documents.DeleteRefRevisions",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "The unique identifier of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -1858,14 +1898,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -2317,6 +2349,54 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Libraries.DocumentDto"
+        ],
+        "summary": "Delete ref of navigation property Documents for Libraries",
+        "operationId": "Libraries.DeleteRefDocuments",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "The unique identifier of LibraryDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "LibraryDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -4083,14 +4163,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -4265,6 +4337,54 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Tasks.RevisionDto"
+        ],
+        "summary": "Delete ref of navigation property Revisions for Tasks",
+        "operationId": "Tasks.DeleteRefRevisions",
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "The unique identifier of DocumentDto",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "DocumentDto"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -629,11 +629,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -757,6 +752,39 @@ paths:
           x-ms-docs-key-type: DocumentDto
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Documents.RevisionDto
+      summary: Delete ref of navigation property Revisions for Documents
+      operationId: Documents.DeleteRefRevisions
+      parameters:
+        - name: Id
+          in: path
+          description: The unique identifier of DocumentDto
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -1311,11 +1339,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -1622,6 +1645,39 @@ paths:
           x-ms-docs-key-type: LibraryDto
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Libraries.DocumentDto
+      summary: Delete ref of navigation property Documents for Libraries
+      operationId: Libraries.DeleteRefDocuments
+      parameters:
+        - name: Id
+          in: path
+          description: The unique identifier of LibraryDto
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: LibraryDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -2884,11 +2940,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -3012,6 +3063,39 @@ paths:
           x-ms-docs-key-type: DocumentDto
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Tasks.RevisionDto
+      summary: Delete ref of navigation property Revisions for Tasks
+      operationId: Tasks.DeleteRefRevisions
+      parameters:
+        - name: Id
+          in: path
+          description: The unique identifier of DocumentDto
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: DocumentDto
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -2520,12 +2520,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -3277,6 +3271,44 @@
         "parameters": [
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -4843,12 +4875,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -5538,6 +5564,44 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
@@ -5942,12 +6006,6 @@
             "in": "header",
             "name": "If-Match",
             "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
             "type": "string"
           }
         ],
@@ -6538,6 +6596,44 @@
         "parameters": [
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Peers for Me",
+        "operationId": "Me.DeleteRefPeers",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -7165,12 +7261,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -7329,6 +7419,55 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -8694,12 +8833,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -9320,6 +9453,44 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property DirectReports for Me",
+        "operationId": "Me.DeleteRefDirectReports",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
@@ -9462,12 +9633,6 @@
             "in": "header",
             "name": "If-Match",
             "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
             "type": "string"
           }
         ],
@@ -10139,6 +10304,44 @@
         "parameters": [
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -11078,12 +11281,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -11242,6 +11439,55 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -11975,12 +12221,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -12139,6 +12379,55 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -13786,12 +14075,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -14569,6 +14852,45 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for NewComePeople",
+        "operationId": "NewComePeople.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -15893,12 +16215,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -16060,6 +16376,56 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for NewComePeople",
+        "operationId": "NewComePeople.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -17807,12 +18173,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -18676,6 +19036,52 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -20506,12 +20912,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -21305,6 +21705,52 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
@@ -21767,12 +22213,6 @@
             "in": "header",
             "name": "If-Match",
             "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
             "type": "string"
           }
         ],
@@ -22478,6 +22918,52 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Peers for People",
+        "operationId": "People.DeleteRefPeers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Trips": {
@@ -23150,12 +23636,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -23338,6 +23818,63 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -24943,12 +25480,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -25665,6 +26196,52 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property DirectReports for People",
+        "operationId": "People.DeleteRefDirectReports",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
       "x-description": "Provides operations to manage the collection of Person entities."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
@@ -25823,12 +26400,6 @@
             "in": "header",
             "name": "If-Match",
             "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
             "type": "string"
           }
         ],
@@ -26604,6 +27175,52 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -27657,12 +28274,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -27845,6 +28456,63 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -28666,12 +29334,6 @@
             "name": "If-Match",
             "description": "ETag",
             "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
           }
         ],
         "responses": {
@@ -28854,6 +29516,63 @@
           },
           {
             "$ref": "#/parameters/refPostBody"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "TripId",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647,
+            "minimum": -2147483648,
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "@id",
+            "description": "The delete Uri",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -1725,10 +1725,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -2253,6 +2249,33 @@ paths:
       operationId: Me.CreateRefFriends
       parameters:
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -3351,10 +3374,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -3830,6 +3849,33 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
     get:
@@ -4121,10 +4167,6 @@ paths:
         - in: header
           name: If-Match
           description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
           type: string
       responses:
         '204':
@@ -4528,6 +4570,33 @@ paths:
       operationId: Me.CreateRefPeers
       parameters:
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Peers for Me
+      operationId: Me.DeleteRefPeers
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -4983,10 +5052,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -5096,6 +5161,42 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: Trip
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -6047,10 +6148,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -6473,6 +6570,33 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property DirectReports for Me
+      operationId: Me.DeleteRefDirectReports
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends:
     get:
@@ -6579,10 +6703,6 @@ paths:
         - in: header
           name: If-Match
           description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
           type: string
       responses:
         '204':
@@ -7047,6 +7167,33 @@ paths:
       operationId: Me.CreateRefFriends
       parameters:
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -7722,10 +7869,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -7835,6 +7978,42 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: Trip
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -8362,10 +8541,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -8475,6 +8650,42 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: Trip
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -9627,10 +9838,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -10163,6 +10370,33 @@ paths:
           type: string
           x-ms-docs-key-type: Person
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete ref of navigation property Friends for NewComePeople
+      operationId: NewComePeople.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -11096,10 +11330,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -11209,6 +11439,42 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: Trip
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - NewComePeople.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for NewComePeople
+      operationId: NewComePeople.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -12440,10 +12706,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -13052,6 +13314,39 @@ paths:
           type: string
           x-ms-docs-key-type: Person
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -14345,10 +14640,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -14902,6 +15193,39 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
     get:
@@ -15236,10 +15560,6 @@ paths:
         - in: header
           name: If-Match
           description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
           type: string
       responses:
         '204':
@@ -15715,6 +16035,39 @@ paths:
           type: string
           x-ms-docs-key-type: Person
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Peers for People
+      operationId: People.DeleteRefPeers
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -16218,10 +16571,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -16349,6 +16698,48 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: Trip
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -17477,10 +17868,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -17975,6 +18362,39 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property DirectReports for People
+      operationId: People.DeleteRefDirectReports
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
     x-description: Provides operations to manage the collection of Person entities.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends':
     get:
@@ -18093,10 +18513,6 @@ paths:
         - in: header
           name: If-Match
           description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
           type: string
       responses:
         '204':
@@ -18639,6 +19055,39 @@ paths:
           type: string
           x-ms-docs-key-type: Person
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -19399,10 +19848,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -19530,6 +19975,48 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: Trip
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success
@@ -20123,10 +20610,6 @@ paths:
           name: If-Match
           description: ETag
           type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
       responses:
         '204':
           description: Success
@@ -20254,6 +20737,48 @@ paths:
           minimum: -2147483648
           x-ms-docs-key-type: Trip
         - $ref: '#/parameters/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: TripId
+          description: The unique identifier of Trip
+          required: true
+          type: integer
+          format: int32
+          maximum: 2147483647
+          minimum: -2147483648
+          x-ms-docs-key-type: Trip
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+        - in: query
+          name: '@id'
+          description: The delete Uri
+          required: true
+          type: string
       responses:
         '204':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -2798,14 +2798,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -3631,6 +3623,48 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -5317,14 +5351,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -6072,6 +6098,48 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
@@ -6517,14 +6585,6 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
             "schema": {
               "type": "string"
             }
@@ -7165,6 +7225,48 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Peers for Me",
+        "operationId": "Me.DeleteRefPeers",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -7873,14 +7975,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -8052,6 +8146,61 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -9549,14 +9698,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -10238,6 +10379,48 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         },
         "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property DirectReports for Me",
+        "operationId": "Me.DeleteRefDirectReports",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
@@ -10398,14 +10581,6 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
             "schema": {
               "type": "string"
             }
@@ -11140,6 +11315,48 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for Me",
+        "operationId": "Me.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -12188,14 +12405,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -12367,6 +12576,61 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -13189,14 +13453,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -13368,6 +13624,61 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "Me.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for Me",
+        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -15226,14 +15537,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -16131,6 +16434,51 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for NewComePeople",
+        "operationId": "NewComePeople.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -17641,14 +17989,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -17829,6 +18169,64 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for NewComePeople",
+        "operationId": "NewComePeople.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -19773,14 +20171,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -20748,6 +21138,58 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -22780,14 +23222,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -23667,6 +24101,58 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager": {
@@ -24186,14 +24672,6 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
             "schema": {
               "type": "string"
             }
@@ -24956,6 +25434,58 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Peers for People",
+        "operationId": "People.DeleteRefPeers",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -25746,14 +26276,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -25955,6 +26477,71 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -27768,14 +28355,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -28579,6 +29158,58 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         },
         "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property DirectReports for People",
+        "operationId": "People.DeleteRefDirectReports",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends": {
@@ -28759,14 +29390,6 @@
             "name": "If-Match",
             "in": "header",
             "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
             "schema": {
               "type": "string"
             }
@@ -29633,6 +30256,58 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete ref of navigation property Friends for People",
+        "operationId": "People.DeleteRefFriends",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -30829,14 +31504,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -31038,6 +31705,71 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -31974,14 +32706,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -32183,6 +32907,71 @@
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        },
+        "x-ms-docs-operation-type": "operation"
+      },
+      "delete": {
+        "tags": [
+          "People.Trips.PlanItem"
+        ],
+        "summary": "Delete ref of navigation property PlanItems for People",
+        "operationId": "People.Trips.DeleteRefPlanItems",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "TripId",
+            "in": "path",
+            "description": "The unique identifier of Trip",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-ms-docs-key-type": "Trip"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "@id",
+            "in": "query",
+            "description": "The delete Uri",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -1901,11 +1901,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -2479,6 +2474,35 @@ paths:
       operationId: Me.CreateRefFriends
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -3670,11 +3694,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -4190,6 +4209,35 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager:
     description: Casts the previous resource to Manager.
     get:
@@ -4512,11 +4560,6 @@ paths:
         - name: If-Match
           in: header
           description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
           schema:
             type: string
       responses:
@@ -4952,6 +4995,35 @@ paths:
       operationId: Me.CreateRefPeers
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Peers for Me
+      operationId: Me.DeleteRefPeers
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -5461,11 +5533,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -5583,6 +5650,45 @@ paths:
           x-ms-docs-key-type: Trip
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -6631,11 +6737,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -7099,6 +7200,35 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property DirectReports for Me
+      operationId: Me.DeleteRefDirectReports
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends:
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -7218,11 +7348,6 @@ paths:
         - name: If-Match
           in: header
           description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
           schema:
             type: string
       responses:
@@ -7728,6 +7853,35 @@ paths:
       operationId: Me.CreateRefFriends
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete ref of navigation property Friends for Me
+      operationId: Me.DeleteRefFriends
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -8476,11 +8630,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -8598,6 +8747,45 @@ paths:
           x-ms-docs-key-type: Trip
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -9185,11 +9373,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -9307,6 +9490,45 @@ paths:
           x-ms-docs-key-type: Trip
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - Me.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for Me
+      operationId: Me.Trips.DeleteRefPlanItems
+      parameters:
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -10597,11 +10819,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -11208,6 +11425,36 @@ paths:
           x-ms-docs-key-type: Person
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete ref of navigation property Friends for NewComePeople
+      operationId: NewComePeople.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -12262,11 +12509,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -12387,6 +12629,46 @@ paths:
           x-ms-docs-key-type: Trip
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - NewComePeople.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for NewComePeople
+      operationId: NewComePeople.Trips.DeleteRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -13747,11 +14029,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -14424,6 +14701,42 @@ paths:
           x-ms-docs-key-type: Person
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -15852,11 +16165,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -16464,6 +16772,42 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager':
     description: Casts the previous resource to Manager.
     get:
@@ -16837,11 +17181,6 @@ paths:
         - name: If-Match
           in: header
           description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
           schema:
             type: string
       responses:
@@ -17362,6 +17701,42 @@ paths:
           x-ms-docs-key-type: Person
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Peers for People
+      operationId: People.DeleteRefPeers
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -17928,11 +18303,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -18071,6 +18441,52 @@ paths:
           x-ms-docs-key-type: Trip
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -19335,11 +19751,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -19888,6 +20299,42 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property DirectReports for People
+      operationId: People.DeleteRefDirectReports
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -20021,11 +20468,6 @@ paths:
         - name: If-Match
           in: header
           description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
           schema:
             type: string
       responses:
@@ -20623,6 +21065,42 @@ paths:
           x-ms-docs-key-type: Person
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Person
+      summary: Delete ref of navigation property Friends for People
+      operationId: People.DeleteRefFriends
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -21473,11 +21951,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -21616,6 +22089,52 @@ paths:
           x-ms-docs-key-type: Trip
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -22282,11 +22801,6 @@ paths:
           description: ETag
           schema:
             type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
       responses:
         '204':
           description: Success
@@ -22425,6 +22939,52 @@ paths:
           x-ms-docs-key-type: Trip
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - People.Trips.PlanItem
+      summary: Delete ref of navigation property PlanItems for People
+      operationId: People.Trips.DeleteRefPlanItems
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: TripId
+          in: path
+          description: The unique identifier of Trip
+          required: true
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: integer
+            format: int32
+          x-ms-docs-key-type: Trip
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+        - name: '@id'
+          in: query
+          description: The delete Uri
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Success


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/453

This PR:
- Adds `delete` operation to collection-valued nav. paths with `$ref`. A required query param of `@id` is also included in the list of parameters.
- Updates test and integration files to validate the above.
