### PR TITLE
[Fix] Fixes inconsistency of nullability of schemas of properties that are a collection of structured types

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -480,7 +480,8 @@ namespace Microsoft.OpenApi.OData.Generator
                 schema.Reference = null;
                 schema.AnyOf = new List<OpenApiSchema>
                 {
-                    new() {
+                    new OpenApiSchema
+                    {
                         UnresolvedReference = true,
                         Reference = new OpenApiReference
                         {
@@ -488,7 +489,8 @@ namespace Microsoft.OpenApi.OData.Generator
                             Id = typeReference.Definition.FullTypeName()
                         }
                     },
-                    new() {
+                    new OpenApiSchema
+                    {
                         Type = "object",
                         Nullable = true
                     }

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiEdmTypeSchemaGenerator.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -461,45 +461,18 @@ namespace Microsoft.OpenApi.OData.Generator
             Debug.Assert(context != null);
             Debug.Assert(typeReference != null);
 
-            OpenApiSchema schema = new OpenApiSchema();
-
-            // AnyOf will only be valid openApi for version 3
-            // otherwise the reference should be set directly
-            // as per OASIS documentation for openApi version 2
-            if (typeReference.IsNullable && 
-                (context.Settings.OpenApiSpecVersion >= OpenApiSpecVersion.OpenApi3_0))
+            OpenApiSchema schema = new OpenApiSchema
             {
-                schema.Reference = null;
-                schema.AnyOf = new List<OpenApiSchema>
-                {
-                    new OpenApiSchema
-                    {
-                        UnresolvedReference = true,
-                        Reference = new OpenApiReference
-                        {
-                            Type = ReferenceType.Schema,
-                            Id = typeReference.Definition.FullTypeName()
-                        }
-                    },
-                    new OpenApiSchema
-                    {
-                        Type = "object",
-                        Nullable = true
-                    }
-                };
-            }
-            else
-            {
-                schema.Type = null;
-                schema.AnyOf = null;
-                schema.Reference = new OpenApiReference
+                Type = null,
+                AnyOf = null,
+                Reference = new OpenApiReference
                 {
                     Type = ReferenceType.Schema,
                     Id = typeReference.Definition.FullTypeName()
-                };
-                schema.UnresolvedReference = true; 
-                schema.Nullable = typeReference.IsNullable;
-            }
+                },
+                UnresolvedReference = true,
+                Nullable = typeReference.IsNullable
+            };
 
             return schema;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.3</Version>
+    <Version>1.6.0-preview.4</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -24,6 +24,7 @@
 - Reads annotations on structural properties of stream types for media entity paths #399
 - Updates the format of the request body schema of a collection of complex property #423
 - Adds a delete operation and a required @id query parameter to collection-valued navigation property paths with $ref #453
+- Fixes inconsistency of nullability of schemas of properties that are a collection of structured types #467
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiEdmTypeSchemaGeneratorTest.cs
@@ -78,15 +78,7 @@ namespace Microsoft.OpenApi.OData.Tests
                 Assert.Equal(@"{
   ""type"": ""array"",
   ""items"": {
-    ""anyOf"": [
-      {
-        ""$ref"": ""#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation""
-      },
-      {
-        ""type"": ""object"",
-        ""nullable"": true
-      }
-    ]
+    ""$ref"": ""#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation""
   }
 }".ChangeLineBreaks(), json);
             }           

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             // Act & Assert
             Assert.Throws<ArgumentNullException>("operation", () => context.CreateResponses(operation: null));
         }
-                
+
         [Theory]
         [InlineData(true, OpenApiSpecVersion.OpenApi3_0)]
         [InlineData(false, OpenApiSpecVersion.OpenApi3_0)]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiResponseGeneratorTests.cs
@@ -161,18 +161,16 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
         }
 
         [Theory]
