### PR TITLE
[Fix] Uses convert setting to toggle between generating query options schemas of type string array or enums

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -555,7 +555,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Items = new OpenApiSchema
                     {
                         Type = "string",
-                        Enum = orderByItems
+                        Enum = context.Settings.UseStringArrayForQueryOptionsSchema ? null : orderByItems
                     }
                 },
                 Style = ParameterStyle.Form,
@@ -639,7 +639,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Items = new OpenApiSchema
                     {
                         Type = "string",
-                        Enum = selectItems
+                        Enum = context.Settings.UseStringArrayForQueryOptionsSchema ? null : selectItems
                     }
                 },
                 Style = ParameterStyle.Form,
@@ -720,7 +720,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Items = new OpenApiSchema
                     {
                         Type = "string",
-                        Enum = expandItems
+                        Enum = context.Settings.UseStringArrayForQueryOptionsSchema ? null : expandItems
                     }
                 },
                 Style = ParameterStyle.Form,

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.8</Version>
+    <Version>1.6.0-preview.9</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -30,6 +30,7 @@
 - Appends parameters and fixes operation ids of navigation property paths generated via composable functions #486
 - Use alternate keys in the generation of operation ids of operations and navigation property alternate paths #488
 - Fixes operation ids of paths with type cast segments #492
+- Uses convert setting to toggle between generating query options schemas of type string array or enums #197
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -356,6 +356,12 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool EnableAliasForOperationSegments { get; set; } = false;
 
+        /// <summary>
+        /// Gets/Sets a value indicating whether or not to generate the schema of query options as an array of string values.
+        /// If false, the schema will be generated as an array of enum string values.
+        /// </summary>
+        public bool UseStringArrayForQueryOptionsSchema { get; set; } = true;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -409,7 +415,8 @@ namespace Microsoft.OpenApi.OData
                 NamespacePrefixToStripForInMethodPaths = this.NamespacePrefixToStripForInMethodPaths,
                 EnableAliasForTypeCastSegments = this.EnableAliasForTypeCastSegments,
                 SemVerVersion = this.SemVerVersion,
-                EnableAliasForOperationSegments = this.EnableAliasForOperationSegments
+                EnableAliasForOperationSegments = this.EnableAliasForOperationSegments,
+                UseStringArrayForQueryOptionsSchema = this.UseStringArrayForQueryOptionsSchema
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -50,6 +50,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.SemVerVersion.get -> string
 Microsoft.OpenApi.OData.OpenApiConvertSettings.SemVerVersion.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.ShowExternalDocs.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.UseStringArrayForQueryOptionsSchema.get -> bool
+Microsoft.OpenApi.OData.OpenApiConvertSettings.UseStringArrayForQueryOptionsSchema.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.UseSuccessStatusCodeRange.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.UseSuccessStatusCodeRange.set -> void
 Microsoft.OpenApi.OData.OpenApiExtensions.OpenApiEnumFlagsExtension

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
@@ -94,7 +94,8 @@ namespace Microsoft.OpenApi.OData.Tests
             {
                 OpenApiSpecVersion = specVersion,
                 ShowSchemaExamples = true, // test for schema examples
-                IncludeAssemblyInfo = false
+                IncludeAssemblyInfo = false,
+                UseStringArrayForQueryOptionsSchema = false
             };
 
             // Act
@@ -123,7 +124,8 @@ namespace Microsoft.OpenApi.OData.Tests
             {
                 OpenApiSpecVersion = specVersion,
                 ShowSchemaExamples = true,
-                IncludeAssemblyInfo = false
+                IncludeAssemblyInfo = false,
+                UseStringArrayForQueryOptionsSchema = false
             };
 
             // Act
@@ -153,7 +155,8 @@ namespace Microsoft.OpenApi.OData.Tests
                 OpenApiSpecVersion = specVersion,
                 ShowLinks = true, // test Links
                 ShowSchemaExamples = true,
-                IncludeAssemblyInfo = false
+                IncludeAssemblyInfo = false,
+                UseStringArrayForQueryOptionsSchema = false
             };
 
             // Act
@@ -183,7 +186,8 @@ namespace Microsoft.OpenApi.OData.Tests
                 OpenApiSpecVersion = specVersion,
                 ShowLinks = true, // test Links
                 ShowSchemaExamples = true,
-                IncludeAssemblyInfo = false
+                IncludeAssemblyInfo = false,
+                UseStringArrayForQueryOptionsSchema = false
             };
 
             // Act
@@ -226,7 +230,7 @@ namespace Microsoft.OpenApi.OData.Tests
 
             // Assert
             if (specVersion == OpenApiSpecVersion.OpenApi2_0)
-            {
+            {            
                 Assert.Equal(Resources.GetString("TripService.OpenApi.V2.json").ChangeLineBreaks(), json);
             }
             else

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/EdmModelOpenApiExtensionsTest.cs
@@ -230,7 +230,7 @@ namespace Microsoft.OpenApi.OData.Tests
 
             // Assert
             if (specVersion == OpenApiSpecVersion.OpenApi2_0)
-            {            
+            {
                 Assert.Equal(Resources.GetString("TripService.OpenApi.V2.json").ChangeLineBreaks(), json);
             }
             else

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -40,12 +40,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "AirlineCode",
-                "AirlineCode desc",
-                "Name",
-                "Name desc"
-              ],
               "type": "string"
             }
           },
@@ -55,10 +49,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "AirlineCode",
-                "Name"
-              ],
               "type": "string"
             }
           },
@@ -68,9 +58,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -147,10 +134,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "AirlineCode",
-                "Name"
-              ],
               "type": "string"
             }
           },
@@ -160,9 +143,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -307,16 +287,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Name",
-                "Name desc",
-                "IcaoCode",
-                "IcaoCode desc",
-                "IataCode",
-                "IataCode desc",
-                "Location",
-                "Location desc"
-              ],
               "type": "string"
             }
           },
@@ -326,12 +296,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Name",
-                "IcaoCode",
-                "IataCode",
-                "Location"
-              ],
               "type": "string"
             }
           },
@@ -341,9 +305,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -420,12 +381,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Name",
-                "IcaoCode",
-                "IataCode",
-                "Location"
-              ],
               "type": "string"
             }
           },
@@ -435,9 +390,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -552,12 +504,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City",
-                "Loc",
-                "EmergencyAuthority"
-              ],
               "type": "string"
             }
           },
@@ -567,10 +513,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "EmergencyAuthority"
-              ],
               "type": "string"
             }
           }
