### PR TITLE
Fixes operation id`s of paths with type cast segments

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -179,7 +179,9 @@ namespace Microsoft.OpenApi.OData.Common
                 {
                     items.Add(navPropSegment.NavigationProperty.Name);
                 }
-                else if (segment is ODataTypeCastSegment typeCastSegment && path.Kind != ODataPathKind.TypeCast)
+                else if (segment is ODataTypeCastSegment typeCastSegment
+                    && path.Kind != ODataPathKind.TypeCast // ex: ~/NavSource/NavProp/TypeCast
+                    && !(path.Kind == ODataPathKind.DollarCount && path.Segments.ElementAt(path.Segments.Count - 2)?.Kind == ODataSegmentKind.TypeCast)) // ex: ~/NavSource/NavProp/TypeCast/$count
                 {
                     // Only the last OData type cast segment identifier is added to the operation id
                     items.Remove(previousTypeCastSegmentId);
@@ -380,7 +382,7 @@ namespace Microsoft.OpenApi.OData.Common
                     }
                     operationId = (entitySet != null) ? entitySet.Name : singleton.Name;
                     operationId += $".{entityTypeName}.{operationName}";
-                }                
+                }
             }
             else if (secondLastSegment is ODataNavigationSourceSegment)
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -362,7 +362,7 @@ namespace Microsoft.OpenApi.OData.Common
                     prefix = navPropSegment?.NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many ? "List" : "Get";
                 }
 
-                operationId =  GenerateNavigationPropertyPathOperationId(path, prefix);
+                operationId = GenerateNavigationPropertyPathOperationId(path, prefix);
             }
             else if (secondLastSegment is ODataKeySegment keySegment)
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/EdmModelHelper.cs
@@ -179,7 +179,7 @@ namespace Microsoft.OpenApi.OData.Common
                 {
                     items.Add(navPropSegment.NavigationProperty.Name);
                 }
-                else if (segment is ODataTypeCastSegment typeCastSegment && path.Kind == ODataPathKind.NavigationProperty)
+                else if (segment is ODataTypeCastSegment typeCastSegment && path.Kind != ODataPathKind.TypeCast)
                 {
                     // Only the last OData type cast segment identifier is added to the operation id
                     items.Remove(previousTypeCastSegmentId);
@@ -352,28 +352,35 @@ namespace Microsoft.OpenApi.OData.Common
                 string listOrGet = includeListOrGetPrefix ? (complexSegment.Property.Type.IsCollection() ? "List" : "Get") : null;
                 operationId = GenerateComplexPropertyPathOperationId(path, listOrGet);
             }
-            else if (secondLastSegment as ODataNavigationPropertySegment is not null || isIndexedCollValuedNavProp)
+            else if (secondLastSegment is ODataNavigationPropertySegment navPropSegment)
             {
-                string listOrGet = null;
+                string prefix = null;
                 if (includeListOrGetPrefix)
                 {
-                    listOrGet = !isIndexedCollValuedNavProp && (secondLastSegment as ODataNavigationPropertySegment)?.NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many ? "List" : "Get";
+                    prefix = navPropSegment?.NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many ? "List" : "Get";
                 }
 
-                operationId = GenerateNavigationPropertyPathOperationId(path, listOrGet);
+                operationId =  GenerateNavigationPropertyPathOperationId(path, prefix);
             }
-            else if (secondLastSegment is ODataKeySegment keySegment && !isIndexedCollValuedNavProp)
+            else if (secondLastSegment is ODataKeySegment keySegment)
             {
-                string entityTypeName = keySegment.EntityType.Name;
-                string getPrefix = includeListOrGetPrefix ? "Get" : null;
-                string operationName = $"{getPrefix}{Utils.UpperFirstChar(entityTypeName)}";
-                if (keySegment.IsAlternateKey)
+                if (isIndexedCollValuedNavProp)
                 {
-                    string alternateKeyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
-                    operationName = $"{operationName}By{alternateKeyName}";
+                    operationId = GenerateNavigationPropertyPathOperationId(path, "Get");
                 }
-                operationId = (entitySet != null) ? entitySet.Name : singleton.Name;
-                operationId += $".{entityTypeName}.{operationName}";
+                else
+                {
+                    string entityTypeName = keySegment.EntityType.Name;
+                    string getPrefix = includeListOrGetPrefix ? "Get" : null;
+                    string operationName = $"{getPrefix}{Utils.UpperFirstChar(entityTypeName)}";
+                    if (keySegment.IsAlternateKey)
+                    {
+                        string alternateKeyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));
+                        operationName = $"{operationName}By{alternateKeyName}";
+                    }
+                    operationId = (entitySet != null) ? entitySet.Name : singleton.Name;
+                    operationId += $".{entityTypeName}.{operationName}";
+                }                
             }
             else if (secondLastSegment is ODataNavigationSourceSegment)
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.7</Version>
+    <Version>1.6.0-preview.8</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -29,6 +29,7 @@
 - Adds delete operation for non-contained navigation properties only if explicitly allowed via annotation #483
 - Appends parameters and fixes operation ids of navigation property paths generated via composable functions #486
 - Use alternate keys in the generation of operation ids of operations and navigation property alternate paths #488
+- Fixes operation ids of paths with type cast segments #492
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -3823,7 +3823,7 @@
           "Me.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.ListAddressInfo",
+        "operationId": "Me.AsEmployee.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -3902,7 +3902,7 @@
           "Me.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -3946,7 +3946,7 @@
           "Me.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.SetAddressInfo",
+        "operationId": "Me.AsEmployee.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -3993,7 +3993,7 @@
           "Me.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.AddressInfo.GetCount-8488",
+        "operationId": "Me.AsEmployee.AddressInfo.GetCount-8488",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -4199,7 +4199,7 @@
         ],
         "summary": "Get ref of BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetRefBestFriend",
+        "operationId": "Me.AsEmployee.GetRefBestFriend",
         "produces": [
           "application/json"
         ],
@@ -4229,7 +4229,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateRefBestFriend",
+        "operationId": "Me.AsEmployee.UpdateRefBestFriend",
         "parameters": [
           {
             "$ref": "#/parameters/refPutBody"
@@ -4257,7 +4257,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for Me",
-        "operationId": "Me.DeleteRefBestFriend",
+        "operationId": "Me.AsEmployee.DeleteRefBestFriend",
         "parameters": [
           {
             "in": "header",
@@ -4291,7 +4291,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.BestFriend.ListAddressInfo",
+        "operationId": "Me.AsEmployee.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -4370,7 +4370,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.BestFriend.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -4414,7 +4414,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.BestFriend.SetAddressInfo",
+        "operationId": "Me.AsEmployee.BestFriend.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -4461,7 +4461,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.AddressInfo.GetCount-81de",
+        "operationId": "Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -4549,7 +4549,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.BestFriend.GetHomeAddress",
+        "operationId": "Me.AsEmployee.BestFriend.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -4604,7 +4604,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.BestFriend.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -4860,7 +4860,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -4902,7 +4902,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.Friends.ListAddressInfo",
+        "operationId": "Me.AsEmployee.Friends.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -4989,7 +4989,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.Friends.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.Friends.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -5041,7 +5041,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.Friends.SetAddressInfo",
+        "operationId": "Me.AsEmployee.Friends.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -5096,7 +5096,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.AddressInfo.GetCount-660e",
+        "operationId": "Me.AsEmployee.Friends.AddressInfo.GetCount-660e",
         "parameters": [
           {
             "in": "path",
@@ -5210,7 +5210,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.Friends.GetHomeAddress",
+        "operationId": "Me.AsEmployee.Friends.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -5273,7 +5273,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.Friends.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.Friends.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -5435,7 +5435,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.GetCount-0cb7",
+        "operationId": "Me.AsEmployee.Friends.GetCount-0cb7",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -5468,7 +5468,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
-        "operationId": "Me.ListRefFriends",
+        "operationId": "Me.AsEmployee.ListRefFriends",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -5541,7 +5541,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to Friends for Me",
-        "operationId": "Me.CreateRefFriends",
+        "operationId": "Me.AsEmployee.CreateRefFriends",
         "parameters": [
           {
             "$ref": "#/parameters/refPostBody"
@@ -5569,7 +5569,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "in": "header",
@@ -5758,7 +5758,7 @@
           "Me.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.GetHomeAddress",
+        "operationId": "Me.AsEmployee.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -5813,7 +5813,7 @@
           "Me.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -5992,7 +5992,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Peers for Me",
-        "operationId": "Me.DeleteRefPeers",
+        "operationId": "Me.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "in": "path",
@@ -6034,7 +6034,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.Peers.ListAddressInfo",
+        "operationId": "Me.AsEmployee.Peers.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -6121,7 +6121,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.Peers.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.Peers.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -6173,7 +6173,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.Peers.SetAddressInfo",
+        "operationId": "Me.AsEmployee.Peers.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -6228,7 +6228,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Peers.AddressInfo.GetCount-3e91",
+        "operationId": "Me.AsEmployee.Peers.AddressInfo.GetCount-3e91",
         "parameters": [
           {
             "in": "path",
@@ -6342,7 +6342,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.Peers.GetHomeAddress",
+        "operationId": "Me.AsEmployee.Peers.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -6405,7 +6405,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.Peers.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.Peers.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -6486,7 +6486,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Peers.GetCount-9fc2",
+        "operationId": "Me.AsEmployee.Peers.GetCount-9fc2",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -6519,7 +6519,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of Peers from Me",
-        "operationId": "Me.ListRefPeers",
+        "operationId": "Me.AsEmployee.ListRefPeers",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -6592,7 +6592,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to Peers for Me",
-        "operationId": "Me.CreateRefPeers",
+        "operationId": "Me.AsEmployee.CreateRefPeers",
         "parameters": [
           {
             "$ref": "#/parameters/refPostBody"
@@ -6620,7 +6620,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Peers for Me",
-        "operationId": "Me.DeleteRefPeers",
+        "operationId": "Me.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "in": "header",
@@ -7253,7 +7253,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -7309,7 +7309,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.PlanItems.GetCount-a822",
+        "operationId": "Me.AsEmployee.Trips.PlanItems.GetCount-a822",
         "parameters": [
           {
             "in": "path",
@@ -7353,7 +7353,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from Me",
-        "operationId": "Me.Trips.ListRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.ListRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -7425,7 +7425,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for Me",
-        "operationId": "Me.Trips.CreateRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -7464,7 +7464,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -7516,7 +7516,7 @@
           "Me.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.GetCount-5aa2",
+        "operationId": "Me.AsEmployee.Trips.GetCount-5aa2",
         "parameters": [
           {
             "in": "header",
@@ -7801,7 +7801,7 @@
           "Me.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.ListAddressInfo",
+        "operationId": "Me.AsManager.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -7880,7 +7880,7 @@
           "Me.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.UpdateAddressInfo",
+        "operationId": "Me.AsManager.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -7924,7 +7924,7 @@
           "Me.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.SetAddressInfo",
+        "operationId": "Me.AsManager.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -7971,7 +7971,7 @@
           "Me.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.AddressInfo.GetCount-75da",
+        "operationId": "Me.AsManager.AddressInfo.GetCount-75da",
         "parameters": [
           {
             "in": "header",
@@ -8201,7 +8201,7 @@
         ],
         "summary": "Get ref of BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetRefBestFriend",
+        "operationId": "Me.AsManager.GetRefBestFriend",
         "produces": [
           "application/json"
         ],
@@ -8231,7 +8231,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateRefBestFriend",
+        "operationId": "Me.AsManager.UpdateRefBestFriend",
         "parameters": [
           {
             "$ref": "#/parameters/refPutBody"
@@ -8259,7 +8259,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for Me",
-        "operationId": "Me.DeleteRefBestFriend",
+        "operationId": "Me.AsManager.DeleteRefBestFriend",
         "parameters": [
           {
             "in": "header",
@@ -8293,7 +8293,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.BestFriend.ListAddressInfo",
+        "operationId": "Me.AsManager.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -8372,7 +8372,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "operationId": "Me.AsManager.BestFriend.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -8416,7 +8416,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.BestFriend.SetAddressInfo",
+        "operationId": "Me.AsManager.BestFriend.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -8463,7 +8463,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.AddressInfo.GetCount-6ea6",
+        "operationId": "Me.AsManager.BestFriend.AddressInfo.GetCount-6ea6",
         "parameters": [
           {
             "in": "header",
@@ -8575,7 +8575,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.BestFriend.GetHomeAddress",
+        "operationId": "Me.AsManager.BestFriend.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -8630,7 +8630,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "operationId": "Me.AsManager.BestFriend.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -8882,7 +8882,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for Me",
-        "operationId": "Me.DeleteRefDirectReports",
+        "operationId": "Me.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "in": "path",
@@ -8924,7 +8924,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.DirectReports.ListAddressInfo",
+        "operationId": "Me.AsManager.DirectReports.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -9011,7 +9011,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.DirectReports.UpdateAddressInfo",
+        "operationId": "Me.AsManager.DirectReports.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -9063,7 +9063,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.DirectReports.SetAddressInfo",
+        "operationId": "Me.AsManager.DirectReports.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -9118,7 +9118,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.DirectReports.AddressInfo.GetCount-f650",
+        "operationId": "Me.AsManager.DirectReports.AddressInfo.GetCount-f650",
         "parameters": [
           {
             "in": "path",
@@ -9256,7 +9256,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.DirectReports.GetHomeAddress",
+        "operationId": "Me.AsManager.DirectReports.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -9319,7 +9319,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.DirectReports.UpdateHomeAddress",
+        "operationId": "Me.AsManager.DirectReports.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -9400,7 +9400,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.DirectReports.GetCount-8b92",
+        "operationId": "Me.AsManager.DirectReports.GetCount-8b92",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -9433,7 +9433,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of DirectReports from Me",
-        "operationId": "Me.ListRefDirectReports",
+        "operationId": "Me.AsManager.ListRefDirectReports",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -9506,7 +9506,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
-        "operationId": "Me.CreateRefDirectReports",
+        "operationId": "Me.AsManager.CreateRefDirectReports",
         "parameters": [
           {
             "$ref": "#/parameters/refPostBody"
@@ -9534,7 +9534,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for Me",
-        "operationId": "Me.DeleteRefDirectReports",
+        "operationId": "Me.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "in": "header",
@@ -9695,7 +9695,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -9737,7 +9737,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.Friends.ListAddressInfo",
+        "operationId": "Me.AsManager.Friends.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -9824,7 +9824,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.Friends.UpdateAddressInfo",
+        "operationId": "Me.AsManager.Friends.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -9876,7 +9876,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.Friends.SetAddressInfo",
+        "operationId": "Me.AsManager.Friends.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -9931,7 +9931,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.AddressInfo.GetCount-b7db",
+        "operationId": "Me.AsManager.Friends.AddressInfo.GetCount-b7db",
         "parameters": [
           {
             "in": "path",
@@ -10045,7 +10045,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.Friends.GetHomeAddress",
+        "operationId": "Me.AsManager.Friends.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -10108,7 +10108,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.Friends.UpdateHomeAddress",
+        "operationId": "Me.AsManager.Friends.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -10270,7 +10270,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.GetCount-60a7",
+        "operationId": "Me.AsManager.Friends.GetCount-60a7",
         "parameters": [
           {
             "$ref": "#/parameters/search"
@@ -10303,7 +10303,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
-        "operationId": "Me.ListRefFriends",
+        "operationId": "Me.AsManager.ListRefFriends",
         "parameters": [
           {
             "$ref": "#/parameters/top"
@@ -10376,7 +10376,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to Friends for Me",
-        "operationId": "Me.CreateRefFriends",
+        "operationId": "Me.AsManager.CreateRefFriends",
         "parameters": [
           {
             "$ref": "#/parameters/refPostBody"
@@ -10404,7 +10404,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "in": "header",
@@ -10593,7 +10593,7 @@
           "Me.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.GetHomeAddress",
+        "operationId": "Me.AsManager.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -10648,7 +10648,7 @@
           "Me.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.UpdateHomeAddress",
+        "operationId": "Me.AsManager.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -11349,7 +11349,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -11405,7 +11405,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.PlanItems.GetCount-5ad2",
+        "operationId": "Me.AsManager.Trips.PlanItems.GetCount-5ad2",
         "parameters": [
           {
             "in": "path",
@@ -11449,7 +11449,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from Me",
-        "operationId": "Me.Trips.ListRefPlanItems",
+        "operationId": "Me.AsManager.Trips.ListRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -11521,7 +11521,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for Me",
-        "operationId": "Me.Trips.CreateRefPlanItems",
+        "operationId": "Me.AsManager.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -11560,7 +11560,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -11612,7 +11612,7 @@
           "Me.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.GetCount-f3f4",
+        "operationId": "Me.AsManager.Trips.GetCount-f3f4",
         "parameters": [
           {
             "in": "header",
@@ -19892,7 +19892,7 @@
           "People.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.ListAddressInfo",
+        "operationId": "People.AsEmployee.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -19979,7 +19979,7 @@
           "People.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -20031,7 +20031,7 @@
           "People.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.SetAddressInfo",
+        "operationId": "People.AsEmployee.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -20086,7 +20086,7 @@
           "People.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.AddressInfo.GetCount-3d43",
+        "operationId": "People.AsEmployee.AddressInfo.GetCount-3d43",
         "parameters": [
           {
             "in": "path",
@@ -20334,7 +20334,7 @@
         ],
         "summary": "Get ref of BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetRefBestFriend",
+        "operationId": "People.AsEmployee.GetRefBestFriend",
         "produces": [
           "application/json"
         ],
@@ -20374,7 +20374,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateRefBestFriend",
+        "operationId": "People.AsEmployee.UpdateRefBestFriend",
         "parameters": [
           {
             "in": "path",
@@ -20410,7 +20410,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for People",
-        "operationId": "People.DeleteRefBestFriend",
+        "operationId": "People.AsEmployee.DeleteRefBestFriend",
         "parameters": [
           {
             "in": "path",
@@ -20452,7 +20452,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.BestFriend.ListAddressInfo",
+        "operationId": "People.AsEmployee.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -20539,7 +20539,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.BestFriend.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -20591,7 +20591,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.BestFriend.SetAddressInfo",
+        "operationId": "People.AsEmployee.BestFriend.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -20646,7 +20646,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.AddressInfo.GetCount-cb8a",
+        "operationId": "People.AsEmployee.BestFriend.AddressInfo.GetCount-cb8a",
         "parameters": [
           {
             "in": "path",
@@ -20760,7 +20760,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.BestFriend.GetHomeAddress",
+        "operationId": "People.AsEmployee.BestFriend.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -20823,7 +20823,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.BestFriend.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -21113,7 +21113,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -21163,7 +21163,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.Friends.ListAddressInfo",
+        "operationId": "People.AsEmployee.Friends.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -21258,7 +21258,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.Friends.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.Friends.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -21318,7 +21318,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.Friends.SetAddressInfo",
+        "operationId": "People.AsEmployee.Friends.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -21381,7 +21381,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.AddressInfo.GetCount-1e8b",
+        "operationId": "People.AsEmployee.Friends.AddressInfo.GetCount-1e8b",
         "parameters": [
           {
             "in": "path",
@@ -21519,7 +21519,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.Friends.GetHomeAddress",
+        "operationId": "People.AsEmployee.Friends.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -21590,7 +21590,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.Friends.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.Friends.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -21776,7 +21776,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.GetCount-4db4",
+        "operationId": "People.AsEmployee.Friends.GetCount-4db4",
         "parameters": [
           {
             "in": "path",
@@ -21817,7 +21817,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
-        "operationId": "People.ListRefFriends",
+        "operationId": "People.AsEmployee.ListRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -21898,7 +21898,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to Friends for People",
-        "operationId": "People.CreateRefFriends",
+        "operationId": "People.AsEmployee.CreateRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -21934,7 +21934,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -22147,7 +22147,7 @@
           "People.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.GetHomeAddress",
+        "operationId": "People.AsEmployee.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -22210,7 +22210,7 @@
           "People.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -22415,7 +22415,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Peers for People",
-        "operationId": "People.DeleteRefPeers",
+        "operationId": "People.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "in": "path",
@@ -22465,7 +22465,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.Peers.ListAddressInfo",
+        "operationId": "People.AsEmployee.Peers.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -22560,7 +22560,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.Peers.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.Peers.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -22620,7 +22620,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.Peers.SetAddressInfo",
+        "operationId": "People.AsEmployee.Peers.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -22683,7 +22683,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Peers.AddressInfo.GetCount-755d",
+        "operationId": "People.AsEmployee.Peers.AddressInfo.GetCount-755d",
         "parameters": [
           {
             "in": "path",
@@ -22821,7 +22821,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.Peers.GetHomeAddress",
+        "operationId": "People.AsEmployee.Peers.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -22892,7 +22892,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.Peers.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.Peers.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -22989,7 +22989,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Peers.GetCount-44d2",
+        "operationId": "People.AsEmployee.Peers.GetCount-44d2",
         "parameters": [
           {
             "in": "path",
@@ -23030,7 +23030,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Peers from People",
-        "operationId": "People.ListRefPeers",
+        "operationId": "People.AsEmployee.ListRefPeers",
         "parameters": [
           {
             "in": "path",
@@ -23111,7 +23111,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to Peers for People",
-        "operationId": "People.CreateRefPeers",
+        "operationId": "People.AsEmployee.CreateRefPeers",
         "parameters": [
           {
             "in": "path",
@@ -23147,7 +23147,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Peers for People",
-        "operationId": "People.DeleteRefPeers",
+        "operationId": "People.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "in": "path",
@@ -23844,7 +23844,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -23908,7 +23908,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.PlanItems.GetCount-7df9",
+        "operationId": "People.AsEmployee.Trips.PlanItems.GetCount-7df9",
         "parameters": [
           {
             "in": "path",
@@ -23960,7 +23960,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from People",
-        "operationId": "People.Trips.ListRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.ListRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -24040,7 +24040,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for People",
-        "operationId": "People.Trips.CreateRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -24087,7 +24087,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -24147,7 +24147,7 @@
           "People.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.GetCount-c760",
+        "operationId": "People.AsEmployee.Trips.GetCount-c760",
         "parameters": [
           {
             "in": "path",
@@ -24486,7 +24486,7 @@
           "People.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.ListAddressInfo",
+        "operationId": "People.AsManager.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -24573,7 +24573,7 @@
           "People.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.UpdateAddressInfo",
+        "operationId": "People.AsManager.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -24625,7 +24625,7 @@
           "People.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.SetAddressInfo",
+        "operationId": "People.AsManager.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -24680,7 +24680,7 @@
           "People.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.AddressInfo.GetCount-f84e",
+        "operationId": "People.AsManager.AddressInfo.GetCount-f84e",
         "parameters": [
           {
             "in": "path",
@@ -24952,7 +24952,7 @@
         ],
         "summary": "Get ref of BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetRefBestFriend",
+        "operationId": "People.AsManager.GetRefBestFriend",
         "produces": [
           "application/json"
         ],
@@ -24992,7 +24992,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateRefBestFriend",
+        "operationId": "People.AsManager.UpdateRefBestFriend",
         "parameters": [
           {
             "in": "path",
@@ -25028,7 +25028,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for People",
-        "operationId": "People.DeleteRefBestFriend",
+        "operationId": "People.AsManager.DeleteRefBestFriend",
         "parameters": [
           {
             "in": "path",
@@ -25070,7 +25070,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.BestFriend.ListAddressInfo",
+        "operationId": "People.AsManager.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -25157,7 +25157,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "operationId": "People.AsManager.BestFriend.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -25209,7 +25209,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.BestFriend.SetAddressInfo",
+        "operationId": "People.AsManager.BestFriend.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -25264,7 +25264,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.AddressInfo.GetCount-5a39",
+        "operationId": "People.AsManager.BestFriend.AddressInfo.GetCount-5a39",
         "parameters": [
           {
             "in": "path",
@@ -25402,7 +25402,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.BestFriend.GetHomeAddress",
+        "operationId": "People.AsManager.BestFriend.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -25465,7 +25465,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "operationId": "People.AsManager.BestFriend.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -25751,7 +25751,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for People",
-        "operationId": "People.DeleteRefDirectReports",
+        "operationId": "People.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "in": "path",
@@ -25801,7 +25801,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.DirectReports.ListAddressInfo",
+        "operationId": "People.AsManager.DirectReports.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -25896,7 +25896,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.DirectReports.UpdateAddressInfo",
+        "operationId": "People.AsManager.DirectReports.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -25956,7 +25956,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.DirectReports.SetAddressInfo",
+        "operationId": "People.AsManager.DirectReports.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -26019,7 +26019,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.DirectReports.AddressInfo.GetCount-f46e",
+        "operationId": "People.AsManager.DirectReports.AddressInfo.GetCount-f46e",
         "parameters": [
           {
             "in": "path",
@@ -26181,7 +26181,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.DirectReports.GetHomeAddress",
+        "operationId": "People.AsManager.DirectReports.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -26252,7 +26252,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.DirectReports.UpdateHomeAddress",
+        "operationId": "People.AsManager.DirectReports.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -26349,7 +26349,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.DirectReports.GetCount-0ec4",
+        "operationId": "People.AsManager.DirectReports.GetCount-0ec4",
         "parameters": [
           {
             "in": "path",
@@ -26390,7 +26390,7 @@
           "People.Person"
         ],
         "summary": "Get ref of DirectReports from People",
-        "operationId": "People.ListRefDirectReports",
+        "operationId": "People.AsManager.ListRefDirectReports",
         "parameters": [
           {
             "in": "path",
@@ -26471,7 +26471,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
-        "operationId": "People.CreateRefDirectReports",
+        "operationId": "People.AsManager.CreateRefDirectReports",
         "parameters": [
           {
             "in": "path",
@@ -26507,7 +26507,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for People",
-        "operationId": "People.DeleteRefDirectReports",
+        "operationId": "People.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "in": "path",
@@ -26684,7 +26684,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -26734,7 +26734,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.Friends.ListAddressInfo",
+        "operationId": "People.AsManager.Friends.ListAddressInfo",
         "parameters": [
           {
             "in": "path",
@@ -26829,7 +26829,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.Friends.UpdateAddressInfo",
+        "operationId": "People.AsManager.Friends.UpdateAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -26889,7 +26889,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.Friends.SetAddressInfo",
+        "operationId": "People.AsManager.Friends.SetAddressInfo",
         "consumes": [
           "application/json"
         ],
@@ -26952,7 +26952,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.AddressInfo.GetCount-f486",
+        "operationId": "People.AsManager.Friends.AddressInfo.GetCount-f486",
         "parameters": [
           {
             "in": "path",
@@ -27090,7 +27090,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.Friends.GetHomeAddress",
+        "operationId": "People.AsManager.Friends.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -27161,7 +27161,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.Friends.UpdateHomeAddress",
+        "operationId": "People.AsManager.Friends.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -27347,7 +27347,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.GetCount-1c0c",
+        "operationId": "People.AsManager.Friends.GetCount-1c0c",
         "parameters": [
           {
             "in": "path",
@@ -27388,7 +27388,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
-        "operationId": "People.ListRefFriends",
+        "operationId": "People.AsManager.ListRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -27469,7 +27469,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to Friends for People",
-        "operationId": "People.CreateRefFriends",
+        "operationId": "People.AsManager.CreateRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -27505,7 +27505,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "in": "path",
@@ -27718,7 +27718,7 @@
           "People.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.GetHomeAddress",
+        "operationId": "People.AsManager.GetHomeAddress",
         "produces": [
           "application/json"
         ],
@@ -27781,7 +27781,7 @@
           "People.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.UpdateHomeAddress",
+        "operationId": "People.AsManager.UpdateHomeAddress",
         "consumes": [
           "application/json"
         ],
@@ -28564,7 +28564,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -28628,7 +28628,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.PlanItems.GetCount-fa08",
+        "operationId": "People.AsManager.Trips.PlanItems.GetCount-fa08",
         "parameters": [
           {
             "in": "path",
@@ -28680,7 +28680,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from People",
-        "operationId": "People.Trips.ListRefPlanItems",
+        "operationId": "People.AsManager.Trips.ListRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -28760,7 +28760,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for People",
-        "operationId": "People.Trips.CreateRefPlanItems",
+        "operationId": "People.AsManager.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -28807,7 +28807,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "in": "path",
@@ -28867,7 +28867,7 @@
           "People.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.GetCount-1f8c",
+        "operationId": "People.AsManager.Trips.GetCount-1f8c",
         "parameters": [
           {
             "in": "path",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -2643,7 +2643,7 @@ paths:
       tags:
         - Me.Location
       summary: Get AddressInfo property value
-      operationId: Me.ListAddressInfo
+      operationId: Me.AsEmployee.ListAddressInfo
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -2693,7 +2693,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property AddressInfo value.
-      operationId: Me.UpdateAddressInfo
+      operationId: Me.AsEmployee.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -2723,7 +2723,7 @@ paths:
       tags:
         - Me.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.SetAddressInfo
+      operationId: Me.AsEmployee.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -2755,7 +2755,7 @@ paths:
       tags:
         - Me.Location
       summary: Get the number of the resource
-      operationId: Me.AddressInfo.GetCount-8488
+      operationId: Me.AsEmployee.AddressInfo.GetCount-8488
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -2901,7 +2901,7 @@ paths:
         - Me.Person
       summary: Get ref of BestFriend from Me
       description: The best friend.
-      operationId: Me.GetRefBestFriend
+      operationId: Me.AsEmployee.GetRefBestFriend
       produces:
         - application/json
       responses:
@@ -2923,7 +2923,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateRefBestFriend
+      operationId: Me.AsEmployee.UpdateRefBestFriend
       parameters:
         - $ref: '#/parameters/refPutBody'
       responses:
@@ -2942,7 +2942,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property BestFriend for Me
-      operationId: Me.DeleteRefBestFriend
+      operationId: Me.AsEmployee.DeleteRefBestFriend
       parameters:
         - in: header
           name: If-Match
@@ -2966,7 +2966,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.BestFriend.ListAddressInfo
+      operationId: Me.AsEmployee.BestFriend.ListAddressInfo
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -3016,7 +3016,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.BestFriend.UpdateAddressInfo
+      operationId: Me.AsEmployee.BestFriend.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -3046,7 +3046,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.BestFriend.SetAddressInfo
+      operationId: Me.AsEmployee.BestFriend.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -3078,7 +3078,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.BestFriend.AddressInfo.GetCount-81de
+      operationId: Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -3136,7 +3136,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.BestFriend.GetHomeAddress
+      operationId: Me.AsEmployee.BestFriend.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -3174,7 +3174,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.BestFriend.UpdateHomeAddress
+      operationId: Me.AsEmployee.BestFriend.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -3362,7 +3362,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsEmployee.DeleteRefFriends
       parameters:
         - in: path
           name: UserName
@@ -3392,7 +3392,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.Friends.ListAddressInfo
+      operationId: Me.AsEmployee.Friends.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -3448,7 +3448,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.Friends.UpdateAddressInfo
+      operationId: Me.AsEmployee.Friends.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -3484,7 +3484,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.Friends.SetAddressInfo
+      operationId: Me.AsEmployee.Friends.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -3522,7 +3522,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.Friends.AddressInfo.GetCount-660e
+      operationId: Me.AsEmployee.Friends.AddressInfo.GetCount-660e
       parameters:
         - in: path
           name: UserName
@@ -3599,7 +3599,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.Friends.GetHomeAddress
+      operationId: Me.AsEmployee.Friends.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -3643,7 +3643,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.Friends.UpdateHomeAddress
+      operationId: Me.AsEmployee.Friends.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -3761,7 +3761,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.Friends.GetCount-0cb7
+      operationId: Me.AsEmployee.Friends.GetCount-0cb7
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -3782,7 +3782,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
-      operationId: Me.ListRefFriends
+      operationId: Me.AsEmployee.ListRefFriends
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -3834,7 +3834,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to Friends for Me
-      operationId: Me.CreateRefFriends
+      operationId: Me.AsEmployee.CreateRefFriends
       parameters:
         - $ref: '#/parameters/refPostBody'
       responses:
@@ -3853,7 +3853,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsEmployee.DeleteRefFriends
       parameters:
         - in: header
           name: If-Match
@@ -3988,7 +3988,7 @@ paths:
       tags:
         - Me.Location
       summary: Get HomeAddress property value
-      operationId: Me.GetHomeAddress
+      operationId: Me.AsEmployee.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -4026,7 +4026,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property HomeAddress value.
-      operationId: Me.UpdateHomeAddress
+      operationId: Me.AsEmployee.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -4156,7 +4156,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Peers for Me
-      operationId: Me.DeleteRefPeers
+      operationId: Me.AsEmployee.DeleteRefPeers
       parameters:
         - in: path
           name: UserName
@@ -4186,7 +4186,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.Peers.ListAddressInfo
+      operationId: Me.AsEmployee.Peers.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -4242,7 +4242,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.Peers.UpdateAddressInfo
+      operationId: Me.AsEmployee.Peers.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -4278,7 +4278,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.Peers.SetAddressInfo
+      operationId: Me.AsEmployee.Peers.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -4316,7 +4316,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.Peers.AddressInfo.GetCount-3e91
+      operationId: Me.AsEmployee.Peers.AddressInfo.GetCount-3e91
       parameters:
         - in: path
           name: UserName
@@ -4393,7 +4393,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.Peers.GetHomeAddress
+      operationId: Me.AsEmployee.Peers.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -4437,7 +4437,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.Peers.UpdateHomeAddress
+      operationId: Me.AsEmployee.Peers.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -4494,7 +4494,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.Peers.GetCount-9fc2
+      operationId: Me.AsEmployee.Peers.GetCount-9fc2
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -4515,7 +4515,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Peers from Me
-      operationId: Me.ListRefPeers
+      operationId: Me.AsEmployee.ListRefPeers
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -4567,7 +4567,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to Peers for Me
-      operationId: Me.CreateRefPeers
+      operationId: Me.AsEmployee.CreateRefPeers
       parameters:
         - $ref: '#/parameters/refPostBody'
       responses:
@@ -4586,7 +4586,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Peers for Me
-      operationId: Me.DeleteRefPeers
+      operationId: Me.AsEmployee.DeleteRefPeers
       parameters:
         - in: header
           name: If-Match
@@ -5043,7 +5043,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -5085,7 +5085,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: Me.Trips.PlanItems.GetCount-a822
+      operationId: Me.AsEmployee.Trips.PlanItems.GetCount-a822
       parameters:
         - in: path
           name: TripId
@@ -5115,7 +5115,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get ref of PlanItems from Me
-      operationId: Me.Trips.ListRefPlanItems
+      operationId: Me.AsEmployee.Trips.ListRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -5164,7 +5164,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for Me
-      operationId: Me.Trips.CreateRefPlanItems
+      operationId: Me.AsEmployee.Trips.CreateRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -5192,7 +5192,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -5230,7 +5230,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get the number of the resource
-      operationId: Me.Trips.GetCount-5aa2
+      operationId: Me.AsEmployee.Trips.GetCount-5aa2
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -5432,7 +5432,7 @@ paths:
       tags:
         - Me.Location
       summary: Get AddressInfo property value
-      operationId: Me.ListAddressInfo
+      operationId: Me.AsManager.ListAddressInfo
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -5482,7 +5482,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property AddressInfo value.
-      operationId: Me.UpdateAddressInfo
+      operationId: Me.AsManager.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -5512,7 +5512,7 @@ paths:
       tags:
         - Me.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.SetAddressInfo
+      operationId: Me.AsManager.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -5544,7 +5544,7 @@ paths:
       tags:
         - Me.Location
       summary: Get the number of the resource
-      operationId: Me.AddressInfo.GetCount-75da
+      operationId: Me.AsManager.AddressInfo.GetCount-75da
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -5706,7 +5706,7 @@ paths:
         - Me.Person
       summary: Get ref of BestFriend from Me
       description: The best friend.
-      operationId: Me.GetRefBestFriend
+      operationId: Me.AsManager.GetRefBestFriend
       produces:
         - application/json
       responses:
@@ -5728,7 +5728,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateRefBestFriend
+      operationId: Me.AsManager.UpdateRefBestFriend
       parameters:
         - $ref: '#/parameters/refPutBody'
       responses:
@@ -5747,7 +5747,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property BestFriend for Me
-      operationId: Me.DeleteRefBestFriend
+      operationId: Me.AsManager.DeleteRefBestFriend
       parameters:
         - in: header
           name: If-Match
@@ -5771,7 +5771,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.BestFriend.ListAddressInfo
+      operationId: Me.AsManager.BestFriend.ListAddressInfo
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -5821,7 +5821,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.BestFriend.UpdateAddressInfo
+      operationId: Me.AsManager.BestFriend.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -5851,7 +5851,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.BestFriend.SetAddressInfo
+      operationId: Me.AsManager.BestFriend.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -5883,7 +5883,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.BestFriend.AddressInfo.GetCount-6ea6
+      operationId: Me.AsManager.BestFriend.AddressInfo.GetCount-6ea6
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -5957,7 +5957,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.BestFriend.GetHomeAddress
+      operationId: Me.AsManager.BestFriend.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -5995,7 +5995,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.BestFriend.UpdateHomeAddress
+      operationId: Me.AsManager.BestFriend.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -6180,7 +6180,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property DirectReports for Me
-      operationId: Me.DeleteRefDirectReports
+      operationId: Me.AsManager.DeleteRefDirectReports
       parameters:
         - in: path
           name: UserName
@@ -6210,7 +6210,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.DirectReports.ListAddressInfo
+      operationId: Me.AsManager.DirectReports.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -6266,7 +6266,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.DirectReports.UpdateAddressInfo
+      operationId: Me.AsManager.DirectReports.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -6302,7 +6302,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.DirectReports.SetAddressInfo
+      operationId: Me.AsManager.DirectReports.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -6340,7 +6340,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.DirectReports.AddressInfo.GetCount-f650
+      operationId: Me.AsManager.DirectReports.AddressInfo.GetCount-f650
       parameters:
         - in: path
           name: UserName
@@ -6433,7 +6433,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.DirectReports.GetHomeAddress
+      operationId: Me.AsManager.DirectReports.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -6477,7 +6477,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.DirectReports.UpdateHomeAddress
+      operationId: Me.AsManager.DirectReports.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -6534,7 +6534,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.DirectReports.GetCount-8b92
+      operationId: Me.AsManager.DirectReports.GetCount-8b92
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -6555,7 +6555,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of DirectReports from Me
-      operationId: Me.ListRefDirectReports
+      operationId: Me.AsManager.ListRefDirectReports
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -6607,7 +6607,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to DirectReports for Me
-      operationId: Me.CreateRefDirectReports
+      operationId: Me.AsManager.CreateRefDirectReports
       parameters:
         - $ref: '#/parameters/refPostBody'
       responses:
@@ -6626,7 +6626,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property DirectReports for Me
-      operationId: Me.DeleteRefDirectReports
+      operationId: Me.AsManager.DeleteRefDirectReports
       parameters:
         - in: header
           name: If-Match
@@ -6744,7 +6744,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsManager.DeleteRefFriends
       parameters:
         - in: path
           name: UserName
@@ -6774,7 +6774,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.Friends.ListAddressInfo
+      operationId: Me.AsManager.Friends.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -6830,7 +6830,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.Friends.UpdateAddressInfo
+      operationId: Me.AsManager.Friends.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -6866,7 +6866,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.Friends.SetAddressInfo
+      operationId: Me.AsManager.Friends.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -6904,7 +6904,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.Friends.AddressInfo.GetCount-b7db
+      operationId: Me.AsManager.Friends.AddressInfo.GetCount-b7db
       parameters:
         - in: path
           name: UserName
@@ -6981,7 +6981,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.Friends.GetHomeAddress
+      operationId: Me.AsManager.Friends.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -7025,7 +7025,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.Friends.UpdateHomeAddress
+      operationId: Me.AsManager.Friends.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -7143,7 +7143,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.Friends.GetCount-60a7
+      operationId: Me.AsManager.Friends.GetCount-60a7
       parameters:
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
@@ -7164,7 +7164,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
-      operationId: Me.ListRefFriends
+      operationId: Me.AsManager.ListRefFriends
       parameters:
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
@@ -7216,7 +7216,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to Friends for Me
-      operationId: Me.CreateRefFriends
+      operationId: Me.AsManager.CreateRefFriends
       parameters:
         - $ref: '#/parameters/refPostBody'
       responses:
@@ -7235,7 +7235,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsManager.DeleteRefFriends
       parameters:
         - in: header
           name: If-Match
@@ -7370,7 +7370,7 @@ paths:
       tags:
         - Me.Location
       summary: Get HomeAddress property value
-      operationId: Me.GetHomeAddress
+      operationId: Me.AsManager.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -7408,7 +7408,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property HomeAddress value.
-      operationId: Me.UpdateHomeAddress
+      operationId: Me.AsManager.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -7912,7 +7912,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -7954,7 +7954,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: Me.Trips.PlanItems.GetCount-5ad2
+      operationId: Me.AsManager.Trips.PlanItems.GetCount-5ad2
       parameters:
         - in: path
           name: TripId
@@ -7984,7 +7984,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get ref of PlanItems from Me
-      operationId: Me.Trips.ListRefPlanItems
+      operationId: Me.AsManager.Trips.ListRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -8033,7 +8033,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for Me
-      operationId: Me.Trips.CreateRefPlanItems
+      operationId: Me.AsManager.Trips.CreateRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -8061,7 +8061,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: TripId
@@ -8099,7 +8099,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get the number of the resource
-      operationId: Me.Trips.GetCount-f3f4
+      operationId: Me.AsManager.Trips.GetCount-f3f4
       parameters:
         - in: header
           name: ConsistencyLevel
@@ -13921,7 +13921,7 @@ paths:
       tags:
         - People.Location
       summary: Get AddressInfo property value
-      operationId: People.ListAddressInfo
+      operationId: People.AsEmployee.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -13977,7 +13977,7 @@ paths:
       tags:
         - People.Location
       summary: Update property AddressInfo value.
-      operationId: People.UpdateAddressInfo
+      operationId: People.AsEmployee.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -14013,7 +14013,7 @@ paths:
       tags:
         - People.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.SetAddressInfo
+      operationId: People.AsEmployee.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -14051,7 +14051,7 @@ paths:
       tags:
         - People.Location
       summary: Get the number of the resource
-      operationId: People.AddressInfo.GetCount-3d43
+      operationId: People.AsEmployee.AddressInfo.GetCount-3d43
       parameters:
         - in: path
           name: UserName
@@ -14228,7 +14228,7 @@ paths:
         - People.Person
       summary: Get ref of BestFriend from People
       description: The best friend.
-      operationId: People.GetRefBestFriend
+      operationId: People.AsEmployee.GetRefBestFriend
       produces:
         - application/json
       parameters:
@@ -14257,7 +14257,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateRefBestFriend
+      operationId: People.AsEmployee.UpdateRefBestFriend
       parameters:
         - in: path
           name: UserName
@@ -14282,7 +14282,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property BestFriend for People
-      operationId: People.DeleteRefBestFriend
+      operationId: People.AsEmployee.DeleteRefBestFriend
       parameters:
         - in: path
           name: UserName
@@ -14312,7 +14312,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.BestFriend.ListAddressInfo
+      operationId: People.AsEmployee.BestFriend.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -14368,7 +14368,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.BestFriend.UpdateAddressInfo
+      operationId: People.AsEmployee.BestFriend.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -14404,7 +14404,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.BestFriend.SetAddressInfo
+      operationId: People.AsEmployee.BestFriend.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -14442,7 +14442,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.BestFriend.AddressInfo.GetCount-cb8a
+      operationId: People.AsEmployee.BestFriend.AddressInfo.GetCount-cb8a
       parameters:
         - in: path
           name: UserName
@@ -14519,7 +14519,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.BestFriend.GetHomeAddress
+      operationId: People.AsEmployee.BestFriend.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -14563,7 +14563,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.BestFriend.UpdateHomeAddress
+      operationId: People.AsEmployee.BestFriend.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -14776,7 +14776,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsEmployee.DeleteRefFriends
       parameters:
         - in: path
           name: UserName
@@ -14812,7 +14812,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.Friends.ListAddressInfo
+      operationId: People.AsEmployee.Friends.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -14874,7 +14874,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.Friends.UpdateAddressInfo
+      operationId: People.AsEmployee.Friends.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -14916,7 +14916,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.Friends.SetAddressInfo
+      operationId: People.AsEmployee.Friends.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -14960,7 +14960,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.Friends.AddressInfo.GetCount-1e8b
+      operationId: People.AsEmployee.Friends.AddressInfo.GetCount-1e8b
       parameters:
         - in: path
           name: UserName
@@ -15055,7 +15055,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.Friends.GetHomeAddress
+      operationId: People.AsEmployee.Friends.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -15105,7 +15105,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.Friends.UpdateHomeAddress
+      operationId: People.AsEmployee.Friends.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -15241,7 +15241,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Friends.GetCount-4db4
+      operationId: People.AsEmployee.Friends.GetCount-4db4
       parameters:
         - in: path
           name: UserName
@@ -15268,7 +15268,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
-      operationId: People.ListRefFriends
+      operationId: People.AsEmployee.ListRefFriends
       parameters:
         - in: path
           name: UserName
@@ -15326,7 +15326,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to Friends for People
-      operationId: People.CreateRefFriends
+      operationId: People.AsEmployee.CreateRefFriends
       parameters:
         - in: path
           name: UserName
@@ -15351,7 +15351,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsEmployee.DeleteRefFriends
       parameters:
         - in: path
           name: UserName
@@ -15504,7 +15504,7 @@ paths:
       tags:
         - People.Location
       summary: Get HomeAddress property value
-      operationId: People.GetHomeAddress
+      operationId: People.AsEmployee.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -15548,7 +15548,7 @@ paths:
       tags:
         - People.Location
       summary: Update property HomeAddress value.
-      operationId: People.UpdateHomeAddress
+      operationId: People.AsEmployee.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -15697,7 +15697,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Peers for People
-      operationId: People.DeleteRefPeers
+      operationId: People.AsEmployee.DeleteRefPeers
       parameters:
         - in: path
           name: UserName
@@ -15733,7 +15733,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.Peers.ListAddressInfo
+      operationId: People.AsEmployee.Peers.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -15795,7 +15795,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.Peers.UpdateAddressInfo
+      operationId: People.AsEmployee.Peers.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -15837,7 +15837,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.Peers.SetAddressInfo
+      operationId: People.AsEmployee.Peers.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -15881,7 +15881,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.Peers.AddressInfo.GetCount-755d
+      operationId: People.AsEmployee.Peers.AddressInfo.GetCount-755d
       parameters:
         - in: path
           name: UserName
@@ -15976,7 +15976,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.Peers.GetHomeAddress
+      operationId: People.AsEmployee.Peers.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -16026,7 +16026,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.Peers.UpdateHomeAddress
+      operationId: People.AsEmployee.Peers.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -16095,7 +16095,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Peers.GetCount-44d2
+      operationId: People.AsEmployee.Peers.GetCount-44d2
       parameters:
         - in: path
           name: UserName
@@ -16122,7 +16122,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Peers from People
-      operationId: People.ListRefPeers
+      operationId: People.AsEmployee.ListRefPeers
       parameters:
         - in: path
           name: UserName
@@ -16180,7 +16180,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to Peers for People
-      operationId: People.CreateRefPeers
+      operationId: People.AsEmployee.CreateRefPeers
       parameters:
         - in: path
           name: UserName
@@ -16205,7 +16205,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Peers for People
-      operationId: People.DeleteRefPeers
+      operationId: People.AsEmployee.DeleteRefPeers
       parameters:
         - in: path
           name: UserName
@@ -16710,7 +16710,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -16758,7 +16758,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: People.Trips.PlanItems.GetCount-7df9
+      operationId: People.AsEmployee.Trips.PlanItems.GetCount-7df9
       parameters:
         - in: path
           name: UserName
@@ -16794,7 +16794,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get ref of PlanItems from People
-      operationId: People.Trips.ListRefPlanItems
+      operationId: People.AsEmployee.Trips.ListRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -16849,7 +16849,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for People
-      operationId: People.Trips.CreateRefPlanItems
+      operationId: People.AsEmployee.Trips.CreateRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -16883,7 +16883,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -16927,7 +16927,7 @@ paths:
       tags:
         - People.Trip
       summary: Get the number of the resource
-      operationId: People.Trips.GetCount-c760
+      operationId: People.AsEmployee.Trips.GetCount-c760
       parameters:
         - in: path
           name: UserName
@@ -17168,7 +17168,7 @@ paths:
       tags:
         - People.Location
       summary: Get AddressInfo property value
-      operationId: People.ListAddressInfo
+      operationId: People.AsManager.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -17224,7 +17224,7 @@ paths:
       tags:
         - People.Location
       summary: Update property AddressInfo value.
-      operationId: People.UpdateAddressInfo
+      operationId: People.AsManager.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -17260,7 +17260,7 @@ paths:
       tags:
         - People.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.SetAddressInfo
+      operationId: People.AsManager.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -17298,7 +17298,7 @@ paths:
       tags:
         - People.Location
       summary: Get the number of the resource
-      operationId: People.AddressInfo.GetCount-f84e
+      operationId: People.AsManager.AddressInfo.GetCount-f84e
       parameters:
         - in: path
           name: UserName
@@ -17491,7 +17491,7 @@ paths:
         - People.Person
       summary: Get ref of BestFriend from People
       description: The best friend.
-      operationId: People.GetRefBestFriend
+      operationId: People.AsManager.GetRefBestFriend
       produces:
         - application/json
       parameters:
@@ -17520,7 +17520,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateRefBestFriend
+      operationId: People.AsManager.UpdateRefBestFriend
       parameters:
         - in: path
           name: UserName
@@ -17545,7 +17545,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property BestFriend for People
-      operationId: People.DeleteRefBestFriend
+      operationId: People.AsManager.DeleteRefBestFriend
       parameters:
         - in: path
           name: UserName
@@ -17575,7 +17575,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.BestFriend.ListAddressInfo
+      operationId: People.AsManager.BestFriend.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -17631,7 +17631,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.BestFriend.UpdateAddressInfo
+      operationId: People.AsManager.BestFriend.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -17667,7 +17667,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.BestFriend.SetAddressInfo
+      operationId: People.AsManager.BestFriend.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -17705,7 +17705,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.BestFriend.AddressInfo.GetCount-5a39
+      operationId: People.AsManager.BestFriend.AddressInfo.GetCount-5a39
       parameters:
         - in: path
           name: UserName
@@ -17798,7 +17798,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.BestFriend.GetHomeAddress
+      operationId: People.AsManager.BestFriend.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -17842,7 +17842,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.BestFriend.UpdateHomeAddress
+      operationId: People.AsManager.BestFriend.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -18052,7 +18052,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property DirectReports for People
-      operationId: People.DeleteRefDirectReports
+      operationId: People.AsManager.DeleteRefDirectReports
       parameters:
         - in: path
           name: UserName
@@ -18088,7 +18088,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.DirectReports.ListAddressInfo
+      operationId: People.AsManager.DirectReports.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -18150,7 +18150,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.DirectReports.UpdateAddressInfo
+      operationId: People.AsManager.DirectReports.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -18192,7 +18192,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.DirectReports.SetAddressInfo
+      operationId: People.AsManager.DirectReports.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -18236,7 +18236,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.DirectReports.AddressInfo.GetCount-f46e
+      operationId: People.AsManager.DirectReports.AddressInfo.GetCount-f46e
       parameters:
         - in: path
           name: UserName
@@ -18347,7 +18347,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.DirectReports.GetHomeAddress
+      operationId: People.AsManager.DirectReports.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -18397,7 +18397,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.DirectReports.UpdateHomeAddress
+      operationId: People.AsManager.DirectReports.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -18466,7 +18466,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.DirectReports.GetCount-0ec4
+      operationId: People.AsManager.DirectReports.GetCount-0ec4
       parameters:
         - in: path
           name: UserName
@@ -18493,7 +18493,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of DirectReports from People
-      operationId: People.ListRefDirectReports
+      operationId: People.AsManager.ListRefDirectReports
       parameters:
         - in: path
           name: UserName
@@ -18551,7 +18551,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to DirectReports for People
-      operationId: People.CreateRefDirectReports
+      operationId: People.AsManager.CreateRefDirectReports
       parameters:
         - in: path
           name: UserName
@@ -18576,7 +18576,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property DirectReports for People
-      operationId: People.DeleteRefDirectReports
+      operationId: People.AsManager.DeleteRefDirectReports
       parameters:
         - in: path
           name: UserName
@@ -18706,7 +18706,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsManager.DeleteRefFriends
       parameters:
         - in: path
           name: UserName
@@ -18742,7 +18742,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.Friends.ListAddressInfo
+      operationId: People.AsManager.Friends.ListAddressInfo
       parameters:
         - in: path
           name: UserName
@@ -18804,7 +18804,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.Friends.UpdateAddressInfo
+      operationId: People.AsManager.Friends.UpdateAddressInfo
       consumes:
         - application/json
       parameters:
@@ -18846,7 +18846,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.Friends.SetAddressInfo
+      operationId: People.AsManager.Friends.SetAddressInfo
       consumes:
         - application/json
       parameters:
@@ -18890,7 +18890,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.Friends.AddressInfo.GetCount-f486
+      operationId: People.AsManager.Friends.AddressInfo.GetCount-f486
       parameters:
         - in: path
           name: UserName
@@ -18985,7 +18985,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.Friends.GetHomeAddress
+      operationId: People.AsManager.Friends.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -19035,7 +19035,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.Friends.UpdateHomeAddress
+      operationId: People.AsManager.Friends.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -19171,7 +19171,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Friends.GetCount-1c0c
+      operationId: People.AsManager.Friends.GetCount-1c0c
       parameters:
         - in: path
           name: UserName
@@ -19198,7 +19198,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
-      operationId: People.ListRefFriends
+      operationId: People.AsManager.ListRefFriends
       parameters:
         - in: path
           name: UserName
@@ -19256,7 +19256,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to Friends for People
-      operationId: People.CreateRefFriends
+      operationId: People.AsManager.CreateRefFriends
       parameters:
         - in: path
           name: UserName
@@ -19281,7 +19281,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsManager.DeleteRefFriends
       parameters:
         - in: path
           name: UserName
@@ -19434,7 +19434,7 @@ paths:
       tags:
         - People.Location
       summary: Get HomeAddress property value
-      operationId: People.GetHomeAddress
+      operationId: People.AsManager.GetHomeAddress
       produces:
         - application/json
       parameters:
@@ -19478,7 +19478,7 @@ paths:
       tags:
         - People.Location
       summary: Update property HomeAddress value.
-      operationId: People.UpdateHomeAddress
+      operationId: People.AsManager.UpdateHomeAddress
       consumes:
         - application/json
       parameters:
@@ -20043,7 +20043,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -20091,7 +20091,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: People.Trips.PlanItems.GetCount-fa08
+      operationId: People.AsManager.Trips.PlanItems.GetCount-fa08
       parameters:
         - in: path
           name: UserName
@@ -20127,7 +20127,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get ref of PlanItems from People
-      operationId: People.Trips.ListRefPlanItems
+      operationId: People.AsManager.Trips.ListRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -20182,7 +20182,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for People
-      operationId: People.Trips.CreateRefPlanItems
+      operationId: People.AsManager.Trips.CreateRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -20216,7 +20216,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - in: path
           name: UserName
@@ -20260,7 +20260,7 @@ paths:
       tags:
         - People.Trip
       summary: Get the number of the resource
-      operationId: People.Trips.GetCount-1f8c
+      operationId: People.AsManager.Trips.GetCount-1f8c
       parameters:
         - in: path
           name: UserName

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -4225,7 +4225,7 @@
           "Me.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.ListAddressInfo",
+        "operationId": "Me.AsEmployee.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -4319,7 +4319,7 @@
           "Me.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.UpdateAddressInfo",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -4360,7 +4360,7 @@
           "Me.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.SetAddressInfo",
+        "operationId": "Me.AsEmployee.SetAddressInfo",
         "parameters": [
           {
             "name": "If-Match",
@@ -4409,7 +4409,7 @@
           "Me.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.AddressInfo.GetCount-8488",
+        "operationId": "Me.AsEmployee.AddressInfo.GetCount-8488",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -4623,7 +4623,7 @@
         ],
         "summary": "Get ref of BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetRefBestFriend",
+        "operationId": "Me.AsEmployee.GetRefBestFriend",
         "responses": {
           "200": {
             "description": "Retrieved navigation property link",
@@ -4654,7 +4654,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateRefBestFriend",
+        "operationId": "Me.AsEmployee.UpdateRefBestFriend",
         "requestBody": {
           "$ref": "#/components/requestBodies/refPutBody"
         },
@@ -4680,7 +4680,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for Me",
-        "operationId": "Me.DeleteRefBestFriend",
+        "operationId": "Me.AsEmployee.DeleteRefBestFriend",
         "parameters": [
           {
             "name": "If-Match",
@@ -4715,7 +4715,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.BestFriend.ListAddressInfo",
+        "operationId": "Me.AsEmployee.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -4809,7 +4809,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.BestFriend.UpdateAddressInfo",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -4850,7 +4850,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.BestFriend.SetAddressInfo",
+        "operationId": "Me.AsEmployee.BestFriend.SetAddressInfo",
         "parameters": [
           {
             "name": "If-Match",
@@ -4899,7 +4899,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.AddressInfo.GetCount-81de",
+        "operationId": "Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -4986,7 +4986,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.BestFriend.GetHomeAddress",
+        "operationId": "Me.AsEmployee.BestFriend.GetHomeAddress",
         "parameters": [
           {
             "name": "$select",
@@ -5052,7 +5052,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.BestFriend.UpdateHomeAddress",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -5332,7 +5332,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -5377,7 +5377,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.Friends.ListAddressInfo",
+        "operationId": "Me.AsEmployee.Friends.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -5481,7 +5481,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.Friends.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.Friends.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -5534,7 +5534,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.Friends.SetAddressInfo",
+        "operationId": "Me.AsEmployee.Friends.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -5593,7 +5593,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.AddressInfo.GetCount-660e",
+        "operationId": "Me.AsEmployee.Friends.AddressInfo.GetCount-660e",
         "parameters": [
           {
             "name": "UserName",
@@ -5712,7 +5712,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.Friends.GetHomeAddress",
+        "operationId": "Me.AsEmployee.Friends.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -5788,7 +5788,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.Friends.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.Friends.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -5967,7 +5967,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.GetCount-0cb7",
+        "operationId": "Me.AsEmployee.Friends.GetCount-0cb7",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -6000,7 +6000,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
-        "operationId": "Me.ListRefFriends",
+        "operationId": "Me.AsEmployee.ListRefFriends",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -6078,7 +6078,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to Friends for Me",
-        "operationId": "Me.CreateRefFriends",
+        "operationId": "Me.AsEmployee.CreateRefFriends",
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
@@ -6104,7 +6104,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "name": "If-Match",
@@ -6311,7 +6311,7 @@
           "Me.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.GetHomeAddress",
+        "operationId": "Me.AsEmployee.GetHomeAddress",
         "parameters": [
           {
             "name": "$select",
@@ -6377,7 +6377,7 @@
           "Me.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.UpdateHomeAddress",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -6569,7 +6569,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Peers for Me",
-        "operationId": "Me.DeleteRefPeers",
+        "operationId": "Me.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "name": "UserName",
@@ -6614,7 +6614,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.Peers.ListAddressInfo",
+        "operationId": "Me.AsEmployee.Peers.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -6718,7 +6718,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.Peers.UpdateAddressInfo",
+        "operationId": "Me.AsEmployee.Peers.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -6771,7 +6771,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.Peers.SetAddressInfo",
+        "operationId": "Me.AsEmployee.Peers.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -6830,7 +6830,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Peers.AddressInfo.GetCount-3e91",
+        "operationId": "Me.AsEmployee.Peers.AddressInfo.GetCount-3e91",
         "parameters": [
           {
             "name": "UserName",
@@ -6949,7 +6949,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.Peers.GetHomeAddress",
+        "operationId": "Me.AsEmployee.Peers.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -7025,7 +7025,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.Peers.UpdateHomeAddress",
+        "operationId": "Me.AsEmployee.Peers.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -7110,7 +7110,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Peers.GetCount-9fc2",
+        "operationId": "Me.AsEmployee.Peers.GetCount-9fc2",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -7143,7 +7143,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of Peers from Me",
-        "operationId": "Me.ListRefPeers",
+        "operationId": "Me.AsEmployee.ListRefPeers",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -7221,7 +7221,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to Peers for Me",
-        "operationId": "Me.CreateRefPeers",
+        "operationId": "Me.AsEmployee.CreateRefPeers",
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
@@ -7247,7 +7247,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Peers for Me",
-        "operationId": "Me.DeleteRefPeers",
+        "operationId": "Me.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "name": "If-Match",
@@ -7952,7 +7952,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -8014,7 +8014,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.PlanItems.GetCount-a822",
+        "operationId": "Me.AsEmployee.Trips.PlanItems.GetCount-a822",
         "parameters": [
           {
             "name": "TripId",
@@ -8060,7 +8060,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from Me",
-        "operationId": "Me.Trips.ListRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.ListRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -8139,7 +8139,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for Me",
-        "operationId": "Me.Trips.CreateRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -8180,7 +8180,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -8238,7 +8238,7 @@
           "Me.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.GetCount-5aa2",
+        "operationId": "Me.AsEmployee.Trips.GetCount-5aa2",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -8550,7 +8550,7 @@
           "Me.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.ListAddressInfo",
+        "operationId": "Me.AsManager.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -8644,7 +8644,7 @@
           "Me.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.UpdateAddressInfo",
+        "operationId": "Me.AsManager.UpdateAddressInfo",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -8685,7 +8685,7 @@
           "Me.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.SetAddressInfo",
+        "operationId": "Me.AsManager.SetAddressInfo",
         "parameters": [
           {
             "name": "If-Match",
@@ -8734,7 +8734,7 @@
           "Me.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.AddressInfo.GetCount-75da",
+        "operationId": "Me.AsManager.AddressInfo.GetCount-75da",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -8976,7 +8976,7 @@
         ],
         "summary": "Get ref of BestFriend from Me",
         "description": "The best friend.",
-        "operationId": "Me.GetRefBestFriend",
+        "operationId": "Me.AsManager.GetRefBestFriend",
         "responses": {
           "200": {
             "description": "Retrieved navigation property link",
@@ -9007,7 +9007,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "Me.UpdateRefBestFriend",
+        "operationId": "Me.AsManager.UpdateRefBestFriend",
         "requestBody": {
           "$ref": "#/components/requestBodies/refPutBody"
         },
@@ -9033,7 +9033,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for Me",
-        "operationId": "Me.DeleteRefBestFriend",
+        "operationId": "Me.AsManager.DeleteRefBestFriend",
         "parameters": [
           {
             "name": "If-Match",
@@ -9068,7 +9068,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.BestFriend.ListAddressInfo",
+        "operationId": "Me.AsManager.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -9162,7 +9162,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.BestFriend.UpdateAddressInfo",
+        "operationId": "Me.AsManager.BestFriend.UpdateAddressInfo",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -9203,7 +9203,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.BestFriend.SetAddressInfo",
+        "operationId": "Me.AsManager.BestFriend.SetAddressInfo",
         "parameters": [
           {
             "name": "If-Match",
@@ -9252,7 +9252,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.BestFriend.AddressInfo.GetCount-6ea6",
+        "operationId": "Me.AsManager.BestFriend.AddressInfo.GetCount-6ea6",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -9367,7 +9367,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.BestFriend.GetHomeAddress",
+        "operationId": "Me.AsManager.BestFriend.GetHomeAddress",
         "parameters": [
           {
             "name": "$select",
@@ -9433,7 +9433,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.BestFriend.UpdateHomeAddress",
+        "operationId": "Me.AsManager.BestFriend.UpdateHomeAddress",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -9709,7 +9709,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for Me",
-        "operationId": "Me.DeleteRefDirectReports",
+        "operationId": "Me.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "name": "UserName",
@@ -9754,7 +9754,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.DirectReports.ListAddressInfo",
+        "operationId": "Me.AsManager.DirectReports.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -9858,7 +9858,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.DirectReports.UpdateAddressInfo",
+        "operationId": "Me.AsManager.DirectReports.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -9911,7 +9911,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.DirectReports.SetAddressInfo",
+        "operationId": "Me.AsManager.DirectReports.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -9970,7 +9970,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.DirectReports.AddressInfo.GetCount-f650",
+        "operationId": "Me.AsManager.DirectReports.AddressInfo.GetCount-f650",
         "parameters": [
           {
             "name": "UserName",
@@ -10117,7 +10117,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.DirectReports.GetHomeAddress",
+        "operationId": "Me.AsManager.DirectReports.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -10193,7 +10193,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.DirectReports.UpdateHomeAddress",
+        "operationId": "Me.AsManager.DirectReports.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -10278,7 +10278,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.DirectReports.GetCount-8b92",
+        "operationId": "Me.AsManager.DirectReports.GetCount-8b92",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -10311,7 +10311,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of DirectReports from Me",
-        "operationId": "Me.ListRefDirectReports",
+        "operationId": "Me.AsManager.ListRefDirectReports",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -10389,7 +10389,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to DirectReports for Me",
-        "operationId": "Me.CreateRefDirectReports",
+        "operationId": "Me.AsManager.CreateRefDirectReports",
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
@@ -10415,7 +10415,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for Me",
-        "operationId": "Me.DeleteRefDirectReports",
+        "operationId": "Me.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "name": "If-Match",
@@ -10595,7 +10595,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -10640,7 +10640,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "Me.Friends.ListAddressInfo",
+        "operationId": "Me.AsManager.Friends.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -10744,7 +10744,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "Me.Friends.UpdateAddressInfo",
+        "operationId": "Me.AsManager.Friends.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -10797,7 +10797,7 @@
           "Me.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "Me.Friends.SetAddressInfo",
+        "operationId": "Me.AsManager.Friends.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -10856,7 +10856,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.AddressInfo.GetCount-b7db",
+        "operationId": "Me.AsManager.Friends.AddressInfo.GetCount-b7db",
         "parameters": [
           {
             "name": "UserName",
@@ -10975,7 +10975,7 @@
           "Me.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.Friends.GetHomeAddress",
+        "operationId": "Me.AsManager.Friends.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -11051,7 +11051,7 @@
           "Me.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.Friends.UpdateHomeAddress",
+        "operationId": "Me.AsManager.Friends.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -11230,7 +11230,7 @@
           "Me.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Friends.GetCount-60a7",
+        "operationId": "Me.AsManager.Friends.GetCount-60a7",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -11263,7 +11263,7 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
-        "operationId": "Me.ListRefFriends",
+        "operationId": "Me.AsManager.ListRefFriends",
         "parameters": [
           {
             "$ref": "#/components/parameters/top"
@@ -11341,7 +11341,7 @@
           "Me.Person"
         ],
         "summary": "Create new navigation property ref to Friends for Me",
-        "operationId": "Me.CreateRefFriends",
+        "operationId": "Me.AsManager.CreateRefFriends",
         "requestBody": {
           "$ref": "#/components/requestBodies/refPostBody"
         },
@@ -11367,7 +11367,7 @@
           "Me.Person"
         ],
         "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
+        "operationId": "Me.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "name": "If-Match",
@@ -11574,7 +11574,7 @@
           "Me.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "Me.GetHomeAddress",
+        "operationId": "Me.AsManager.GetHomeAddress",
         "parameters": [
           {
             "name": "$select",
@@ -11640,7 +11640,7 @@
           "Me.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "Me.UpdateHomeAddress",
+        "operationId": "Me.AsManager.UpdateHomeAddress",
         "requestBody": {
           "description": "New property values",
           "content": {
@@ -12412,7 +12412,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -12474,7 +12474,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.PlanItems.GetCount-5ad2",
+        "operationId": "Me.AsManager.Trips.PlanItems.GetCount-5ad2",
         "parameters": [
           {
             "name": "TripId",
@@ -12520,7 +12520,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from Me",
-        "operationId": "Me.Trips.ListRefPlanItems",
+        "operationId": "Me.AsManager.Trips.ListRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -12599,7 +12599,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for Me",
-        "operationId": "Me.Trips.CreateRefPlanItems",
+        "operationId": "Me.AsManager.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -12640,7 +12640,7 @@
           "Me.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for Me",
-        "operationId": "Me.Trips.DeleteRefPlanItems",
+        "operationId": "Me.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "TripId",
@@ -12698,7 +12698,7 @@
           "Me.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "Me.Trips.GetCount-f3f4",
+        "operationId": "Me.AsManager.Trips.GetCount-f3f4",
         "parameters": [
           {
             "name": "ConsistencyLevel",
@@ -21932,7 +21932,7 @@
           "People.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.ListAddressInfo",
+        "operationId": "People.AsEmployee.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -22036,7 +22036,7 @@
           "People.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -22089,7 +22089,7 @@
           "People.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.SetAddressInfo",
+        "operationId": "People.AsEmployee.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -22148,7 +22148,7 @@
           "People.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.AddressInfo.GetCount-3d43",
+        "operationId": "People.AsEmployee.AddressInfo.GetCount-3d43",
         "parameters": [
           {
             "name": "UserName",
@@ -22416,7 +22416,7 @@
         ],
         "summary": "Get ref of BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetRefBestFriend",
+        "operationId": "People.AsEmployee.GetRefBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -22459,7 +22459,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateRefBestFriend",
+        "operationId": "People.AsEmployee.UpdateRefBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -22497,7 +22497,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for People",
-        "operationId": "People.DeleteRefBestFriend",
+        "operationId": "People.AsEmployee.DeleteRefBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -22542,7 +22542,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.BestFriend.ListAddressInfo",
+        "operationId": "People.AsEmployee.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -22646,7 +22646,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.BestFriend.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -22699,7 +22699,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.BestFriend.SetAddressInfo",
+        "operationId": "People.AsEmployee.BestFriend.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -22758,7 +22758,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.AddressInfo.GetCount-cb8a",
+        "operationId": "People.AsEmployee.BestFriend.AddressInfo.GetCount-cb8a",
         "parameters": [
           {
             "name": "UserName",
@@ -22877,7 +22877,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.BestFriend.GetHomeAddress",
+        "operationId": "People.AsEmployee.BestFriend.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -22953,7 +22953,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.BestFriend.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -23277,7 +23277,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -23332,7 +23332,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.Friends.ListAddressInfo",
+        "operationId": "People.AsEmployee.Friends.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -23446,7 +23446,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.Friends.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.Friends.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -23509,7 +23509,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.Friends.SetAddressInfo",
+        "operationId": "People.AsEmployee.Friends.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -23578,7 +23578,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.AddressInfo.GetCount-1e8b",
+        "operationId": "People.AsEmployee.Friends.AddressInfo.GetCount-1e8b",
         "parameters": [
           {
             "name": "UserName",
@@ -23727,7 +23727,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.Friends.GetHomeAddress",
+        "operationId": "People.AsEmployee.Friends.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -23813,7 +23813,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.Friends.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.Friends.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -24022,7 +24022,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.GetCount-4db4",
+        "operationId": "People.AsEmployee.Friends.GetCount-4db4",
         "parameters": [
           {
             "name": "UserName",
@@ -24065,7 +24065,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
-        "operationId": "People.ListRefFriends",
+        "operationId": "People.AsEmployee.ListRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -24153,7 +24153,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to Friends for People",
-        "operationId": "People.CreateRefFriends",
+        "operationId": "People.AsEmployee.CreateRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -24191,7 +24191,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsEmployee.DeleteRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -24428,7 +24428,7 @@
           "People.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.GetHomeAddress",
+        "operationId": "People.AsEmployee.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -24504,7 +24504,7 @@
           "People.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -24730,7 +24730,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Peers for People",
-        "operationId": "People.DeleteRefPeers",
+        "operationId": "People.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "name": "UserName",
@@ -24785,7 +24785,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.Peers.ListAddressInfo",
+        "operationId": "People.AsEmployee.Peers.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -24899,7 +24899,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.Peers.UpdateAddressInfo",
+        "operationId": "People.AsEmployee.Peers.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -24962,7 +24962,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.Peers.SetAddressInfo",
+        "operationId": "People.AsEmployee.Peers.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -25031,7 +25031,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Peers.AddressInfo.GetCount-755d",
+        "operationId": "People.AsEmployee.Peers.AddressInfo.GetCount-755d",
         "parameters": [
           {
             "name": "UserName",
@@ -25180,7 +25180,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.Peers.GetHomeAddress",
+        "operationId": "People.AsEmployee.Peers.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -25266,7 +25266,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.Peers.UpdateHomeAddress",
+        "operationId": "People.AsEmployee.Peers.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -25371,7 +25371,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Peers.GetCount-44d2",
+        "operationId": "People.AsEmployee.Peers.GetCount-44d2",
         "parameters": [
           {
             "name": "UserName",
@@ -25414,7 +25414,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Peers from People",
-        "operationId": "People.ListRefPeers",
+        "operationId": "People.AsEmployee.ListRefPeers",
         "parameters": [
           {
             "name": "UserName",
@@ -25502,7 +25502,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to Peers for People",
-        "operationId": "People.CreateRefPeers",
+        "operationId": "People.AsEmployee.CreateRefPeers",
         "parameters": [
           {
             "name": "UserName",
@@ -25540,7 +25540,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Peers for People",
-        "operationId": "People.DeleteRefPeers",
+        "operationId": "People.AsEmployee.DeleteRefPeers",
         "parameters": [
           {
             "name": "UserName",
@@ -26327,7 +26327,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -26399,7 +26399,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.PlanItems.GetCount-7df9",
+        "operationId": "People.AsEmployee.Trips.PlanItems.GetCount-7df9",
         "parameters": [
           {
             "name": "UserName",
@@ -26455,7 +26455,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from People",
-        "operationId": "People.Trips.ListRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.ListRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -26544,7 +26544,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for People",
-        "operationId": "People.Trips.CreateRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -26595,7 +26595,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsEmployee.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -26663,7 +26663,7 @@
           "People.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.GetCount-c760",
+        "operationId": "People.AsEmployee.Trips.GetCount-c760",
         "parameters": [
           {
             "name": "UserName",
@@ -27043,7 +27043,7 @@
           "People.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.ListAddressInfo",
+        "operationId": "People.AsManager.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -27147,7 +27147,7 @@
           "People.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.UpdateAddressInfo",
+        "operationId": "People.AsManager.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -27200,7 +27200,7 @@
           "People.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.SetAddressInfo",
+        "operationId": "People.AsManager.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -27259,7 +27259,7 @@
           "People.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.AddressInfo.GetCount-f84e",
+        "operationId": "People.AsManager.AddressInfo.GetCount-f84e",
         "parameters": [
           {
             "name": "UserName",
@@ -27555,7 +27555,7 @@
         ],
         "summary": "Get ref of BestFriend from People",
         "description": "The best friend.",
-        "operationId": "People.GetRefBestFriend",
+        "operationId": "People.AsManager.GetRefBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -27598,7 +27598,7 @@
         ],
         "summary": "Update the best friend.",
         "description": "Update an instance of a best friend.",
-        "operationId": "People.UpdateRefBestFriend",
+        "operationId": "People.AsManager.UpdateRefBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -27636,7 +27636,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property BestFriend for People",
-        "operationId": "People.DeleteRefBestFriend",
+        "operationId": "People.AsManager.DeleteRefBestFriend",
         "parameters": [
           {
             "name": "UserName",
@@ -27681,7 +27681,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.BestFriend.ListAddressInfo",
+        "operationId": "People.AsManager.BestFriend.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -27785,7 +27785,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.BestFriend.UpdateAddressInfo",
+        "operationId": "People.AsManager.BestFriend.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -27838,7 +27838,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.BestFriend.SetAddressInfo",
+        "operationId": "People.AsManager.BestFriend.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -27897,7 +27897,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.BestFriend.AddressInfo.GetCount-5a39",
+        "operationId": "People.AsManager.BestFriend.AddressInfo.GetCount-5a39",
         "parameters": [
           {
             "name": "UserName",
@@ -28044,7 +28044,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.BestFriend.GetHomeAddress",
+        "operationId": "People.AsManager.BestFriend.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -28120,7 +28120,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.BestFriend.UpdateHomeAddress",
+        "operationId": "People.AsManager.BestFriend.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -28440,7 +28440,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for People",
-        "operationId": "People.DeleteRefDirectReports",
+        "operationId": "People.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "name": "UserName",
@@ -28495,7 +28495,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.DirectReports.ListAddressInfo",
+        "operationId": "People.AsManager.DirectReports.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -28609,7 +28609,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.DirectReports.UpdateAddressInfo",
+        "operationId": "People.AsManager.DirectReports.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -28672,7 +28672,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.DirectReports.SetAddressInfo",
+        "operationId": "People.AsManager.DirectReports.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -28741,7 +28741,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.DirectReports.AddressInfo.GetCount-f46e",
+        "operationId": "People.AsManager.DirectReports.AddressInfo.GetCount-f46e",
         "parameters": [
           {
             "name": "UserName",
@@ -28918,7 +28918,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.DirectReports.GetHomeAddress",
+        "operationId": "People.AsManager.DirectReports.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -29004,7 +29004,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.DirectReports.UpdateHomeAddress",
+        "operationId": "People.AsManager.DirectReports.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -29109,7 +29109,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.DirectReports.GetCount-0ec4",
+        "operationId": "People.AsManager.DirectReports.GetCount-0ec4",
         "parameters": [
           {
             "name": "UserName",
@@ -29152,7 +29152,7 @@
           "People.Person"
         ],
         "summary": "Get ref of DirectReports from People",
-        "operationId": "People.ListRefDirectReports",
+        "operationId": "People.AsManager.ListRefDirectReports",
         "parameters": [
           {
             "name": "UserName",
@@ -29240,7 +29240,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to DirectReports for People",
-        "operationId": "People.CreateRefDirectReports",
+        "operationId": "People.AsManager.CreateRefDirectReports",
         "parameters": [
           {
             "name": "UserName",
@@ -29278,7 +29278,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property DirectReports for People",
-        "operationId": "People.DeleteRefDirectReports",
+        "operationId": "People.AsManager.DeleteRefDirectReports",
         "parameters": [
           {
             "name": "UserName",
@@ -29478,7 +29478,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -29533,7 +29533,7 @@
           "People.Person.Location"
         ],
         "summary": "Get AddressInfo property value",
-        "operationId": "People.Friends.ListAddressInfo",
+        "operationId": "People.AsManager.Friends.ListAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -29647,7 +29647,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property AddressInfo value.",
-        "operationId": "People.Friends.UpdateAddressInfo",
+        "operationId": "People.AsManager.Friends.UpdateAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -29710,7 +29710,7 @@
           "People.Person.Location"
         ],
         "summary": "Sets a new value for the collection of Location.",
-        "operationId": "People.Friends.SetAddressInfo",
+        "operationId": "People.AsManager.Friends.SetAddressInfo",
         "parameters": [
           {
             "name": "UserName",
@@ -29779,7 +29779,7 @@
           "People.Person.Location"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.AddressInfo.GetCount-f486",
+        "operationId": "People.AsManager.Friends.AddressInfo.GetCount-f486",
         "parameters": [
           {
             "name": "UserName",
@@ -29928,7 +29928,7 @@
           "People.Person.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.Friends.GetHomeAddress",
+        "operationId": "People.AsManager.Friends.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -30014,7 +30014,7 @@
           "People.Person.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.Friends.UpdateHomeAddress",
+        "operationId": "People.AsManager.Friends.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -30223,7 +30223,7 @@
           "People.Person"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Friends.GetCount-1c0c",
+        "operationId": "People.AsManager.Friends.GetCount-1c0c",
         "parameters": [
           {
             "name": "UserName",
@@ -30266,7 +30266,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
-        "operationId": "People.ListRefFriends",
+        "operationId": "People.AsManager.ListRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -30354,7 +30354,7 @@
           "People.Person"
         ],
         "summary": "Create new navigation property ref to Friends for People",
-        "operationId": "People.CreateRefFriends",
+        "operationId": "People.AsManager.CreateRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -30392,7 +30392,7 @@
           "People.Person"
         ],
         "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
+        "operationId": "People.AsManager.DeleteRefFriends",
         "parameters": [
           {
             "name": "UserName",
@@ -30629,7 +30629,7 @@
           "People.Location"
         ],
         "summary": "Get HomeAddress property value",
-        "operationId": "People.GetHomeAddress",
+        "operationId": "People.AsManager.GetHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -30705,7 +30705,7 @@
           "People.Location"
         ],
         "summary": "Update property HomeAddress value.",
-        "operationId": "People.UpdateHomeAddress",
+        "operationId": "People.AsManager.UpdateHomeAddress",
         "parameters": [
           {
             "name": "UserName",
@@ -31585,7 +31585,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -31657,7 +31657,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.PlanItems.GetCount-fa08",
+        "operationId": "People.AsManager.Trips.PlanItems.GetCount-fa08",
         "parameters": [
           {
             "name": "UserName",
@@ -31713,7 +31713,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Get ref of PlanItems from People",
-        "operationId": "People.Trips.ListRefPlanItems",
+        "operationId": "People.AsManager.Trips.ListRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -31802,7 +31802,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Create new navigation property ref to PlanItems for People",
-        "operationId": "People.Trips.CreateRefPlanItems",
+        "operationId": "People.AsManager.Trips.CreateRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -31853,7 +31853,7 @@
           "People.Trips.PlanItem"
         ],
         "summary": "Delete ref of navigation property PlanItems for People",
-        "operationId": "People.Trips.DeleteRefPlanItems",
+        "operationId": "People.AsManager.Trips.DeleteRefPlanItems",
         "parameters": [
           {
             "name": "UserName",
@@ -31921,7 +31921,7 @@
           "People.Trip"
         ],
         "summary": "Get the number of the resource",
-        "operationId": "People.Trips.GetCount-1f8c",
+        "operationId": "People.AsManager.Trips.GetCount-1f8c",
         "parameters": [
           {
             "name": "UserName",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -2907,7 +2907,7 @@ paths:
       tags:
         - Me.Location
       summary: Get AddressInfo property value
-      operationId: Me.ListAddressInfo
+      operationId: Me.AsEmployee.ListAddressInfo
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -2969,7 +2969,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property AddressInfo value.
-      operationId: Me.UpdateAddressInfo
+      operationId: Me.AsEmployee.UpdateAddressInfo
       requestBody:
         description: New property values
         content:
@@ -2997,7 +2997,7 @@ paths:
       tags:
         - Me.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.SetAddressInfo
+      operationId: Me.AsEmployee.SetAddressInfo
       parameters:
         - name: If-Match
           in: header
@@ -3030,7 +3030,7 @@ paths:
       tags:
         - Me.Location
       summary: Get the number of the resource
-      operationId: Me.AddressInfo.GetCount-8488
+      operationId: Me.AsEmployee.AddressInfo.GetCount-8488
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -3182,7 +3182,7 @@ paths:
         - Me.Person
       summary: Get ref of BestFriend from Me
       description: The best friend.
-      operationId: Me.GetRefBestFriend
+      operationId: Me.AsEmployee.GetRefBestFriend
       responses:
         '200':
           description: Retrieved navigation property link
@@ -3204,7 +3204,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateRefBestFriend
+      operationId: Me.AsEmployee.UpdateRefBestFriend
       requestBody:
         $ref: '#/components/requestBodies/refPutBody'
       responses:
@@ -3223,7 +3223,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property BestFriend for Me
-      operationId: Me.DeleteRefBestFriend
+      operationId: Me.AsEmployee.DeleteRefBestFriend
       parameters:
         - name: If-Match
           in: header
@@ -3247,7 +3247,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.BestFriend.ListAddressInfo
+      operationId: Me.AsEmployee.BestFriend.ListAddressInfo
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -3309,7 +3309,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.BestFriend.UpdateAddressInfo
+      operationId: Me.AsEmployee.BestFriend.UpdateAddressInfo
       requestBody:
         description: New property values
         content:
@@ -3337,7 +3337,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.BestFriend.SetAddressInfo
+      operationId: Me.AsEmployee.BestFriend.SetAddressInfo
       parameters:
         - name: If-Match
           in: header
@@ -3370,7 +3370,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.BestFriend.AddressInfo.GetCount-81de
+      operationId: Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -3427,7 +3427,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.BestFriend.GetHomeAddress
+      operationId: Me.AsEmployee.BestFriend.GetHomeAddress
       parameters:
         - name: $select
           in: query
@@ -3473,7 +3473,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.BestFriend.UpdateHomeAddress
+      operationId: Me.AsEmployee.BestFriend.UpdateHomeAddress
       requestBody:
         description: New property values
         content:
@@ -3680,7 +3680,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsEmployee.DeleteRefFriends
       parameters:
         - name: UserName
           in: path
@@ -3711,7 +3711,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.Friends.ListAddressInfo
+      operationId: Me.AsEmployee.Friends.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -3780,7 +3780,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.Friends.UpdateAddressInfo
+      operationId: Me.AsEmployee.Friends.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -3816,7 +3816,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.Friends.SetAddressInfo
+      operationId: Me.AsEmployee.Friends.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -3856,7 +3856,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.Friends.AddressInfo.GetCount-660e
+      operationId: Me.AsEmployee.Friends.AddressInfo.GetCount-660e
       parameters:
         - name: UserName
           in: path
@@ -3935,7 +3935,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.Friends.GetHomeAddress
+      operationId: Me.AsEmployee.Friends.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -3988,7 +3988,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.Friends.UpdateHomeAddress
+      operationId: Me.AsEmployee.Friends.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -4117,7 +4117,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.Friends.GetCount-0cb7
+      operationId: Me.AsEmployee.Friends.GetCount-0cb7
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -4138,7 +4138,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
-      operationId: Me.ListRefFriends
+      operationId: Me.AsEmployee.ListRefFriends
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -4194,7 +4194,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to Friends for Me
-      operationId: Me.CreateRefFriends
+      operationId: Me.AsEmployee.CreateRefFriends
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
       responses:
@@ -4213,7 +4213,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsEmployee.DeleteRefFriends
       parameters:
         - name: If-Match
           in: header
@@ -4361,7 +4361,7 @@ paths:
       tags:
         - Me.Location
       summary: Get HomeAddress property value
-      operationId: Me.GetHomeAddress
+      operationId: Me.AsEmployee.GetHomeAddress
       parameters:
         - name: $select
           in: query
@@ -4407,7 +4407,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property HomeAddress value.
-      operationId: Me.UpdateHomeAddress
+      operationId: Me.AsEmployee.UpdateHomeAddress
       requestBody:
         description: New property values
         content:
@@ -4548,7 +4548,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Peers for Me
-      operationId: Me.DeleteRefPeers
+      operationId: Me.AsEmployee.DeleteRefPeers
       parameters:
         - name: UserName
           in: path
@@ -4579,7 +4579,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.Peers.ListAddressInfo
+      operationId: Me.AsEmployee.Peers.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -4648,7 +4648,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.Peers.UpdateAddressInfo
+      operationId: Me.AsEmployee.Peers.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -4684,7 +4684,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.Peers.SetAddressInfo
+      operationId: Me.AsEmployee.Peers.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -4724,7 +4724,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.Peers.AddressInfo.GetCount-3e91
+      operationId: Me.AsEmployee.Peers.AddressInfo.GetCount-3e91
       parameters:
         - name: UserName
           in: path
@@ -4803,7 +4803,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.Peers.GetHomeAddress
+      operationId: Me.AsEmployee.Peers.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -4856,7 +4856,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.Peers.UpdateHomeAddress
+      operationId: Me.AsEmployee.Peers.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -4915,7 +4915,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.Peers.GetCount-9fc2
+      operationId: Me.AsEmployee.Peers.GetCount-9fc2
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -4936,7 +4936,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Peers from Me
-      operationId: Me.ListRefPeers
+      operationId: Me.AsEmployee.ListRefPeers
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -4992,7 +4992,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to Peers for Me
-      operationId: Me.CreateRefPeers
+      operationId: Me.AsEmployee.CreateRefPeers
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
       responses:
@@ -5011,7 +5011,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Peers for Me
-      operationId: Me.DeleteRefPeers
+      operationId: Me.AsEmployee.DeleteRefPeers
       parameters:
         - name: If-Match
           in: header
@@ -5518,7 +5518,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -5563,7 +5563,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: Me.Trips.PlanItems.GetCount-a822
+      operationId: Me.AsEmployee.Trips.PlanItems.GetCount-a822
       parameters:
         - name: TripId
           in: path
@@ -5594,7 +5594,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get ref of PlanItems from Me
-      operationId: Me.Trips.ListRefPlanItems
+      operationId: Me.AsEmployee.Trips.ListRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -5648,7 +5648,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for Me
-      operationId: Me.Trips.CreateRefPlanItems
+      operationId: Me.AsEmployee.Trips.CreateRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -5678,7 +5678,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -5719,7 +5719,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get the number of the resource
-      operationId: Me.Trips.GetCount-5aa2
+      operationId: Me.AsEmployee.Trips.GetCount-5aa2
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -5942,7 +5942,7 @@ paths:
       tags:
         - Me.Location
       summary: Get AddressInfo property value
-      operationId: Me.ListAddressInfo
+      operationId: Me.AsManager.ListAddressInfo
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -6004,7 +6004,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property AddressInfo value.
-      operationId: Me.UpdateAddressInfo
+      operationId: Me.AsManager.UpdateAddressInfo
       requestBody:
         description: New property values
         content:
@@ -6032,7 +6032,7 @@ paths:
       tags:
         - Me.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.SetAddressInfo
+      operationId: Me.AsManager.SetAddressInfo
       parameters:
         - name: If-Match
           in: header
@@ -6065,7 +6065,7 @@ paths:
       tags:
         - Me.Location
       summary: Get the number of the resource
-      operationId: Me.AddressInfo.GetCount-75da
+      operationId: Me.AsManager.AddressInfo.GetCount-75da
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -6235,7 +6235,7 @@ paths:
         - Me.Person
       summary: Get ref of BestFriend from Me
       description: The best friend.
-      operationId: Me.GetRefBestFriend
+      operationId: Me.AsManager.GetRefBestFriend
       responses:
         '200':
           description: Retrieved navigation property link
@@ -6257,7 +6257,7 @@ paths:
         - Me.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: Me.UpdateRefBestFriend
+      operationId: Me.AsManager.UpdateRefBestFriend
       requestBody:
         $ref: '#/components/requestBodies/refPutBody'
       responses:
@@ -6276,7 +6276,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property BestFriend for Me
-      operationId: Me.DeleteRefBestFriend
+      operationId: Me.AsManager.DeleteRefBestFriend
       parameters:
         - name: If-Match
           in: header
@@ -6300,7 +6300,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.BestFriend.ListAddressInfo
+      operationId: Me.AsManager.BestFriend.ListAddressInfo
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -6362,7 +6362,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.BestFriend.UpdateAddressInfo
+      operationId: Me.AsManager.BestFriend.UpdateAddressInfo
       requestBody:
         description: New property values
         content:
@@ -6390,7 +6390,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.BestFriend.SetAddressInfo
+      operationId: Me.AsManager.BestFriend.SetAddressInfo
       parameters:
         - name: If-Match
           in: header
@@ -6423,7 +6423,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.BestFriend.AddressInfo.GetCount-6ea6
+      operationId: Me.AsManager.BestFriend.AddressInfo.GetCount-6ea6
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -6498,7 +6498,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.BestFriend.GetHomeAddress
+      operationId: Me.AsManager.BestFriend.GetHomeAddress
       parameters:
         - name: $select
           in: query
@@ -6544,7 +6544,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.BestFriend.UpdateHomeAddress
+      operationId: Me.AsManager.BestFriend.UpdateHomeAddress
       requestBody:
         description: New property values
         content:
@@ -6748,7 +6748,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property DirectReports for Me
-      operationId: Me.DeleteRefDirectReports
+      operationId: Me.AsManager.DeleteRefDirectReports
       parameters:
         - name: UserName
           in: path
@@ -6779,7 +6779,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.DirectReports.ListAddressInfo
+      operationId: Me.AsManager.DirectReports.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -6848,7 +6848,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.DirectReports.UpdateAddressInfo
+      operationId: Me.AsManager.DirectReports.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -6884,7 +6884,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.DirectReports.SetAddressInfo
+      operationId: Me.AsManager.DirectReports.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -6924,7 +6924,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.DirectReports.AddressInfo.GetCount-f650
+      operationId: Me.AsManager.DirectReports.AddressInfo.GetCount-f650
       parameters:
         - name: UserName
           in: path
@@ -7021,7 +7021,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.DirectReports.GetHomeAddress
+      operationId: Me.AsManager.DirectReports.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -7074,7 +7074,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.DirectReports.UpdateHomeAddress
+      operationId: Me.AsManager.DirectReports.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -7133,7 +7133,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.DirectReports.GetCount-8b92
+      operationId: Me.AsManager.DirectReports.GetCount-8b92
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -7154,7 +7154,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of DirectReports from Me
-      operationId: Me.ListRefDirectReports
+      operationId: Me.AsManager.ListRefDirectReports
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -7210,7 +7210,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to DirectReports for Me
-      operationId: Me.CreateRefDirectReports
+      operationId: Me.AsManager.CreateRefDirectReports
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
       responses:
@@ -7229,7 +7229,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property DirectReports for Me
-      operationId: Me.DeleteRefDirectReports
+      operationId: Me.AsManager.DeleteRefDirectReports
       parameters:
         - name: If-Match
           in: header
@@ -7361,7 +7361,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsManager.DeleteRefFriends
       parameters:
         - name: UserName
           in: path
@@ -7392,7 +7392,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get AddressInfo property value
-      operationId: Me.Friends.ListAddressInfo
+      operationId: Me.AsManager.Friends.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -7461,7 +7461,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property AddressInfo value.
-      operationId: Me.Friends.UpdateAddressInfo
+      operationId: Me.AsManager.Friends.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -7497,7 +7497,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: Me.Friends.SetAddressInfo
+      operationId: Me.AsManager.Friends.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -7537,7 +7537,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get the number of the resource
-      operationId: Me.Friends.AddressInfo.GetCount-b7db
+      operationId: Me.AsManager.Friends.AddressInfo.GetCount-b7db
       parameters:
         - name: UserName
           in: path
@@ -7616,7 +7616,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Get HomeAddress property value
-      operationId: Me.Friends.GetHomeAddress
+      operationId: Me.AsManager.Friends.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -7669,7 +7669,7 @@ paths:
       tags:
         - Me.Person.Location
       summary: Update property HomeAddress value.
-      operationId: Me.Friends.UpdateHomeAddress
+      operationId: Me.AsManager.Friends.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -7798,7 +7798,7 @@ paths:
       tags:
         - Me.Person
       summary: Get the number of the resource
-      operationId: Me.Friends.GetCount-60a7
+      operationId: Me.AsManager.Friends.GetCount-60a7
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -7819,7 +7819,7 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
-      operationId: Me.ListRefFriends
+      operationId: Me.AsManager.ListRefFriends
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -7875,7 +7875,7 @@ paths:
       tags:
         - Me.Person
       summary: Create new navigation property ref to Friends for Me
-      operationId: Me.CreateRefFriends
+      operationId: Me.AsManager.CreateRefFriends
       requestBody:
         $ref: '#/components/requestBodies/refPostBody'
       responses:
@@ -7894,7 +7894,7 @@ paths:
       tags:
         - Me.Person
       summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
+      operationId: Me.AsManager.DeleteRefFriends
       parameters:
         - name: If-Match
           in: header
@@ -8042,7 +8042,7 @@ paths:
       tags:
         - Me.Location
       summary: Get HomeAddress property value
-      operationId: Me.GetHomeAddress
+      operationId: Me.AsManager.GetHomeAddress
       parameters:
         - name: $select
           in: query
@@ -8088,7 +8088,7 @@ paths:
       tags:
         - Me.Location
       summary: Update property HomeAddress value.
-      operationId: Me.UpdateHomeAddress
+      operationId: Me.AsManager.UpdateHomeAddress
       requestBody:
         description: New property values
         content:
@@ -8640,7 +8640,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -8685,7 +8685,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: Me.Trips.PlanItems.GetCount-5ad2
+      operationId: Me.AsManager.Trips.PlanItems.GetCount-5ad2
       parameters:
         - name: TripId
           in: path
@@ -8716,7 +8716,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Get ref of PlanItems from Me
-      operationId: Me.Trips.ListRefPlanItems
+      operationId: Me.AsManager.Trips.ListRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -8770,7 +8770,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for Me
-      operationId: Me.Trips.CreateRefPlanItems
+      operationId: Me.AsManager.Trips.CreateRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -8800,7 +8800,7 @@ paths:
       tags:
         - Me.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for Me
-      operationId: Me.Trips.DeleteRefPlanItems
+      operationId: Me.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - name: TripId
           in: path
@@ -8841,7 +8841,7 @@ paths:
       tags:
         - Me.Trip
       summary: Get the number of the resource
-      operationId: Me.Trips.GetCount-f3f4
+      operationId: Me.AsManager.Trips.GetCount-f3f4
       parameters:
         - name: ConsistencyLevel
           in: header
@@ -15282,7 +15282,7 @@ paths:
       tags:
         - People.Location
       summary: Get AddressInfo property value
-      operationId: People.ListAddressInfo
+      operationId: People.AsEmployee.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -15351,7 +15351,7 @@ paths:
       tags:
         - People.Location
       summary: Update property AddressInfo value.
-      operationId: People.UpdateAddressInfo
+      operationId: People.AsEmployee.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -15387,7 +15387,7 @@ paths:
       tags:
         - People.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.SetAddressInfo
+      operationId: People.AsEmployee.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -15427,7 +15427,7 @@ paths:
       tags:
         - People.Location
       summary: Get the number of the resource
-      operationId: People.AddressInfo.GetCount-3d43
+      operationId: People.AsEmployee.AddressInfo.GetCount-3d43
       parameters:
         - name: UserName
           in: path
@@ -15616,7 +15616,7 @@ paths:
         - People.Person
       summary: Get ref of BestFriend from People
       description: The best friend.
-      operationId: People.GetRefBestFriend
+      operationId: People.AsEmployee.GetRefBestFriend
       parameters:
         - name: UserName
           in: path
@@ -15646,7 +15646,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateRefBestFriend
+      operationId: People.AsEmployee.UpdateRefBestFriend
       parameters:
         - name: UserName
           in: path
@@ -15673,7 +15673,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property BestFriend for People
-      operationId: People.DeleteRefBestFriend
+      operationId: People.AsEmployee.DeleteRefBestFriend
       parameters:
         - name: UserName
           in: path
@@ -15704,7 +15704,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.BestFriend.ListAddressInfo
+      operationId: People.AsEmployee.BestFriend.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -15773,7 +15773,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.BestFriend.UpdateAddressInfo
+      operationId: People.AsEmployee.BestFriend.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -15809,7 +15809,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.BestFriend.SetAddressInfo
+      operationId: People.AsEmployee.BestFriend.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -15849,7 +15849,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.BestFriend.AddressInfo.GetCount-cb8a
+      operationId: People.AsEmployee.BestFriend.AddressInfo.GetCount-cb8a
       parameters:
         - name: UserName
           in: path
@@ -15928,7 +15928,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.BestFriend.GetHomeAddress
+      operationId: People.AsEmployee.BestFriend.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -15981,7 +15981,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.BestFriend.UpdateHomeAddress
+      operationId: People.AsEmployee.BestFriend.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -16218,7 +16218,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsEmployee.DeleteRefFriends
       parameters:
         - name: UserName
           in: path
@@ -16256,7 +16256,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.Friends.ListAddressInfo
+      operationId: People.AsEmployee.Friends.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -16332,7 +16332,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.Friends.UpdateAddressInfo
+      operationId: People.AsEmployee.Friends.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -16375,7 +16375,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.Friends.SetAddressInfo
+      operationId: People.AsEmployee.Friends.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -16422,7 +16422,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.Friends.AddressInfo.GetCount-1e8b
+      operationId: People.AsEmployee.Friends.AddressInfo.GetCount-1e8b
       parameters:
         - name: UserName
           in: path
@@ -16522,7 +16522,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.Friends.GetHomeAddress
+      operationId: People.AsEmployee.Friends.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -16582,7 +16582,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.Friends.UpdateHomeAddress
+      operationId: People.AsEmployee.Friends.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -16732,7 +16732,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Friends.GetCount-4db4
+      operationId: People.AsEmployee.Friends.GetCount-4db4
       parameters:
         - name: UserName
           in: path
@@ -16760,7 +16760,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
-      operationId: People.ListRefFriends
+      operationId: People.AsEmployee.ListRefFriends
       parameters:
         - name: UserName
           in: path
@@ -16823,7 +16823,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to Friends for People
-      operationId: People.CreateRefFriends
+      operationId: People.AsEmployee.CreateRefFriends
       parameters:
         - name: UserName
           in: path
@@ -16850,7 +16850,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsEmployee.DeleteRefFriends
       parameters:
         - name: UserName
           in: path
@@ -17019,7 +17019,7 @@ paths:
       tags:
         - People.Location
       summary: Get HomeAddress property value
-      operationId: People.GetHomeAddress
+      operationId: People.AsEmployee.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -17072,7 +17072,7 @@ paths:
       tags:
         - People.Location
       summary: Update property HomeAddress value.
-      operationId: People.UpdateHomeAddress
+      operationId: People.AsEmployee.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -17236,7 +17236,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Peers for People
-      operationId: People.DeleteRefPeers
+      operationId: People.AsEmployee.DeleteRefPeers
       parameters:
         - name: UserName
           in: path
@@ -17274,7 +17274,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.Peers.ListAddressInfo
+      operationId: People.AsEmployee.Peers.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -17350,7 +17350,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.Peers.UpdateAddressInfo
+      operationId: People.AsEmployee.Peers.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -17393,7 +17393,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.Peers.SetAddressInfo
+      operationId: People.AsEmployee.Peers.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -17440,7 +17440,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.Peers.AddressInfo.GetCount-755d
+      operationId: People.AsEmployee.Peers.AddressInfo.GetCount-755d
       parameters:
         - name: UserName
           in: path
@@ -17540,7 +17540,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.Peers.GetHomeAddress
+      operationId: People.AsEmployee.Peers.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -17600,7 +17600,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.Peers.UpdateHomeAddress
+      operationId: People.AsEmployee.Peers.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -17673,7 +17673,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Peers.GetCount-44d2
+      operationId: People.AsEmployee.Peers.GetCount-44d2
       parameters:
         - name: UserName
           in: path
@@ -17701,7 +17701,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Peers from People
-      operationId: People.ListRefPeers
+      operationId: People.AsEmployee.ListRefPeers
       parameters:
         - name: UserName
           in: path
@@ -17764,7 +17764,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to Peers for People
-      operationId: People.CreateRefPeers
+      operationId: People.AsEmployee.CreateRefPeers
       parameters:
         - name: UserName
           in: path
@@ -17791,7 +17791,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Peers for People
-      operationId: People.DeleteRefPeers
+      operationId: People.AsEmployee.DeleteRefPeers
       parameters:
         - name: UserName
           in: path
@@ -18355,7 +18355,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -18407,7 +18407,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: People.Trips.PlanItems.GetCount-7df9
+      operationId: People.AsEmployee.Trips.PlanItems.GetCount-7df9
       parameters:
         - name: UserName
           in: path
@@ -18445,7 +18445,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get ref of PlanItems from People
-      operationId: People.Trips.ListRefPlanItems
+      operationId: People.AsEmployee.Trips.ListRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -18506,7 +18506,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for People
-      operationId: People.Trips.CreateRefPlanItems
+      operationId: People.AsEmployee.Trips.CreateRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -18543,7 +18543,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsEmployee.Trips.DeleteRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -18591,7 +18591,7 @@ paths:
       tags:
         - People.Trip
       summary: Get the number of the resource
-      operationId: People.Trips.GetCount-c760
+      operationId: People.AsEmployee.Trips.GetCount-c760
       parameters:
         - name: UserName
           in: path
@@ -18860,7 +18860,7 @@ paths:
       tags:
         - People.Location
       summary: Get AddressInfo property value
-      operationId: People.ListAddressInfo
+      operationId: People.AsManager.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -18929,7 +18929,7 @@ paths:
       tags:
         - People.Location
       summary: Update property AddressInfo value.
-      operationId: People.UpdateAddressInfo
+      operationId: People.AsManager.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -18965,7 +18965,7 @@ paths:
       tags:
         - People.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.SetAddressInfo
+      operationId: People.AsManager.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -19005,7 +19005,7 @@ paths:
       tags:
         - People.Location
       summary: Get the number of the resource
-      operationId: People.AddressInfo.GetCount-f84e
+      operationId: People.AsManager.AddressInfo.GetCount-f84e
       parameters:
         - name: UserName
           in: path
@@ -19212,7 +19212,7 @@ paths:
         - People.Person
       summary: Get ref of BestFriend from People
       description: The best friend.
-      operationId: People.GetRefBestFriend
+      operationId: People.AsManager.GetRefBestFriend
       parameters:
         - name: UserName
           in: path
@@ -19242,7 +19242,7 @@ paths:
         - People.Person
       summary: Update the best friend.
       description: Update an instance of a best friend.
-      operationId: People.UpdateRefBestFriend
+      operationId: People.AsManager.UpdateRefBestFriend
       parameters:
         - name: UserName
           in: path
@@ -19269,7 +19269,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property BestFriend for People
-      operationId: People.DeleteRefBestFriend
+      operationId: People.AsManager.DeleteRefBestFriend
       parameters:
         - name: UserName
           in: path
@@ -19300,7 +19300,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.BestFriend.ListAddressInfo
+      operationId: People.AsManager.BestFriend.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -19369,7 +19369,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.BestFriend.UpdateAddressInfo
+      operationId: People.AsManager.BestFriend.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -19405,7 +19405,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.BestFriend.SetAddressInfo
+      operationId: People.AsManager.BestFriend.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -19445,7 +19445,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.BestFriend.AddressInfo.GetCount-5a39
+      operationId: People.AsManager.BestFriend.AddressInfo.GetCount-5a39
       parameters:
         - name: UserName
           in: path
@@ -19542,7 +19542,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.BestFriend.GetHomeAddress
+      operationId: People.AsManager.BestFriend.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -19595,7 +19595,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.BestFriend.UpdateHomeAddress
+      operationId: People.AsManager.BestFriend.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -19829,7 +19829,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property DirectReports for People
-      operationId: People.DeleteRefDirectReports
+      operationId: People.AsManager.DeleteRefDirectReports
       parameters:
         - name: UserName
           in: path
@@ -19867,7 +19867,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.DirectReports.ListAddressInfo
+      operationId: People.AsManager.DirectReports.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -19943,7 +19943,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.DirectReports.UpdateAddressInfo
+      operationId: People.AsManager.DirectReports.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -19986,7 +19986,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.DirectReports.SetAddressInfo
+      operationId: People.AsManager.DirectReports.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -20033,7 +20033,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.DirectReports.AddressInfo.GetCount-f46e
+      operationId: People.AsManager.DirectReports.AddressInfo.GetCount-f46e
       parameters:
         - name: UserName
           in: path
@@ -20151,7 +20151,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.DirectReports.GetHomeAddress
+      operationId: People.AsManager.DirectReports.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -20211,7 +20211,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.DirectReports.UpdateHomeAddress
+      operationId: People.AsManager.DirectReports.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -20284,7 +20284,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.DirectReports.GetCount-0ec4
+      operationId: People.AsManager.DirectReports.GetCount-0ec4
       parameters:
         - name: UserName
           in: path
@@ -20312,7 +20312,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of DirectReports from People
-      operationId: People.ListRefDirectReports
+      operationId: People.AsManager.ListRefDirectReports
       parameters:
         - name: UserName
           in: path
@@ -20375,7 +20375,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to DirectReports for People
-      operationId: People.CreateRefDirectReports
+      operationId: People.AsManager.CreateRefDirectReports
       parameters:
         - name: UserName
           in: path
@@ -20402,7 +20402,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property DirectReports for People
-      operationId: People.DeleteRefDirectReports
+      operationId: People.AsManager.DeleteRefDirectReports
       parameters:
         - name: UserName
           in: path
@@ -20548,7 +20548,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsManager.DeleteRefFriends
       parameters:
         - name: UserName
           in: path
@@ -20586,7 +20586,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get AddressInfo property value
-      operationId: People.Friends.ListAddressInfo
+      operationId: People.AsManager.Friends.ListAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -20662,7 +20662,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property AddressInfo value.
-      operationId: People.Friends.UpdateAddressInfo
+      operationId: People.AsManager.Friends.UpdateAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -20705,7 +20705,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Sets a new value for the collection of Location.
-      operationId: People.Friends.SetAddressInfo
+      operationId: People.AsManager.Friends.SetAddressInfo
       parameters:
         - name: UserName
           in: path
@@ -20752,7 +20752,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get the number of the resource
-      operationId: People.Friends.AddressInfo.GetCount-f486
+      operationId: People.AsManager.Friends.AddressInfo.GetCount-f486
       parameters:
         - name: UserName
           in: path
@@ -20852,7 +20852,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Get HomeAddress property value
-      operationId: People.Friends.GetHomeAddress
+      operationId: People.AsManager.Friends.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -20912,7 +20912,7 @@ paths:
       tags:
         - People.Person.Location
       summary: Update property HomeAddress value.
-      operationId: People.Friends.UpdateHomeAddress
+      operationId: People.AsManager.Friends.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -21062,7 +21062,7 @@ paths:
       tags:
         - People.Person
       summary: Get the number of the resource
-      operationId: People.Friends.GetCount-1c0c
+      operationId: People.AsManager.Friends.GetCount-1c0c
       parameters:
         - name: UserName
           in: path
@@ -21090,7 +21090,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
-      operationId: People.ListRefFriends
+      operationId: People.AsManager.ListRefFriends
       parameters:
         - name: UserName
           in: path
@@ -21153,7 +21153,7 @@ paths:
       tags:
         - People.Person
       summary: Create new navigation property ref to Friends for People
-      operationId: People.CreateRefFriends
+      operationId: People.AsManager.CreateRefFriends
       parameters:
         - name: UserName
           in: path
@@ -21180,7 +21180,7 @@ paths:
       tags:
         - People.Person
       summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
+      operationId: People.AsManager.DeleteRefFriends
       parameters:
         - name: UserName
           in: path
@@ -21349,7 +21349,7 @@ paths:
       tags:
         - People.Location
       summary: Get HomeAddress property value
-      operationId: People.GetHomeAddress
+      operationId: People.AsManager.GetHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -21402,7 +21402,7 @@ paths:
       tags:
         - People.Location
       summary: Update property HomeAddress value.
-      operationId: People.UpdateHomeAddress
+      operationId: People.AsManager.UpdateHomeAddress
       parameters:
         - name: UserName
           in: path
@@ -22028,7 +22028,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -22080,7 +22080,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get the number of the resource
-      operationId: People.Trips.PlanItems.GetCount-fa08
+      operationId: People.AsManager.Trips.PlanItems.GetCount-fa08
       parameters:
         - name: UserName
           in: path
@@ -22118,7 +22118,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Get ref of PlanItems from People
-      operationId: People.Trips.ListRefPlanItems
+      operationId: People.AsManager.Trips.ListRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -22179,7 +22179,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Create new navigation property ref to PlanItems for People
-      operationId: People.Trips.CreateRefPlanItems
+      operationId: People.AsManager.Trips.CreateRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -22216,7 +22216,7 @@ paths:
       tags:
         - People.Trips.PlanItem
       summary: Delete ref of navigation property PlanItems for People
-      operationId: People.Trips.DeleteRefPlanItems
+      operationId: People.AsManager.Trips.DeleteRefPlanItems
       parameters:
         - name: UserName
           in: path
@@ -22264,7 +22264,7 @@ paths:
       tags:
         - People.Trip
       summary: Get the number of the resource
-      operationId: People.Trips.GetCount-1f8c
+      operationId: People.AsManager.Trips.GetCount-1f8c
       parameters:
         - name: UserName
           in: path


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/492

This PR:
- Resolves operation id`s of paths with type cast segments that weren't previously included in the operation name.
- Updates the integration tests.
- Updates release notes.