-        [InlineData(true, OpenApiSpecVersion.OpenApi3_0)]
-        [InlineData(false, OpenApiSpecVersion.OpenApi3_0)]
-        [InlineData(true, OpenApiSpecVersion.OpenApi2_0)]
-        [InlineData(false, OpenApiSpecVersion.OpenApi2_0)]
-        public void CreateResponseForEdmFunctionReturnCorrectResponses(bool isFunctionImport, OpenApiSpecVersion specVersion)
+       
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateResponseForEdmFunctionReturnCorrectResponses(bool isFunctionImport)
         {
             // Arrange
             string operationName = "GetPersonWithMostFriends";
             IEdmModel model = EdmModelHelper.TripServiceModel;
             ODataContext context = new ODataContext(model);
 
-            context.Settings.OpenApiSpecVersion = specVersion;
 
             // Act
             OpenApiResponses responses;
@@ -201,30 +199,11 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             Assert.NotNull(response.Content);
             OpenApiMediaType mediaType = response.Content["application/json"];
 
-            // openApi version 2 should not use AnyOf
-            if (specVersion == OpenApiSpecVersion.OpenApi2_0)
-            {
-                Assert.NotNull(mediaType.Schema);
-                Assert.Null(mediaType.Schema.AnyOf);
-                Assert.NotNull(mediaType.Schema.Reference);
-                Assert.Equal("Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person", mediaType.Schema.Reference.Id);
-                Assert.True(mediaType.Schema.Nullable);
-            }
-            else
-            {
-                Assert.NotNull(mediaType.Schema);
-                Assert.Null(mediaType.Schema.Reference);
-                Assert.NotNull(mediaType.Schema.AnyOf);
-                Assert.Equal(2, mediaType.Schema.AnyOf.Count);
-                var anyOfRef = mediaType.Schema.AnyOf.FirstOrDefault();
-                Assert.NotNull(anyOfRef);
-                Assert.Equal("Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person", anyOfRef.Reference.Id);
-                var anyOfNull = mediaType.Schema.AnyOf.Skip(1).FirstOrDefault();
-                Assert.NotNull(anyOfNull.Type);
-                Assert.Equal("object", anyOfNull.Type);
-                Assert.True(anyOfNull.Nullable);
-
-            }
+            Assert.NotNull(mediaType.Schema);
+            Assert.Null(mediaType.Schema.AnyOf);
+            Assert.NotNull(mediaType.Schema.Reference);
+            Assert.Equal("Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person", mediaType.Schema.Reference.Id);
+            Assert.True(mediaType.Schema.Nullable);   
         }
 
         [Fact]
@@ -378,15 +357,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
                 ""value"": {
                   ""type"": ""array"",
                   ""items"": {
-                    ""anyOf"": [
-                      {
-                        ""$ref"": ""#/components/schemas/microsoft.graph.application""
-                      },
-                      {
-                        ""type"": ""object"",
-                        ""nullable"": true
-                      }
-                    ]
+                    ""$ref"": ""#/components/schemas/microsoft.graph.application""
                   }
                 }
               }
@@ -415,15 +386,7 @@ namespace Microsoft.OpenApi.OData.Generator.Tests
             ""value"": {
               ""type"": ""array"",
               ""items"": {
-                ""anyOf"": [
-                  {
-                    ""$ref"": ""#/components/schemas/microsoft.graph.application""
-                  },
-                  {
-                    ""type"": ""object"",
-                    ""nullable"": true
-                  }
-                ]
+                ""$ref"": ""#/components/schemas/microsoft.graph.application""
               }
             },
             ""@odata.nextLink"": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -4716,15 +4716,7 @@
           "Tags": {
             "type": "array",
             "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
-                },
-                {
-                  "type": "object",
-                  "nullable": true
-                }
-              ]
+              "$ref": "#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto"
             }
           },
           "Revisions": {
@@ -5307,29 +5299,13 @@
           "DocumentClasses": {
             "type": "array",
             "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
-                },
-                {
-                  "type": "object",
-                  "nullable": true
-                }
-              ]
+              "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass"
             }
           },
           "Tags": {
             "type": "array",
             "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
-                },
-                {
-                  "type": "object",
-                  "nullable": true
-                }
-              ]
+              "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
             }
           },
           "Library": {
@@ -6311,15 +6287,7 @@
               "Documents": {
                 "type": "array",
                 "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
-                    },
-                    {
-                      "type": "object",
-                      "nullable": true
-                    }
-                  ]
+                  "$ref": "#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel"
                 }
               }
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -3319,10 +3319,7 @@ components:
         Tags:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
-              - type: object
-                nullable: true
+            $ref: '#/components/schemas/Siterra.Documents.App.DTO.DocumentTagRelDto'
         Revisions:
           type: array
           items:
@@ -3785,17 +3782,11 @@ components:
         DocumentClasses:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
-              - type: object
-                nullable: true
+            $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentClass'
         Tags:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
-              - type: object
-                nullable: true
+            $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
         Library:
           anyOf:
             - $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Library.Library'
@@ -4537,10 +4528,7 @@ components:
             Documents:
               type: array
               items:
-                anyOf:
-                  - $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
-                  - type: object
-                    nullable: true
+                $ref: '#/components/schemas/Siterra.Documents.BusinessLogic.Entities.Document.DocumentTagRel'
       example:
         Id: integer (identifier)
         DomainId: integer

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -7775,15 +7775,7 @@
                     "value": {
                       "type": "array",
                       "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                          },
-                          {
-                            "type": "object",
-                            "nullable": true
-                          }
-                        ]
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                       }
                     }
                   }