@@ -651,22 +593,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -676,12 +602,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -835,12 +755,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -850,10 +764,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -863,9 +773,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -1089,10 +996,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -1102,9 +1005,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -1295,22 +1195,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -1320,12 +1204,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -1418,12 +1296,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -1433,10 +1305,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -1446,9 +1314,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -1665,22 +1530,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -1690,12 +1539,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -1886,12 +1729,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -1901,10 +1738,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -1914,9 +1747,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -2132,10 +1962,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -2145,9 +1971,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -2250,22 +2073,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -2275,12 +2082,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -2323,22 +2124,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -2348,12 +2133,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -2408,30 +2187,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -2441,22 +2196,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -2466,12 +2205,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -2578,12 +2311,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -2593,10 +2320,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -2606,9 +2329,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -2874,10 +2594,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -2887,9 +2603,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -3018,22 +2731,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -3043,12 +2740,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -3099,22 +2790,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -3124,12 +2799,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -3217,30 +2886,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -3359,30 +3004,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -3392,22 +3013,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -3417,12 +3022,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -3507,30 +3106,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -3540,22 +3115,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -3565,12 +3124,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -3643,10 +3196,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -3656,9 +3205,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -3761,22 +3307,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -3786,12 +3316,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -3846,12 +3370,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -3861,10 +3379,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -3874,9 +3388,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -4093,22 +3604,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -4118,12 +3613,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -4314,12 +3803,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -4329,10 +3812,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -4342,9 +3821,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -4560,10 +4036,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -4573,9 +4045,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -4678,22 +4147,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -4703,12 +4156,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -4763,30 +4210,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -4796,22 +4219,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -4821,12 +4228,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -4933,12 +4334,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -4948,10 +4343,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -4961,9 +4352,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -5229,10 +4617,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -5242,9 +4626,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -5373,22 +4754,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -5398,12 +4763,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -5491,30 +4850,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -5633,30 +4968,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -5666,22 +4977,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -5691,12 +4986,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -5769,10 +5058,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -5782,9 +5067,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -5899,30 +5181,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -5932,22 +5190,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -5957,12 +5199,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -6065,12 +5301,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -6080,10 +5310,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -6093,9 +5319,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -6361,10 +5584,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -6374,9 +5593,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -6542,30 +5758,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -6697,24 +5889,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -6724,17 +5898,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -6744,10 +5907,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -6848,17 +6007,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -6868,10 +6016,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -7037,22 +6181,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -7062,30 +6190,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -7095,12 +6199,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -7180,18 +6278,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           },
@@ -7201,13 +6287,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "ConfirmationCode",
-                "StartsAt",
-                "EndsAt",
-                "Duration"
-              ],
               "type": "string"
             }
           },
@@ -7217,9 +6296,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -7387,18 +6463,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           }
@@ -7617,17 +6681,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -7637,24 +6690,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -7664,10 +6699,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -7739,22 +6770,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -7764,12 +6779,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -7824,12 +6833,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -7839,10 +6842,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -7852,9 +6851,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -8095,22 +7091,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -8120,12 +7100,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -8316,12 +7290,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -8331,10 +7299,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -8344,9 +7308,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -8586,10 +7547,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -8599,9 +7556,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -8704,22 +7658,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -8729,12 +7667,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -8789,30 +7721,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -8822,22 +7730,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -8847,12 +7739,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -8955,12 +7841,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -8970,10 +7850,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -8983,9 +7859,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -9275,10 +8148,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -9288,9 +8157,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -9456,30 +8322,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -9598,30 +8440,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -9631,22 +8449,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -9656,12 +8458,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -9768,12 +8564,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -9783,10 +8573,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -9796,9 +8582,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -10064,10 +8847,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -10077,9 +8856,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -10208,22 +8984,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -10233,12 +8993,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -10326,30 +9080,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -10468,30 +9198,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -10501,22 +9207,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -10526,12 +9216,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -10604,10 +9288,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -10617,9 +9297,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -10793,24 +9470,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -10820,17 +9479,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -10840,10 +9488,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -10944,17 +9588,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -10964,10 +9597,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -11133,22 +9762,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -11158,30 +9771,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -11191,12 +9780,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -11276,18 +9859,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           },
@@ -11297,13 +9868,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "ConfirmationCode",
-                "StartsAt",
-                "EndsAt",
-                "Duration"
-              ],
               "type": "string"
             }
           },
@@ -11313,9 +9877,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -11483,18 +10044,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           }
@@ -11760,24 +10309,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -11787,17 +10318,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -11807,10 +10327,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -11911,17 +10427,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -11931,10 +10436,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -12100,22 +10601,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -12125,30 +10610,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -12158,12 +10619,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -12243,18 +10698,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           },
@@ -12264,13 +10707,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "ConfirmationCode",
-                "StartsAt",
-                "EndsAt",
-                "Duration"
-              ],
               "type": "string"
             }
           },
@@ -12280,9 +10716,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -12450,18 +10883,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           }
@@ -12647,30 +11068,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -12680,22 +11077,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -12705,12 +11086,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -12787,22 +11162,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -12812,12 +11171,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -12944,12 +11297,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -12959,10 +11306,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -12972,9 +11315,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -13223,22 +11563,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -13248,12 +11572,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -13482,12 +11800,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -13497,10 +11809,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -13510,9 +11818,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -13802,10 +12107,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -13815,9 +12116,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -13946,22 +12244,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -13971,12 +12253,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -14027,22 +12303,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -14052,12 +12312,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -14120,30 +12374,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -14153,22 +12383,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -14178,12 +12392,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -14288,12 +12496,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -14303,10 +12505,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -14316,9 +12514,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -14614,10 +12809,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -14627,9 +12818,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -14761,22 +12949,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -14786,12 +12958,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -14843,22 +13009,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -14868,12 +13018,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -14963,30 +13107,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -15108,30 +13228,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -15141,22 +13237,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -15166,12 +13246,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -15258,30 +13332,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -15291,22 +13341,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -15316,12 +13350,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -15396,10 +13424,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -15409,9 +13433,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -15567,17 +13588,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -15587,24 +13597,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -15614,10 +13606,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -15839,24 +13827,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -15866,17 +13836,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -15886,10 +13845,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -15988,17 +13943,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -16008,10 +13952,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -16176,22 +14116,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -16201,30 +14125,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -16234,12 +14134,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -16316,18 +14210,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           },
@@ -16337,13 +14219,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "ConfirmationCode",
-                "StartsAt",
-                "EndsAt",
-                "Duration"
-              ],
               "type": "string"
             }
           },
@@ -16353,9 +14228,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -16522,18 +14394,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           }
@@ -16753,30 +14613,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -16786,22 +14622,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -16811,12 +14631,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -16919,22 +14733,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -16944,12 +14742,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -17097,12 +14889,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -17112,10 +14898,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -17125,9 +14907,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -17394,22 +15173,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -17419,12 +15182,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -17657,12 +15414,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -17672,10 +15423,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -17685,9 +15432,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -17953,10 +15697,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -17966,9 +15706,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -18097,22 +15834,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -18122,12 +15843,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -18178,22 +15893,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -18203,12 +15902,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -18271,30 +15964,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -18304,22 +15973,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -18329,12 +15982,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -18457,12 +16104,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -18472,10 +16113,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -18485,9 +16122,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -18801,10 +16435,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -18814,9 +16444,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -18969,22 +16596,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -18994,12 +16605,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -19058,22 +16663,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -19083,12 +16672,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -19192,30 +16775,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -19358,30 +16917,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -19391,22 +16926,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -19416,12 +16935,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -19522,30 +17035,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -19555,22 +17044,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -19580,12 +17053,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -19674,10 +17141,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -19687,9 +17150,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -19830,22 +17290,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -19855,12 +17299,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -19923,12 +17361,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -19938,10 +17370,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -19951,9 +17379,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -20220,22 +17645,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -20245,12 +17654,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -20483,12 +17886,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -20498,10 +17895,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -20511,9 +17904,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -20779,10 +18169,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -20792,9 +18178,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -20923,22 +18306,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -20948,12 +18315,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -21016,30 +18377,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -21049,22 +18386,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -21074,12 +18395,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -21202,12 +18517,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -21217,10 +18526,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -21230,9 +18535,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -21546,10 +18848,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -21559,9 +18857,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -21714,22 +19009,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -21739,12 +19018,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -21848,30 +19121,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -22014,30 +19263,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -22047,22 +19272,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -22072,12 +19281,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -22166,10 +19369,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -22179,9 +19378,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -22322,30 +19518,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -22355,22 +19527,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -22380,12 +19536,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -22504,12 +19654,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -22519,10 +19663,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -22532,9 +19672,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -22848,10 +19985,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -22861,9 +19994,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -23061,30 +20191,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -23240,24 +20346,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -23267,17 +20355,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -23287,10 +20364,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -23407,17 +20480,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -23427,10 +20489,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -23620,22 +20678,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -23645,30 +20687,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -23678,12 +20696,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -23771,18 +20783,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           },
@@ -23792,13 +20792,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "ConfirmationCode",
-                "StartsAt",
-                "EndsAt",
-                "Duration"
-              ],
               "type": "string"
             }
           },
