### PR TITLE
Adds `delete` operation for non-contained navigation properties only if explicitly allowed via annotation

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.4</Version>
+    <Version>1.6.0-preview.5</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -25,6 +25,7 @@
 - Updates the format of the request body schema of a collection of complex property #423
 - Adds a delete operation and a required @id query parameter to collection-valued navigation property paths with $ref #453
 - Fixes inconsistency of nullability of schemas of properties that are a collection of structured types #467
+- Adds delete operation for non-contained navigation properties only if explicitly allowed via annotation #483
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -247,7 +247,7 @@ namespace Microsoft.OpenApi.OData
         /// <summary>
         /// Gets/Sets a value indicating whether or not to expand derived types to retrieve their declared navigation properties.
         /// </summary>
-        [Obsolete("Use RetrieveDerivedTypesProperties to Get or Set the value.")]
+        [Obsolete("Use GenerateDerivedTypesProperties to Get or Set the value.")]
         public bool ExpandDerivedTypesNavigationProperties
         {
             get => GenerateDerivedTypesProperties;
@@ -299,7 +299,7 @@ namespace Microsoft.OpenApi.OData
         public bool RequireRestrictionAnnotationsToGenerateComplexPropertyPaths { get; set; } = true;
 
         /// <summary>
-        /// Gets/sets a dictionary containing a mapping of custom atttribute names and extension names.
+        /// Gets/sets a dictionary containing a mapping of custom attribute names and extension names.
         /// </summary>
         public Dictionary<string, string> CustomXMLAttributesMapping { get; set; } = new();
 

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -204,19 +204,20 @@ namespace Microsoft.OpenApi.OData.PathItem
                 DeleteRestrictionsType entityDeleteRestriction = Context.Model.GetRecord<DeleteRestrictionsType>(_navPropEntityType);
                 bool isDeletableDefault = navPropDeleteRestriction == null && entityDeleteRestriction == null;
 
-                if (isDeletableDefault ||
+                if ((isDeletableDefault ||
                 ((entityDeleteRestriction?.IsDeletable ?? true) &&
-                (navPropDeleteRestriction?.IsDeletable ?? true)))
+                (navPropDeleteRestriction?.IsDeletable ?? true))) &&
+                (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many ||
+                LastSegmentIsKeySegment))
                 {
-                    if (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment)
-                    {
-                        AddOperation(item, OperationType.Delete);
-                    }
+                    AddOperation(item, OperationType.Delete);
                 }
             }
             else
             {
-                if ((navPropDeleteRestriction?.IsDeletable ?? false) &&
+                // Add delete operation for non-contained nav. props only if explicitly set to true via annotation
+                // Note: Use Deletable and not IsDeletable
+                if ((navPropDeleteRestriction?.Deletable ?? false) && 
                     (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many ||
                     LastSegmentIsKeySegment))
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -199,26 +199,23 @@ namespace Microsoft.OpenApi.OData.PathItem
             DeleteRestrictionsType navPropDeleteRestriction = restriction?.DeleteRestrictions ??
                Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty);
 
-            if (NavigationProperty.ContainsTarget)
-            {
-                DeleteRestrictionsType entityDeleteRestriction = Context.Model.GetRecord<DeleteRestrictionsType>(_navPropEntityType);
-                bool isDeletableDefault = navPropDeleteRestriction == null && entityDeleteRestriction == null;
+            if (!(NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many || LastSegmentIsKeySegment))
+                return;
 
-                if ((isDeletableDefault ||
+            DeleteRestrictionsType entityDeleteRestriction = Context.Model.GetRecord<DeleteRestrictionsType>(_navPropEntityType);
+            bool isDeletable = 
+                (navPropDeleteRestriction == null && entityDeleteRestriction == null) ||
                 ((entityDeleteRestriction?.IsDeletable ?? true) &&
-                (navPropDeleteRestriction?.IsDeletable ?? true))) &&
-                (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many ||
-                LastSegmentIsKeySegment))
-                {
-                    AddOperation(item, OperationType.Delete);
-                }
+                (navPropDeleteRestriction?.IsDeletable ?? true));
+
+            if (NavigationProperty.ContainsTarget && isDeletable)
+            {
+                AddOperation(item, OperationType.Delete);
             }
-            else if ((navPropDeleteRestriction?.Deletable ?? false) &&
-                    (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many ||
-                    LastSegmentIsKeySegment))
+            else if (navPropDeleteRestriction?.Deletable ?? false)
             {
                 // Add delete operation for non-contained nav. props only if explicitly set to true via annotation
-                // Note: Use Deletable and not IsDeletable
+                // Note: Use Deletable and NOT IsDeletable
                 AddOperation(item, OperationType.Delete);
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/NavigationPropertyPathItemHandler.cs
@@ -213,16 +213,13 @@ namespace Microsoft.OpenApi.OData.PathItem
                     AddOperation(item, OperationType.Delete);
                 }
             }
-            else
+            else if ((navPropDeleteRestriction?.Deletable ?? false) &&
+                    (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many ||
+                    LastSegmentIsKeySegment))
             {
                 // Add delete operation for non-contained nav. props only if explicitly set to true via annotation
                 // Note: Use Deletable and not IsDeletable
-                if ((navPropDeleteRestriction?.Deletable ?? false) && 
-                    (NavigationProperty.TargetMultiplicity() != EdmMultiplicity.Many ||
-                    LastSegmentIsKeySegment))
-                {
-                    AddOperation(item, OperationType.Delete);
-                }
+                AddOperation(item, OperationType.Delete);
             }
 
             return;


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/483

This PR:
- Ensures `delete` operations for non-contained nav. props is generated only if `DeleteRestrictions` exists for this nav. prop and the `Deletable` property is set to `true`.
- Updates test to validate the above.
- Updates release note.
- Minor documentation text fixes to the convert settings.