### PR TITLE
Appends parameters and fixes operation ids of navigation property paths generated via composable functions

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -187,6 +187,7 @@ namespace Microsoft.OpenApi.OData.Common
                 }
                 else if (segment is ODataOperationSegment operationSegment)
                 {
+                    // Navigation property generated via composable function
                     items.Add(operationSegment.Identifier);
                 }
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -163,7 +163,11 @@ namespace Microsoft.OpenApi.OData.Common
 
             // For navigation property paths with odata type cast segments
             // the OData type cast segments identifiers will be used in the operation id
-            IEnumerable<ODataSegment> segments = path.Segments.Skip(1).Where(static s => s is ODataNavigationPropertySegment || s is ODataTypeCastSegment);
+            IEnumerable<ODataSegment> segments = path.Segments.Skip(1)
+                .Where(static s => 
+                s is ODataNavigationPropertySegment ||
+                s is ODataTypeCastSegment ||
+                s is ODataOperationSegment);
             Utils.CheckArgumentNull(segments, nameof(segments));
 
             string previousTypeCastSegmentId = null;
@@ -180,6 +184,10 @@ namespace Microsoft.OpenApi.OData.Common
                     IEdmSchemaElement schemaElement = typeCastSegment.StructuredType as IEdmSchemaElement;
                     previousTypeCastSegmentId = "As" + Utils.UpperFirstChar(schemaElement.Name);
                     items.Add(previousTypeCastSegmentId);
+                }
+                else if (segment is ODataOperationSegment operationSegment)
+                {
+                    items.Add(operationSegment.Identifier);
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -292,6 +292,29 @@ namespace Microsoft.OpenApi.OData.Generator
                 pathParameters.AddRange(context.CreateKeyParameters(keySegment, mapping));
             }
 
+            foreach (ODataOperationSegment operationSegment in path.OfType<ODataOperationSegment>())
+            {
+                if (operationSegment.Operation is not IEdmFunction function)
+                {
+                    continue;
+                }
+
+                if (operationSegment.ParameterMappings != null)
+                {
+                    IList<OpenApiParameter> parameters = context.CreateParameters(function, operationSegment.ParameterMappings);
+                    foreach (var parameter in parameters)
+                    {
+                        pathParameters.AppendParameter(parameter);
+                    }
+                }
+                else
+                {
+                    IDictionary<string, string> mappings = parameterMappings[operationSegment];
+                    IList<OpenApiParameter> parameters = context.CreateParameters(function, mappings);
+                    pathParameters.AddRange(parameters);                    
+                }
+            }
+
             // Add the route prefix parameter v1{data}
             if (context.Settings.RoutePathPrefixProvider?.Parameters != null)
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -27,7 +27,7 @@
 - Fixes inconsistency of nullability of schemas of properties that are a collection of structured types #467
 - Generates $expand query parameter for operations whose return type is a collection #481
 - Adds delete operation for non-contained navigation properties only if explicitly allowed via annotation #483
-- Appends parameters and fixes operation ids of navigation property paths generated via composable functions 3486
+- Appends parameters and fixes operation ids of navigation property paths generated via composable functions #486
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.5</Version>
+    <Version>1.6.0-preview.6</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -26,6 +26,7 @@
 - Adds a delete operation and a required @id query parameter to collection-valued navigation property paths with $ref #453
 - Fixes inconsistency of nullability of schemas of properties that are a collection of structured types #467
 - Generates $expand query parameter for operations whose return type is a collection #481
+- Appends parameters and fixes operation ids of navigation property paths generated via composable functions 3486
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -133,32 +133,6 @@ namespace Microsoft.OpenApi.OData.Operation
             if (EdmOperation.IsFunction())
             {
                 IEdmFunction function = (IEdmFunction)EdmOperation;
-
-                if (OperationSegment.ParameterMappings != null)
-                {
-                    IList<OpenApiParameter> parameters = Context.CreateParameters(function, OperationSegment.ParameterMappings);
-                    foreach (var parameter in parameters)
-                    {
-                        operation.Parameters.AppendParameter(parameter);
-                    }
-                }
-                else
-                {
-                    IDictionary<string, string> mappings = ParameterMappings[OperationSegment];
-                    IList<OpenApiParameter> parameters = Context.CreateParameters(function, mappings);
-                    if (operation.Parameters == null)
-                    {
-                        operation.Parameters = parameters;
-                    }
-                    else
-                    {
-                        foreach (var parameter in parameters)
-                        {
-                            operation.Parameters.AppendParameter(parameter);
-                        }
-                    }
-                }
-
                 AppendSystemQueryOptions(function, operation);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/486

This PR:
1. Fixes navigation property paths generated via composable functions by:
 - Appending any function parameters to the list of parameters.
 - Including the function name in the operation id name. This will help in avoiding duplicates in similar navigation property paths that don't have the composable function. This has been achieved by refactoring the function parameter generation into the central `OpenApiParameterGenerator` class instead of in the `OperationOperationHandler` class.
2. Add a test to validate the above fixes/refactorings.
3. Update the release note