@@ -23808,9 +20801,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -24002,18 +20992,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           }
@@ -24274,17 +21252,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -24294,24 +21261,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -24321,10 +21270,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -24424,22 +21369,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -24449,12 +21378,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -24517,12 +21440,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -24532,10 +21449,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -24545,9 +21458,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -24838,22 +21748,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -24863,12 +21757,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -25101,12 +21989,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -25116,10 +21998,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -25129,9 +22007,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -25421,10 +22296,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -25434,9 +22305,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -25565,22 +22433,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -25590,12 +22442,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -25658,30 +22504,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -25691,22 +22513,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -25716,12 +22522,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -25840,12 +22640,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -25855,10 +22649,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -25868,9 +22658,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -26208,10 +22995,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -26221,9 +23004,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -26421,30 +23201,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -26587,30 +23343,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -26620,22 +23352,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -26645,12 +23361,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -26773,12 +23483,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "Address desc",
-                "City",
-                "City desc"
-              ],
               "type": "string"
             }
           },
@@ -26788,10 +23492,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -26801,9 +23501,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -27117,10 +23814,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -27130,9 +23823,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -27285,22 +23975,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -27310,12 +23984,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -27419,30 +24087,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           }
@@ -27585,30 +24229,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -27618,22 +24238,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -27643,12 +24247,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -27737,10 +24335,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "Address",
-                "City"
-              ],
               "type": "string"
             }
           },
@@ -27750,9 +24344,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -27960,24 +24551,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -27987,17 +24560,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -28007,10 +24569,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -28127,17 +24685,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -28147,10 +24694,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -28340,22 +24883,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -28365,30 +24892,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -28398,12 +24901,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -28491,18 +24988,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           },
@@ -28512,13 +24997,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "ConfirmationCode",
-                "StartsAt",
-                "EndsAt",
-                "Duration"
-              ],
               "type": "string"
             }
           },
@@ -28528,9 +25006,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -28722,18 +25197,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           }
@@ -29047,24 +25510,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "TripId desc",
-                "ShareId",
-                "ShareId desc",
-                "Name",
-                "Name desc",
-                "Budget",
-                "Budget desc",
-                "Description",
-                "Description desc",
-                "Tags",
-                "Tags desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc"
-              ],
               "type": "string"
             }
           },
@@ -29074,17 +25519,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -29094,10 +25528,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -29214,17 +25644,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "TripId",
-                "ShareId",
-                "Name",
-                "Budget",
-                "Description",
-                "Tags",
-                "StartsAt",
-                "EndsAt",
-                "PlanItems"
-              ],
               "type": "string"
             }
           },
@@ -29234,10 +25653,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "PlanItems"
-              ],
               "type": "string"
             }
           }
@@ -29427,22 +25842,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -29452,30 +25851,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -29485,12 +25860,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -29578,18 +25947,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           },
@@ -29599,13 +25956,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "ConfirmationCode",
-                "StartsAt",
-                "EndsAt",
-                "Duration"
-              ],
               "type": "string"
             }
           },
@@ -29615,9 +25965,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*"
-              ],
               "type": "string"
             }
           }
@@ -29809,18 +26156,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "PlanItemId",
-                "PlanItemId desc",
-                "ConfirmationCode",
-                "ConfirmationCode desc",
-                "StartsAt",
-                "StartsAt desc",
-                "EndsAt",
-                "EndsAt desc",
-                "Duration",
-                "Duration desc"
-              ],
               "type": "string"
             }
           }
@@ -30087,30 +26422,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -30120,22 +26431,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -30145,12 +26440,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }
@@ -30259,30 +26548,6 @@
             "description": "Order items by property values",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "UserName desc",
-                "FirstName",
-                "FirstName desc",
-                "LastName",
-                "LastName desc",
-                "MiddleName",
-                "MiddleName desc",
-                "Gender",
-                "Gender desc",
-                "Age",
-                "Age desc",
-                "Emails",
-                "Emails desc",
-                "AddressInfo",
-                "AddressInfo desc",
-                "HomeAddress",
-                "HomeAddress desc",
-                "FavoriteFeature",
-                "FavoriteFeature desc",
-                "Features",
-                "Features desc"
-              ],
               "type": "string"
             }
           },
@@ -30292,22 +26557,6 @@
             "description": "Select properties to be returned",
             "type": "array",
             "items": {
-              "enum": [
-                "UserName",
-                "FirstName",
-                "LastName",
-                "MiddleName",
-                "Gender",
-                "Age",
-                "Emails",
-                "AddressInfo",
-                "HomeAddress",
-                "FavoriteFeature",
-                "Features",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           },
@@ -30317,12 +26566,6 @@
             "description": "Expand related entities",
             "type": "array",
             "items": {
-              "enum": [
-                "*",
-                "Friends",
-                "BestFriend",
-                "Trips"
-              ],
               "type": "string"
             }
           }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -25,28 +25,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - AirlineCode
-              - AirlineCode desc
-              - Name
-              - Name desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - AirlineCode
-              - Name
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -98,17 +88,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - AirlineCode
-              - Name
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -199,34 +184,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Name
-              - Name desc
-              - IcaoCode
-              - IcaoCode desc
-              - IataCode
-              - IataCode desc
-              - Location
-              - Location desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Name
-              - IcaoCode
-              - IataCode
-              - Location
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -278,19 +247,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Name
-              - IcaoCode
-              - IataCode
-              - Location
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -369,20 +331,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
-              - Loc
-              - EmergencyAuthority
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - EmergencyAuthority
             type: string
       responses:
         '200':
@@ -437,32 +391,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -562,28 +496,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -730,17 +654,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -866,32 +785,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -951,28 +850,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -1119,32 +1008,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -1274,28 +1143,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -1441,17 +1300,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -1523,32 +1377,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -1578,32 +1412,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -1636,61 +1450,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -1761,28 +1532,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -1965,17 +1726,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -2066,32 +1822,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -2127,32 +1863,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -2206,29 +1922,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -2306,61 +1999,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -2412,61 +2062,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -2515,17 +2122,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -2597,32 +2199,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -2655,28 +2237,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -2823,32 +2395,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -2978,28 +2530,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -3145,17 +2687,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -3227,32 +2764,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -3285,61 +2802,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -3410,28 +2884,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -3614,17 +3078,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -3715,32 +3174,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -3794,29 +3233,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -3894,61 +3310,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -3997,17 +3370,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -4082,61 +3450,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -4204,28 +3529,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -4408,17 +3723,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -4527,29 +3837,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -4636,48 +3923,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -4750,25 +4007,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -4884,61 +4128,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -4990,37 +4191,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - PlanItemId
-              - ConfirmationCode
-              - StartsAt
-              - EndsAt
-              - Duration
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -5136,17 +4318,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
       responses:
         '200':