@@ -12205,15 +12197,7 @@
                     "value": {
                       "type": "array",
                       "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                          },
-                          {
-                            "type": "object",
-                            "nullable": true
-                          }
-                        ]
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                       }
                     }
                   }
@@ -13253,15 +13237,7 @@
                     "value": {
                       "type": "array",
                       "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                          },
-                          {
-                            "type": "object",
-                            "nullable": true
-                          }
-                        ]
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                       }
                     }
                   }
@@ -17791,15 +17767,7 @@
                     "value": {
                       "type": "array",
                       "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                          },
-                          {
-                            "type": "object",
-                            "nullable": true
-                          }
-                        ]
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                       }
                     }
                   }
@@ -26056,15 +26024,7 @@
                     "value": {
                       "type": "array",
                       "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                          },
-                          {
-                            "type": "object",
-                            "nullable": true
-                          }
-                        ]
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                       }
                     }
                   }
@@ -31284,15 +31244,7 @@
                     "value": {
                       "type": "array",
                       "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                          },
-                          {
-                            "type": "object",
-                            "nullable": true
-                          }
-                        ]
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                       }
                     }
                   }
@@ -32486,15 +32438,7 @@
                     "value": {
                       "type": "array",
                       "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                          },
-                          {
-                            "type": "object",
-                            "nullable": true
-                          }
-                        ]
+                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                       }
                     }
                   }
@@ -33542,15 +33486,7 @@
           "AddressInfo": {
             "type": "array",
             "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
-                },
-                {
-                  "type": "object",
-                  "nullable": true
-                }
-              ]
+              "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"
             }
           },
           "HomeAddress": {
@@ -34674,15 +34610,7 @@
                 "value": {
                   "type": "array",
                   "items": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
-                      },
-                      {
-                        "type": "object",
-                        "nullable": true
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"
                   }
                 }
               }
@@ -34717,15 +34645,7 @@
                 "value": {
                   "type": "array",
                   "items": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
-                      },
-                      {
-                        "type": "object",
-                        "nullable": true
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
                   }
                 }
               }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -5397,10 +5397,7 @@ paths:
                   value:
                     type: array
                     items:
-                      anyOf:
-                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                        - type: object
-                          nullable: true
+                      $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -8494,10 +8491,7 @@ paths:
                   value:
                     type: array
                     items:
-                      anyOf:
-                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                        - type: object
-                          nullable: true
+                      $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -9237,10 +9231,7 @@ paths:
                   value:
                     type: array
                     items:
-                      anyOf:
-                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                        - type: object
-                          nullable: true
+                      $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -12377,10 +12368,7 @@ paths:
                   value:
                     type: array
                     items:
-                      anyOf:
-                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                        - type: object
-                          nullable: true
+                      $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: function
@@ -18153,10 +18141,7 @@ paths:
                   value:
                     type: array
                     items:
-                      anyOf:
-                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                        - type: object
-                          nullable: true
+                      $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -21801,10 +21786,7 @@ paths:
                   value:
                     type: array
                     items:
-                      anyOf:
-                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                        - type: object
-                          nullable: true
+                      $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -22651,10 +22633,7 @@ paths:
                   value:
                     type: array
                     items:
-                      anyOf:
-                        - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                        - type: object
-                          nullable: true
+                      $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -23382,10 +23361,7 @@ components:
         AddressInfo:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
-              - type: object
-                nullable: true
+            $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
         HomeAddress:
           anyOf:
             - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location'
@@ -24085,10 +24061,7 @@ components:
               value:
                 type: array
                 items:
-                  anyOf:
-                    - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
-                    - type: object
-                      nullable: true
+                  $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip'
     UpdatePersonLastNameResponse:
       description: Success
       content:
@@ -24110,10 +24083,7 @@ components:
               value:
                 type: array
                 items:
-                  anyOf:
-                    - $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
-                    - type: object
-                      nullable: true
+                  $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
   parameters:
     top:
       name: $top


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/467

This PR:
- Ensures that schemas of properties of collection of complex types are consistent with those of entity types, such that:
```YAML
identities:
  type: array
  items:
    anyOf:
      - $ref: '#/components/schemas/microsoft.graph.objectIdentity'
      - type: object
         nullable: true
```

should be...

```YAML
identities:
  type: array
  items:
    $ref: '#/components/schemas/microsoft.graph.objectIdentity'
```

[NB] Collection of structured types are not nullable.

- Updates tests
- Updates release notes