### PR TITLE
Use alternate keys in the generation of operation ids of operations and navigation property alternate paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -163,11 +163,13 @@ namespace Microsoft.OpenApi.OData.Common
 
             // For navigation property paths with odata type cast segments
             // the OData type cast segments identifiers will be used in the operation id
+            // The same applies for navigation property paths with operation segments.
             IEnumerable<ODataSegment> segments = path.Segments.Skip(1)
                 .Where(static s => 
                 s is ODataNavigationPropertySegment ||
                 s is ODataTypeCastSegment ||
-                s is ODataOperationSegment);
+                s is ODataOperationSegment ||
+                s is ODataKeySegment);
             Utils.CheckArgumentNull(segments, nameof(segments));
 
             string previousTypeCastSegmentId = null;
@@ -189,6 +191,18 @@ namespace Microsoft.OpenApi.OData.Common
                 {
                     // Navigation property generated via composable function
                     items.Add(operationSegment.Identifier);
+                }
+                else if (segment is ODataKeySegment keySegment && keySegment.IsAlternateKey)
+                {
+                    // We'll consider alternate keys in the operation id to eliminate potential duplicates with operation id of primary path                    
+                    if (segment == segments.Last())
+                    {                        
+                        items.Add("By" + string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x))));
+                    }
+                    else
+                    {
+                        items.Add(keySegment.Identifier);
+                    }
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.6</Version>
+    <Version>1.6.0-preview.7</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -28,6 +28,7 @@
 - Generates $expand query parameter for operations whose return type is a collection #481
 - Adds delete operation for non-contained navigation properties only if explicitly allowed via annotation #483
 - Appends parameters and fixes operation ids of navigation property paths generated via composable functions #486
+- Use alternate keys in the generation of operation ids of operations and navigation property alternate paths #488
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmOperationOperationHandler.cs
@@ -73,16 +73,30 @@ namespace Microsoft.OpenApi.OData.Operation
                 // in the operationId to avoid potential
                 // duplicates in entity vs entityset functions/actions
 
-                List<string> identifiers = new();
+                List<string> identifiers = [];
                 foreach (ODataSegment segment in Path.Segments)
                 {
-                    if (segment is not ODataKeySegment)
+                    if (segment is ODataKeySegment keySegment)
                     {
-                        identifiers.Add(segment.Identifier);
+                        if (!keySegment.IsAlternateKey) 
+                        {
+                            identifiers.Add(segment.EntityType.Name);
+                            continue;
+                        }
+
+                        // We'll consider alternate keys in the operation id to eliminate potential duplicates with operation id of primary path
+                        if (segment == Path.Segments.Last())
+                        {
+                            identifiers.Add("By" + string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x))));
+                        }
+                        else
+                        {
+                            identifiers.Add(keySegment.Identifier);
+                        }
                     }
                     else
                     {
-                        identifiers.Add(segment.EntityType.Name);
+                        identifiers.Add(segment.Identifier);
                     }
                 }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(16976, paths.Count());
+            Assert.Equal(16980, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17627, paths.Count());
+            Assert.Equal(17631, paths.Count());
         }
 
         [Theory]


### PR DESCRIPTION
This PR:

- Uses alternate key segment identifiers in the generation of operation ids of operations and navigation property alternate paths.
- Adds tests to validate that alternate key identifiers are used in the generation of operation ids.
- Updates the integration test file.
- Updates release notes.