@@ -5295,48 +4466,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -5386,32 +4527,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -5444,28 +4565,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -5628,32 +4739,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -5783,28 +4874,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -5966,17 +5047,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -6048,32 +5124,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -6106,61 +5162,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -6228,28 +5241,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -6448,17 +5451,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -6567,29 +5565,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -6667,61 +5642,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -6792,28 +5724,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -6996,17 +5918,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -7097,32 +6014,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -7176,29 +6073,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -7276,61 +6150,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -7379,17 +6210,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -7505,48 +6331,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -7619,25 +6415,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -7753,61 +6536,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -7859,37 +6599,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - PlanItemId
-              - ConfirmationCode
-              - StartsAt
-              - EndsAt
-              - Duration
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -8005,17 +6726,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
       responses:
         '200':
@@ -8196,48 +6906,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -8310,25 +6990,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -8444,61 +7111,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -8550,37 +7174,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - PlanItemId
-              - ConfirmationCode
-              - StartsAt
-              - EndsAt
-              - Duration
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -8696,17 +7301,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
       responses:
         '200':
@@ -8831,61 +7425,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -8937,32 +7488,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -9044,28 +7575,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -9229,32 +7750,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -9412,28 +7913,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -9632,17 +8123,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -9733,32 +8219,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -9794,32 +8260,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -9858,61 +8304,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -9980,28 +8383,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -10200,17 +8593,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -10301,32 +8689,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -10362,32 +8730,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -10441,29 +8789,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -10541,61 +8866,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -10647,61 +8929,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -10750,17 +8989,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -10861,48 +9095,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -11049,48 +9253,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -11160,25 +9334,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -11291,61 +9452,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -11394,37 +9512,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - PlanItemId
-              - ConfirmationCode
-              - StartsAt
-              - EndsAt
-              - Duration
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -11537,17 +9636,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
       responses:
         '200':
@@ -11689,61 +9777,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -11815,32 +9860,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -11940,28 +9965,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -12145,32 +10160,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -12331,28 +10326,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -12535,17 +10520,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -12636,32 +10616,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -12697,32 +10657,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -12761,61 +10701,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -12898,28 +10795,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -13138,17 +11025,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -13257,32 +11139,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -13324,32 +11186,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -13415,29 +11257,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -13533,61 +11352,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -13651,61 +11427,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -13766,17 +11499,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -13875,32 +11603,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -13939,28 +11647,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -14144,32 +11842,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -14330,28 +12008,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -14534,17 +12202,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -14635,32 +12298,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -14699,61 +12342,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -14836,28 +12436,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -15076,17 +12666,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -15195,32 +12780,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -15286,29 +12851,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -15404,61 +12946,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -15519,17 +13018,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -15623,61 +13117,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -15757,28 +13208,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -15997,17 +13438,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -16140,29 +13576,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -16267,48 +13680,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -16393,25 +13776,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -16545,61 +13915,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -16657,37 +13984,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - PlanItemId
-              - ConfirmationCode
-              - StartsAt
-              - EndsAt
-              - Duration
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -16821,17 +14129,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
       responses:
         '200':
@@ -17011,48 +14308,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -17122,32 +14389,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -17186,28 +14433,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -17407,32 +14644,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -17593,28 +14810,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -17813,17 +15020,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -17914,32 +15116,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -17978,61 +15160,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -18112,28 +15251,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -18368,17 +15497,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -18511,29 +15635,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -18629,61 +15730,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -18766,28 +15824,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - Address
-              - Address desc
-              - City
-              - City desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -19006,17 +16054,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -19125,32 +16168,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -19216,29 +16239,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
       responses:
         '200':
@@ -19334,61 +16334,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -19449,17 +16406,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - Address
-              - City
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -19600,48 +16552,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -19726,25 +16648,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -19878,61 +16787,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -19990,37 +16856,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - PlanItemId
-              - ConfirmationCode
-              - StartsAt
-              - EndsAt
-              - Duration
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -20154,17 +17001,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
       responses:
         '200':
@@ -20381,48 +17217,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - TripId
-              - TripId desc
-              - ShareId
-              - ShareId desc
-              - Name
-              - Name desc
-              - Budget
-              - Budget desc
-              - Description
-              - Description desc
-              - Tags
-              - Tags desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -20507,25 +17313,12 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - TripId
-              - ShareId
-              - Name
-              - Budget
-              - Description
-              - Tags
-              - StartsAt
-              - EndsAt
-              - PlanItems
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - PlanItems
             type: string
       responses:
         '200':
@@ -20659,61 +17452,18 @@ paths:
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $orderby
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -20771,37 +17521,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - PlanItemId
-              - ConfirmationCode
-              - StartsAt
-              - EndsAt
-              - Duration
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
             type: string
       responses:
         '200':
@@ -20935,17 +17666,6 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - PlanItemId
-              - PlanItemId desc
-              - ConfirmationCode
-              - ConfirmationCode desc
-              - StartsAt
-              - StartsAt desc
-              - EndsAt
-              - EndsAt desc
-              - Duration
-              - Duration desc
             type: string
       responses:
         '200':
@@ -21125,61 +17845,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':
@@ -21247,61 +17924,18 @@ paths:
           description: Order items by property values
           type: array
           items:
-            enum:
-              - UserName
-              - UserName desc
-              - FirstName
-              - FirstName desc
-              - LastName
-              - LastName desc
-              - MiddleName
-              - MiddleName desc
-              - Gender
-              - Gender desc
-              - Age
-              - Age desc
-              - Emails
-              - Emails desc
-              - AddressInfo
-              - AddressInfo desc
-              - HomeAddress
-              - HomeAddress desc
-              - FavoriteFeature
-              - FavoriteFeature desc
-              - Features
-              - Features desc
             type: string
         - in: query
           name: $select
           description: Select properties to be returned
           type: array
           items:
-            enum:
-              - UserName
-              - FirstName
-              - LastName
-              - MiddleName
-              - Gender
-              - Age
-              - Emails
-              - AddressInfo
-              - HomeAddress
-              - FavoriteFeature
-              - Features
-              - Friends
-              - BestFriend
-              - Trips
             type: string
         - in: query
           name: $expand
           description: Expand related entities
           type: array
           items:
-            enum:
-              - '*'
-              - Friends
-              - BestFriend
-              - Trips
             type: string
       responses:
         '200':

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -45,12 +45,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "AirlineCode",
-                  "AirlineCode desc",
-                  "Name",
-                  "Name desc"
-                ],
                 "type": "string"
               }
             }
@@ -65,10 +59,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "AirlineCode",
-                  "Name"
-                ],
                 "type": "string"
               }
             }
@@ -83,9 +73,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -164,10 +151,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "AirlineCode",
-                  "Name"
-                ],
                 "type": "string"
               }
             }
@@ -182,9 +165,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -343,16 +323,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Name",
-                  "Name desc",
-                  "IcaoCode",
-                  "IcaoCode desc",
-                  "IataCode",
-                  "IataCode desc",
-                  "Location",
-                  "Location desc"
-                ],
                 "type": "string"
               }
             }
@@ -367,12 +337,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Name",
-                  "IcaoCode",
-                  "IataCode",
-                  "Location"
-                ],
                 "type": "string"
               }
             }
@@ -387,9 +351,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -468,12 +429,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Name",
-                  "IcaoCode",
-                  "IataCode",
-                  "Location"
-                ],
                 "type": "string"
               }
             }
@@ -488,9 +443,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -617,12 +569,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City",
-                  "Loc",
-                  "EmergencyAuthority"
-                ],
                 "type": "string"
               }
             }
