### PR TITLE
Generates `$expand` query parameter for operations whose return type is a collection

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.4</Version>
+    <Version>1.6.0-preview.5</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -25,6 +25,7 @@
 - Updates the format of the request body schema of a collection of complex property #423
 - Adds a delete operation and a required @id query parameter to collection-valued navigation property paths with $ref #453
 - Fixes inconsistency of nullability of schemas of properties that are a collection of structured types #467
+- Generates $expand query parameter for operations whose return type is a collection #481
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -249,6 +249,12 @@ namespace Microsoft.OpenApi.OData.Operation
                     {
                         operation.Parameters.AppendParameter(orderbyParameter);
                     }
+
+                    // $expand
+                    if (Context.CreateExpand(function, entityType) is OpenApiParameter expandParameter)
+                    {
+                        operation.Parameters.AppendParameter(expandParameter);
+                    }
                 }
             }
         }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -7082,6 +7082,21 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7627,6 +7642,19 @@
                 "StartsAt desc",
                 "EndsAt",
                 "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
               ],
               "type": "string"
             }
@@ -11102,6 +11130,21 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -12039,6 +12082,21 @@
                 "FavoriteFeature desc",
                 "Features",
                 "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
               ],
               "type": "string"
             }
@@ -15441,6 +15499,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -16039,6 +16110,21 @@
                 "FavoriteFeature desc",
                 "Features",
                 "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
               ],
               "type": "string"
             }
@@ -23441,6 +23527,21 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -24060,6 +24161,19 @@
                 "StartsAt desc",
                 "EndsAt",
                 "EndsAt desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "PlanItems"
               ],
               "type": "string"
             }
@@ -28079,6 +28193,21 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -29136,6 +29265,21 @@
                 "FavoriteFeature desc",
                 "Features",
                 "Features desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "$expand",
+            "description": "Expand related entities",
+            "type": "array",
+            "items": {
+              "enum": [
+                "*",
+                "Friends",
+                "BestFriend",
+                "Trips"
               ],
               "type": "string"
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -4925,6 +4925,17 @@ paths:
               - Features
               - Features desc
             type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
       responses:
         '200':
           description: Success
@@ -5309,6 +5320,15 @@ paths:
               - StartsAt desc
               - EndsAt
               - EndsAt desc
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
             type: string
       responses:
         '200':
@@ -7742,6 +7762,17 @@ paths:
               - Features
               - Features desc
             type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
       responses:
         '200':
           description: Success
@@ -8413,6 +8444,17 @@ paths:
               - FavoriteFeature desc
               - Features
               - Features desc
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
             type: string
       responses:
         '200':
@@ -10781,6 +10823,15 @@ paths:
               - EndsAt
               - EndsAt desc
             type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
+            type: string
       responses:
         '200':
           $ref: '#/responses/GetFriendsTripsResponse'
@@ -11208,6 +11259,17 @@ paths:
               - FavoriteFeature desc
               - Features
               - Features desc
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
             type: string
       responses:
         '200':
@@ -16432,6 +16494,17 @@ paths:
               - Features
               - Features desc
             type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
       responses:
         '200':
           description: Success
@@ -16871,6 +16944,15 @@ paths:
               - StartsAt desc
               - EndsAt
               - EndsAt desc
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - PlanItems
             type: string
       responses:
         '200':
@@ -19709,6 +19791,17 @@ paths:
               - Features
               - Features desc
             type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
+            type: string
       responses:
         '200':
           description: Success
@@ -20470,6 +20563,17 @@ paths:
               - FavoriteFeature desc
               - Features
               - Features desc
+            type: string
+        - in: query
+          name: $expand
+          description: Expand related entities
+          type: array
+          items:
+            enum:
+              - '*'
+              - Friends
+              - BestFriend
+              - Trips
             type: string
       responses:
         '200':

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -7761,6 +7761,26 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -8369,6 +8389,24 @@
                   "StartsAt desc",
                   "EndsAt",
                   "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
                 ],
                 "type": "string"
               }
@@ -12183,6 +12221,26 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -13219,6 +13277,26 @@
                   "FavoriteFeature desc",
                   "Features",
                   "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
                 ],
                 "type": "string"
               }
@@ -17073,6 +17151,24 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -17749,6 +17845,26 @@
                   "FavoriteFeature desc",
                   "Features",
                   "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
                 ],
                 "type": "string"
               }
@@ -26010,6 +26126,26 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -26710,6 +26846,24 @@
                   "StartsAt desc",
                   "EndsAt",
                   "EndsAt desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "PlanItems"
                 ],
                 "type": "string"
               }
@@ -31230,6 +31384,26 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
+                ],
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
@@ -32420,6 +32594,26 @@
                   "FavoriteFeature desc",
                   "Features",
                   "Features desc"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "enum": [
+                  "*",
+                  "Friends",
+                  "BestFriend",
+                  "Trips"
                 ],
                 "type": "string"
               }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -5385,6 +5385,21 @@ paths:
                 - Features
                 - Features desc
               type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
       responses:
         '200':
           description: Success
@@ -5812,6 +5827,19 @@ paths:
                 - StartsAt desc
                 - EndsAt
                 - EndsAt desc
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
               type: string
       responses:
         '200':
@@ -8479,6 +8507,21 @@ paths:
                 - Features
                 - Features desc
               type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
       responses:
         '200':
           description: Success
@@ -9218,6 +9261,21 @@ paths:
                 - FavoriteFeature desc
                 - Features
                 - Features desc
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
               type: string
       responses:
         '200':
@@ -11879,6 +11937,19 @@ paths:
                 - EndsAt
                 - EndsAt desc
               type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
+              type: string
       responses:
         '200':
           $ref: '#/components/responses/GetFriendsTripsResponse'
@@ -12355,6 +12426,21 @@ paths:
                 - FavoriteFeature desc
                 - Features
                 - Features desc
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
               type: string
       responses:
         '200':
@@ -18129,6 +18215,21 @@ paths:
                 - Features
                 - Features desc
               type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
       responses:
         '200':
           description: Success
@@ -18620,6 +18721,19 @@ paths:
                 - StartsAt desc
                 - EndsAt
                 - EndsAt desc
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - PlanItems
               type: string
       responses:
         '200':
@@ -21774,6 +21888,21 @@ paths:
                 - Features
                 - Features desc
               type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
+              type: string
       responses:
         '200':
           description: Success
@@ -22620,6 +22749,21 @@ paths:
                 - FavoriteFeature desc
                 - Features
                 - Features desc
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - '*'
+                - Friends
+                - BestFriend
+                - Trips
               type: string
       responses:
         '200':


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/481

This PR:
- Generates `$expand` parameter for operations whose return type is a collection of an entity type.
- Updates tests
- Updates release note.