@@ -637,10 +583,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "EmergencyAuthority"
-                ],
                 "type": "string"
               }
             }
@@ -731,22 +673,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -761,12 +687,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -939,12 +859,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -959,10 +873,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -977,9 +887,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -1217,10 +1124,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -1235,9 +1138,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -1482,22 +1382,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -1512,12 +1396,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -1615,12 +1493,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -1635,10 +1507,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -1653,9 +1521,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -1873,22 +1738,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -1903,12 +1752,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -2105,12 +1948,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -2125,10 +1962,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -2143,9 +1976,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -2361,10 +2191,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -2379,9 +2205,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -2488,22 +2311,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -2518,12 +2325,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -2572,22 +2373,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -2602,12 +2387,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -2671,30 +2450,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -2709,22 +2464,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -2739,12 +2478,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -2861,12 +2594,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -2881,10 +2608,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -2899,9 +2622,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -3181,10 +2901,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -3199,9 +2915,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -3342,22 +3055,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -3372,12 +3069,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -3436,22 +3127,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -3466,12 +3141,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -3568,30 +3237,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -3717,30 +3362,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -3755,22 +3376,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -3785,12 +3390,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -3880,30 +3479,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -3918,22 +3493,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -3948,12 +3507,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -4027,10 +3580,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -4045,9 +3594,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -4154,22 +3700,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -4184,12 +3714,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -4252,12 +3776,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -4272,10 +3790,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -4290,9 +3804,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -4510,22 +4021,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -4540,12 +4035,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -4742,12 +4231,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -4762,10 +4245,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -4780,9 +4259,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -4998,10 +4474,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -5016,9 +4488,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -5125,22 +4594,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -5155,12 +4608,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -5224,30 +4671,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -5262,22 +4685,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -5292,12 +4699,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -5414,12 +4815,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -5434,10 +4829,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -5452,9 +4843,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -5734,10 +5122,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -5752,9 +5136,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -5895,22 +5276,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -5925,12 +5290,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -6027,30 +5386,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -6176,30 +5511,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -6214,22 +5525,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -6244,12 +5539,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -6323,10 +5612,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -6341,9 +5626,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -6465,30 +5747,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -6503,22 +5761,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -6533,12 +5775,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -6651,12 +5887,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -6671,10 +5901,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -6689,9 +5915,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -6971,10 +6194,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -6989,9 +6208,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -7170,30 +6386,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -7334,24 +6526,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -7366,17 +6540,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -7391,10 +6554,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -7497,17 +6656,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -7522,10 +6670,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -7704,22 +6848,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -7734,30 +6862,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -7772,12 +6876,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -7868,18 +6966,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -7894,13 +6980,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "ConfirmationCode",
-                  "StartsAt",
-                  "EndsAt",
-                  "Duration"
-                ],
                 "type": "string"
               }
             }
@@ -7915,9 +6994,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -8100,18 +7176,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -8347,17 +7411,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -8372,24 +7425,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -8404,10 +7439,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -8479,22 +7510,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -8509,12 +7524,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -8577,12 +7586,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -8597,10 +7600,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -8615,9 +7614,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -8863,22 +7859,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -8893,12 +7873,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -9095,12 +8069,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -9115,10 +8083,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -9133,9 +8097,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -9379,10 +8340,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -9397,9 +8354,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -9506,22 +8460,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -9536,12 +8474,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -9605,30 +8537,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -9643,22 +8551,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -9673,12 +8565,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -9791,12 +8677,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -9811,10 +8691,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -9829,9 +8705,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -10139,10 +9012,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -10157,9 +9026,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -10338,30 +9204,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -10487,30 +9329,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -10525,22 +9343,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -10555,12 +9357,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -10677,12 +9473,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -10697,10 +9487,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -10715,9 +9501,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -10997,10 +9780,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -11015,9 +9794,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -11158,22 +9934,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -11188,12 +9948,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -11290,30 +10044,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -11439,30 +10169,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -11477,22 +10183,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -11507,12 +10197,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -11586,10 +10270,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -11604,9 +10284,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -11794,24 +10471,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -11826,17 +10485,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -11851,10 +10499,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -11957,17 +10601,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -11982,10 +10615,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -12164,22 +10793,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -12194,30 +10807,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -12232,12 +10821,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -12328,18 +10911,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -12354,13 +10925,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "ConfirmationCode",
-                  "StartsAt",
-                  "EndsAt",
-                  "Duration"
-                ],
                 "type": "string"
               }
             }
@@ -12375,9 +10939,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -12560,18 +11121,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -12854,24 +11403,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -12886,17 +11417,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -12911,10 +11431,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -13017,17 +11533,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -13042,10 +11547,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -13224,22 +11725,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -13254,30 +11739,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -13292,12 +11753,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -13388,18 +11843,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -13414,13 +11857,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "ConfirmationCode",
-                  "StartsAt",
-                  "EndsAt",
-                  "Duration"
-                ],
                 "type": "string"
               }
             }
@@ -13435,9 +11871,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -13620,18 +12053,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -13832,30 +12253,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -13870,22 +12267,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -13900,12 +12281,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -13984,22 +12359,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -14014,12 +12373,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -14161,12 +12514,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -14181,10 +12528,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -14199,9 +12542,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -14469,22 +12809,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -14499,12 +12823,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -14753,12 +13071,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -14773,10 +13085,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -14791,9 +13099,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -15101,10 +13406,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -15119,9 +13420,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -15262,22 +13560,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -15292,12 +13574,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -15356,22 +13632,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -15386,12 +13646,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -15465,30 +13719,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -15503,22 +13733,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -15533,12 +13747,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -15657,12 +13865,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -15677,10 +13879,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -15695,9 +13893,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -16023,10 +14218,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -16041,9 +14232,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -16193,22 +14381,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16223,12 +14395,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16290,22 +14456,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16320,12 +14470,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16428,30 +14572,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -16588,30 +14708,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -16626,22 +14722,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16656,12 +14736,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16757,30 +14831,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -16795,22 +14845,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16825,12 +14859,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -16910,10 +14938,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -16928,9 +14952,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -17105,17 +15126,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -17130,24 +15140,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -17162,10 +15154,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -17413,24 +15401,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -17445,17 +15415,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -17470,10 +15429,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -17580,17 +15535,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -17605,10 +15549,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -17792,22 +15732,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -17822,30 +15746,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -17860,12 +15760,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -17955,18 +15849,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -17981,13 +15863,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "ConfirmationCode",
-                  "StartsAt",
-                  "EndsAt",
-                  "Duration"
-                ],
                 "type": "string"
               }
             }
@@ -18002,9 +15877,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -18192,18 +16064,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -18446,30 +16306,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -18484,22 +16320,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -18514,12 +16334,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -18626,22 +16440,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -18656,12 +16454,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -18824,12 +16616,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -18844,10 +16630,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -18862,9 +16644,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -19146,22 +16925,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -19176,12 +16939,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -19434,12 +17191,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -19454,10 +17205,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -19472,9 +17219,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -19754,10 +17498,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -19772,9 +17512,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -19915,22 +17652,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -19945,12 +17666,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -20009,22 +17724,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -20039,12 +17738,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -20118,30 +17811,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -20156,22 +17825,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -20186,12 +17839,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -20328,12 +17975,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -20348,10 +17989,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -20366,9 +18003,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -20708,10 +18342,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -20726,9 +18356,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -20899,22 +18526,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -20929,12 +18540,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21003,22 +18608,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21033,12 +18622,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21155,30 +18738,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -21336,30 +18895,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -21374,22 +18909,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21404,12 +18923,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21519,30 +19032,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -21557,22 +19046,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21587,12 +19060,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21686,10 +19153,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -21704,9 +19167,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -21861,22 +19321,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21891,12 +19335,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -21969,12 +19407,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -21989,10 +19421,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -22007,9 +19435,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -22291,22 +19716,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -22321,12 +19730,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -22579,12 +19982,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -22599,10 +19996,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -22617,9 +20010,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -22899,10 +20289,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -22917,9 +20303,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -23060,22 +20443,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -23090,12 +20457,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -23169,30 +20530,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -23207,22 +20544,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -23237,12 +20558,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -23379,12 +20694,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -23399,10 +20708,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -23417,9 +20722,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -23759,10 +21061,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -23777,9 +21075,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -23950,22 +21245,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -23980,12 +21259,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -24102,30 +21375,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -24283,30 +21532,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -24321,22 +21546,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -24351,12 +21560,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -24450,10 +21653,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -24468,9 +21667,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -24626,30 +21822,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -24664,22 +21836,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -24694,12 +21850,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -24832,12 +21982,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -24852,10 +21996,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -24870,9 +22010,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -25212,10 +22349,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -25230,9 +22363,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -25451,30 +22581,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -25647,24 +22753,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -25679,17 +22767,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -25704,10 +22781,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -25832,17 +22905,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -25857,10 +22919,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -26069,22 +23127,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -26099,30 +23141,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -26137,12 +23155,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -26243,18 +23255,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -26269,13 +23269,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "ConfirmationCode",
-                  "StartsAt",
-                  "EndsAt",
-                  "Duration"
-                ],
                 "type": "string"
               }
             }
@@ -26290,9 +23283,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -26505,18 +23495,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -26804,17 +23782,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -26829,24 +23796,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -26861,10 +23810,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -26972,22 +23917,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -27002,12 +23931,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -27080,12 +24003,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -27100,10 +24017,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -27118,9 +24031,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -27430,22 +24340,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -27460,12 +24354,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -27718,12 +24606,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -27738,10 +24620,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -27756,9 +24634,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -28066,10 +24941,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -28084,9 +24955,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -28227,22 +25095,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -28257,12 +25109,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -28336,30 +25182,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -28374,22 +25196,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -28404,12 +25210,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -28542,12 +25342,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -28562,10 +25356,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -28580,9 +25370,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -28950,10 +25737,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -28968,9 +25751,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -29189,30 +25969,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -29370,30 +26126,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -29408,22 +26140,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -29438,12 +26154,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -29580,12 +26290,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "Address desc",
-                  "City",
-                  "City desc"
-                ],
                 "type": "string"
               }
             }
@@ -29600,10 +26304,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -29618,9 +26318,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -29960,10 +26657,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -29978,9 +26671,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -30151,22 +26841,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -30181,12 +26855,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -30303,30 +26971,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -30484,30 +27128,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -30522,22 +27142,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -30552,12 +27156,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -30651,10 +27249,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "Address",
-                  "City"
-                ],
                 "type": "string"
               }
             }
@@ -30669,9 +27263,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -30905,24 +27496,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -30937,17 +27510,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -30962,10 +27524,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -31090,17 +27648,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -31115,10 +27662,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -31327,22 +27870,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -31357,30 +27884,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -31395,12 +27898,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -31501,18 +27998,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -31527,13 +28012,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "ConfirmationCode",
-                  "StartsAt",
-                  "EndsAt",
-                  "Duration"
-                ],
                 "type": "string"
               }
             }
@@ -31548,9 +28026,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -31763,18 +28238,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -32119,24 +28582,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "TripId desc",
-                  "ShareId",
-                  "ShareId desc",
-                  "Name",
-                  "Name desc",
-                  "Budget",
-                  "Budget desc",
-                  "Description",
-                  "Description desc",
-                  "Tags",
-                  "Tags desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc"
-                ],
                 "type": "string"
               }
             }
@@ -32151,17 +28596,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -32176,10 +28610,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -32304,17 +28734,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "TripId",
-                  "ShareId",
-                  "Name",
-                  "Budget",
-                  "Description",
-                  "Tags",
-                  "StartsAt",
-                  "EndsAt",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -32329,10 +28748,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "PlanItems"
-                ],
                 "type": "string"
               }
             }
@@ -32541,22 +28956,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -32571,30 +28970,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -32609,12 +28984,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -32715,18 +29084,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -32741,13 +29098,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "ConfirmationCode",
-                  "StartsAt",
-                  "EndsAt",
-                  "Duration"
-                ],
                 "type": "string"
               }
             }
@@ -32762,9 +29112,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*"
-                ],
                 "type": "string"
               }
             }
@@ -32977,18 +29324,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "PlanItemId",
-                  "PlanItemId desc",
-                  "ConfirmationCode",
-                  "ConfirmationCode desc",
-                  "StartsAt",
-                  "StartsAt desc",
-                  "EndsAt",
-                  "EndsAt desc",
-                  "Duration",
-                  "Duration desc"
-                ],
                 "type": "string"
               }
             }
@@ -33280,30 +29615,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -33318,22 +29629,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -33348,12 +29643,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -33471,30 +29760,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "UserName desc",
-                  "FirstName",
-                  "FirstName desc",
-                  "LastName",
-                  "LastName desc",
-                  "MiddleName",
-                  "MiddleName desc",
-                  "Gender",
-                  "Gender desc",
-                  "Age",
-                  "Age desc",
-                  "Emails",
-                  "Emails desc",
-                  "AddressInfo",
-                  "AddressInfo desc",
-                  "HomeAddress",
-                  "HomeAddress desc",
-                  "FavoriteFeature",
-                  "FavoriteFeature desc",
-                  "Features",
-                  "Features desc"
-                ],
                 "type": "string"
               }
             }
@@ -33509,22 +29774,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "UserName",
-                  "FirstName",
-                  "LastName",
-                  "MiddleName",
-                  "Gender",
-                  "Age",
-                  "Emails",
-                  "AddressInfo",
-                  "HomeAddress",
-                  "FavoriteFeature",
-                  "Features",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }
@@ -33539,12 +29788,6 @@
               "uniqueItems": true,
               "type": "array",
               "items": {
-                "enum": [
-                  "*",
-                  "Friends",
-                  "BestFriend",
-                  "Trips"
-                ],
                 "type": "string"
               }
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -28,11 +28,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - AirlineCode
-                - AirlineCode desc
-                - Name
-                - Name desc
               type: string
         - name: $select
           in: query
@@ -43,9 +38,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - AirlineCode
-                - Name
               type: string
         - name: $expand
           in: query
@@ -56,8 +48,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -110,9 +100,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - AirlineCode
-                - Name
               type: string
         - name: $expand
           in: query
@@ -123,8 +110,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -223,15 +208,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Name
-                - Name desc
-                - IcaoCode
-                - IcaoCode desc
-                - IataCode
-                - IataCode desc
-                - Location
-                - Location desc
               type: string
         - name: $select
           in: query
@@ -242,11 +218,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Name
-                - IcaoCode
-                - IataCode
-                - Location
               type: string
         - name: $expand
           in: query
@@ -257,8 +228,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -311,11 +280,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Name
-                - IcaoCode
-                - IataCode
-                - Location
               type: string
         - name: $expand
           in: query
@@ -326,8 +290,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -412,11 +374,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
-                - Loc
-                - EmergencyAuthority
               type: string
         - name: $expand
           in: query
@@ -427,9 +384,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - EmergencyAuthority
               type: string
       responses:
         '200':
@@ -490,21 +444,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -515,11 +454,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -630,11 +564,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -645,9 +574,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -658,8 +584,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -813,9 +737,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -826,8 +747,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -975,21 +894,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -1000,11 +904,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -1067,11 +966,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -1082,9 +976,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -1095,8 +986,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -1244,21 +1133,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -1269,11 +1143,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -1407,11 +1276,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -1422,9 +1286,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -1435,8 +1296,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -1582,9 +1441,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -1595,8 +1451,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -1671,21 +1525,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -1696,11 +1535,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -1734,21 +1568,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -1759,11 +1578,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -1802,29 +1616,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -1835,21 +1626,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -1860,11 +1636,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -1941,11 +1712,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -1956,9 +1722,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -1969,8 +1732,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -2160,9 +1921,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -2173,8 +1931,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -2272,21 +2028,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -2297,11 +2038,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -2342,21 +2078,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -2367,11 +2088,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -2431,29 +2147,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -2537,29 +2230,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -2570,21 +2240,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -2595,11 +2250,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -2655,29 +2305,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -2688,21 +2315,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -2713,11 +2325,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -2767,9 +2374,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -2780,8 +2384,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -2856,21 +2458,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -2881,11 +2468,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -2923,11 +2505,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -2938,9 +2515,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -2951,8 +2525,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -3100,21 +2672,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -3125,11 +2682,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -3263,11 +2815,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -3278,9 +2825,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -3291,8 +2835,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -3438,9 +2980,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -3451,8 +2990,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -3527,21 +3064,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -3552,11 +3074,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -3595,29 +3112,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -3628,21 +3122,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -3653,11 +3132,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -3734,11 +3208,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -3749,9 +3218,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -3762,8 +3228,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -3953,9 +3417,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -3966,8 +3427,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -4065,21 +3524,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -4090,11 +3534,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -4154,29 +3593,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -4260,29 +3676,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -4293,21 +3686,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -4318,11 +3696,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -4372,9 +3745,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -4385,8 +3755,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -4466,29 +3834,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -4499,21 +3844,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -4524,11 +3854,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -4602,11 +3927,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -4617,9 +3937,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -4630,8 +3947,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -4821,9 +4136,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -4834,8 +4146,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -4952,29 +4262,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -5068,23 +4355,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $select
           in: query
@@ -5095,16 +4365,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -5115,9 +4375,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -5191,16 +4448,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -5211,9 +4458,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -5336,21 +4580,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $orderby
           in: query
@@ -5361,29 +4590,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $expand
           in: query
@@ -5394,11 +4600,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -5457,17 +4658,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
         - name: $select
           in: query
@@ -5478,12 +4668,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - ConfirmationCode
-                - StartsAt
-                - EndsAt
-                - Duration
               type: string
         - name: $expand
           in: query
@@ -5494,8 +4678,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -5620,17 +4802,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
       responses:
         '200':
@@ -5790,16 +4961,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $orderby
           in: query
@@ -5810,23 +4971,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $expand
           in: query
@@ -5837,9 +4981,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -5891,21 +5032,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -5916,11 +5042,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -5958,11 +5079,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -5973,9 +5089,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -5986,8 +5099,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -6153,21 +5264,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -6178,11 +5274,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -6316,11 +5407,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -6331,9 +5417,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -6344,8 +5427,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -6509,9 +5590,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -6522,8 +5600,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -6598,21 +5674,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -6623,11 +5684,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -6666,29 +5722,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -6699,21 +5732,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -6724,11 +5742,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -6802,11 +5815,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -6817,9 +5825,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -6830,8 +5835,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -7039,9 +6042,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -7052,8 +6052,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -7170,29 +6168,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -7276,29 +6251,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -7309,21 +6261,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -7334,11 +6271,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -7415,11 +6347,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -7430,9 +6357,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -7443,8 +6367,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -7634,9 +6556,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -7647,8 +6566,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -7746,21 +6663,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -7771,11 +6673,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -7835,29 +6732,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -7941,29 +6815,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -7974,21 +6825,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -7999,11 +6835,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -8053,9 +6884,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -8066,8 +6894,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -8190,23 +7016,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $select
           in: query
@@ -8217,16 +7026,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -8237,9 +7036,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -8313,16 +7109,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -8333,9 +7119,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -8458,21 +7241,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $orderby
           in: query
@@ -8483,29 +7251,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $expand
           in: query
@@ -8516,11 +7261,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -8579,17 +7319,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
         - name: $select
           in: query
@@ -8600,12 +7329,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - ConfirmationCode
-                - StartsAt
-                - EndsAt
-                - Duration
               type: string
         - name: $expand
           in: query
@@ -8616,8 +7339,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -8742,17 +7463,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
       responses:
         '200':
@@ -8945,23 +7655,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $select
           in: query
@@ -8972,16 +7665,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -8992,9 +7675,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -9068,16 +7748,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -9088,9 +7758,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -9213,21 +7880,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $orderby
           in: query
@@ -9238,29 +7890,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $expand
           in: query
@@ -9271,11 +7900,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -9334,17 +7958,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
         - name: $select
           in: query
@@ -9355,12 +7968,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - ConfirmationCode
-                - StartsAt
-                - EndsAt
-                - Duration
               type: string
         - name: $expand
           in: query
@@ -9371,8 +7978,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -9497,17 +8102,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
       responses:
         '200':
@@ -9642,29 +8236,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -9675,21 +8246,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -9700,11 +8256,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -9757,21 +8308,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -9782,11 +8318,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -9876,11 +8407,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -9891,9 +8417,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -9904,8 +8427,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -10079,21 +8600,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -10104,11 +8610,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -10277,11 +8778,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -10292,9 +8788,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -10305,8 +8798,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -10514,9 +9005,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -10527,8 +9015,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -10626,21 +9112,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -10651,11 +9122,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -10696,21 +9162,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -10721,11 +9172,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -10771,29 +9217,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -10804,21 +9227,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -10829,11 +9237,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -10909,11 +9312,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -10924,9 +9322,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -10937,8 +9332,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -11152,9 +9545,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -11165,8 +9555,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -11267,21 +9655,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -11292,11 +9665,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -11338,21 +9706,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -11363,11 +9716,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -11429,29 +9777,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -11539,29 +9864,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -11572,21 +9874,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -11597,11 +9884,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -11659,29 +9941,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -11692,21 +9951,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -11717,11 +9961,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -11773,9 +10012,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -11786,8 +10022,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -11899,16 +10133,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $orderby
           in: query
@@ -11919,23 +10143,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $expand
           in: query
@@ -11946,9 +10153,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -12110,23 +10314,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $select
           in: query
@@ -12137,16 +10324,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -12157,9 +10334,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -12233,16 +10407,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -12253,9 +10417,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -12378,21 +10539,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $orderby
           in: query
@@ -12403,29 +10549,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $expand
           in: query
@@ -12436,11 +10559,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -12497,17 +10615,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
         - name: $select
           in: query
@@ -12518,12 +10625,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - ConfirmationCode
-                - StartsAt
-                - EndsAt
-                - Duration
               type: string
         - name: $expand
           in: query
@@ -12534,8 +10635,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -12660,17 +10759,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
       responses:
         '200':
@@ -12826,29 +10914,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -12859,21 +10924,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -12884,11 +10934,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -12962,21 +11007,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -12987,11 +11017,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -13099,11 +11124,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -13114,9 +11134,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -13127,8 +11144,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -13320,21 +11335,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -13345,11 +11345,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -13521,11 +11516,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -13536,9 +11526,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -13549,8 +11536,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -13740,9 +11725,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -13753,8 +11735,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -13852,21 +11832,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -13877,11 +11842,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -13922,21 +11882,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -13947,11 +11892,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -13997,29 +11937,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -14030,21 +11947,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -14055,11 +11957,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -14150,11 +12047,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -14165,9 +12057,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -14178,8 +12067,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -14411,9 +12298,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -14424,8 +12308,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -14544,21 +12426,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -14569,11 +12436,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -14621,21 +12483,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -14646,11 +12493,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -14724,29 +12566,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -14852,29 +12671,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -14885,21 +12681,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -14910,11 +12691,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -14984,29 +12760,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -15017,21 +12770,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -15042,11 +12780,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -15110,9 +12843,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -15123,8 +12853,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -15231,21 +12959,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -15256,11 +12969,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -15305,11 +13013,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -15320,9 +13023,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -15333,8 +13033,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -15526,21 +13224,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -15551,11 +13234,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -15727,11 +13405,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -15742,9 +13415,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -15755,8 +13425,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -15946,9 +13614,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -15959,8 +13624,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -16058,21 +13721,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -16083,11 +13731,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -16133,29 +13776,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -16166,21 +13786,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -16191,11 +13796,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -16286,11 +13886,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -16301,9 +13896,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -16314,8 +13906,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -16547,9 +14137,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -16560,8 +14147,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -16680,21 +14265,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -16705,11 +14275,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -16783,29 +14348,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -16911,29 +14453,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -16944,21 +14463,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -16969,11 +14473,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -17037,9 +14536,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -17050,8 +14546,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -17154,29 +14648,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -17187,21 +14658,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -17212,11 +14668,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -17304,11 +14755,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -17319,9 +14765,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -17332,8 +14775,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -17565,9 +15006,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -17578,8 +15016,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -17724,29 +15160,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -17862,23 +15275,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $select
           in: query
@@ -17889,16 +15285,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -17909,9 +15295,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -18000,16 +15383,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -18020,9 +15393,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -18166,21 +15536,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $orderby
           in: query
@@ -18191,29 +15546,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $expand
           in: query
@@ -18224,11 +15556,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -18294,17 +15621,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
         - name: $select
           in: query
@@ -18315,12 +15631,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - ConfirmationCode
-                - StartsAt
-                - EndsAt
-                - Duration
               type: string
         - name: $expand
           in: query
@@ -18331,8 +15641,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -18478,17 +15786,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
       responses:
         '200':
@@ -18684,16 +15981,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $orderby
           in: query
@@ -18704,23 +15991,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $expand
           in: query
@@ -18731,9 +16001,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -18809,21 +16076,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -18834,11 +16086,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -18883,11 +16130,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -18898,9 +16140,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -18911,8 +16150,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -19122,21 +16359,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -19147,11 +16369,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -19323,11 +16540,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -19338,9 +16550,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -19351,8 +16560,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -19560,9 +16767,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -19573,8 +16777,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -19672,21 +16874,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -19697,11 +16884,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -19747,29 +16929,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -19780,21 +16939,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -19805,11 +16949,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -19897,11 +17036,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -19912,9 +17046,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -19925,8 +17056,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -20176,9 +17305,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -20189,8 +17315,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -20335,29 +17459,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -20463,29 +17564,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -20496,21 +17574,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -20521,11 +17584,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -20616,11 +17674,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - Address desc
-                - City
-                - City desc
               type: string
         - name: $select
           in: query
@@ -20631,9 +17684,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -20644,8 +17694,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -20877,9 +17925,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -20890,8 +17935,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -21010,21 +18053,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -21035,11 +18063,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -21113,29 +18136,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
       responses:
         '200':
@@ -21241,29 +18241,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -21274,21 +18251,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -21299,11 +18261,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -21367,9 +18324,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - Address
-                - City
               type: string
         - name: $expand
           in: query
@@ -21380,8 +18334,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -21535,23 +18487,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $select
           in: query
@@ -21562,16 +18497,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -21582,9 +18507,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -21673,16 +18595,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -21693,9 +18605,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -21839,21 +18748,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $orderby
           in: query
@@ -21864,29 +18758,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $expand
           in: query
@@ -21897,11 +18768,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -21967,17 +18833,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
         - name: $select
           in: query
@@ -21988,12 +18843,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - ConfirmationCode
-                - StartsAt
-                - EndsAt
-                - Duration
               type: string
         - name: $expand
           in: query
@@ -22004,8 +18853,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -22151,17 +18998,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
       responses:
         '200':
@@ -22397,23 +19233,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - TripId desc
-                - ShareId
-                - ShareId desc
-                - Name
-                - Name desc
-                - Budget
-                - Budget desc
-                - Description
-                - Description desc
-                - Tags
-                - Tags desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
               type: string
         - name: $select
           in: query
@@ -22424,16 +19243,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -22444,9 +19253,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -22535,16 +19341,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - TripId
-                - ShareId
-                - Name
-                - Budget
-                - Description
-                - Tags
-                - StartsAt
-                - EndsAt
-                - PlanItems
               type: string
         - name: $expand
           in: query
@@ -22555,9 +19351,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - PlanItems
               type: string
       responses:
         '200':
@@ -22701,21 +19494,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $orderby
           in: query
@@ -22726,29 +19504,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $expand
           in: query
@@ -22759,11 +19514,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -22829,17 +19579,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
         - name: $select
           in: query
@@ -22850,12 +19589,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - ConfirmationCode
-                - StartsAt
-                - EndsAt
-                - Duration
               type: string
         - name: $expand
           in: query
@@ -22866,8 +19599,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
               type: string
       responses:
         '200':
@@ -23013,17 +19744,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - PlanItemId
-                - PlanItemId desc
-                - ConfirmationCode
-                - ConfirmationCode desc
-                - StartsAt
-                - StartsAt desc
-                - EndsAt
-                - EndsAt desc
-                - Duration
-                - Duration desc
               type: string
       responses:
         '200':
@@ -23218,29 +19938,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -23251,21 +19948,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -23276,11 +19958,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':
@@ -23354,29 +20031,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - UserName desc
-                - FirstName
-                - FirstName desc
-                - LastName
-                - LastName desc
-                - MiddleName
-                - MiddleName desc
-                - Gender
-                - Gender desc
-                - Age
-                - Age desc
-                - Emails
-                - Emails desc
-                - AddressInfo
-                - AddressInfo desc
-                - HomeAddress
-                - HomeAddress desc
-                - FavoriteFeature
-                - FavoriteFeature desc
-                - Features
-                - Features desc
               type: string
         - name: $select
           in: query
@@ -23387,21 +20041,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - UserName
-                - FirstName
-                - LastName
-                - MiddleName
-                - Gender
-                - Age
-                - Emails
-                - AddressInfo
-                - HomeAddress
-                - FavoriteFeature
-                - Features
-                - Friends
-                - BestFriend
-                - Trips
               type: string
         - name: $expand
           in: query
@@ -23412,11 +20051,6 @@ paths:
             uniqueItems: true
             type: array
             items:
-              enum:
-                - '*'
-                - Friends
-                - BestFriend
-                - Trips
               type: string
       responses:
         '200':


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/197

This PR:
- Proposes a new convert setting: `UseStringArrayForQueryOptionsSchema` for toggling between generating schemas 
of query options of type string array or enums.
- Uses the above convert setting when generating schemas of query options: `$select`, `$expand` and `$orderby`
- Updates tests to validate the above.
- Updates release notes