### PR TITLE
[Feature] Adds ability to change the response or request body content media type based on custom annotation properties

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.0-preview.9</Version>
+    <Version>1.6.0-preview.10</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -31,6 +31,7 @@
 - Use alternate keys in the generation of operation ids of operations and navigation property alternate paths #488
 - Fixes operation ids of paths with type cast segments #492
 - Uses convert setting to toggle between generating query options schemas of type string array or enums #197
+- Adds ability to change the response or request body content media type based on custom annotation properties #405
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -149,7 +149,7 @@ namespace Microsoft.OpenApi.OData.Operation
             }
             else
             {
-                // Add annotated request content mime types
+                // Add the annotated request content media types
                 IEnumerable<string> mediaTypes = _insertRestrictions?.RequestContentTypes;
                 if (mediaTypes != null)
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -136,7 +136,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 }
                 else
                 {
-                    // Default content type
+                    // Default stream content type
                     content.Add(Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
                     {
                         Schema = new OpenApiSchema
@@ -147,11 +147,29 @@ namespace Microsoft.OpenApi.OData.Operation
                     });
                 }
             }
-
-            content.Add(Constants.ApplicationJsonMediaType, new OpenApiMediaType
+            else
             {
-                Schema = schema
-            });
+                // Add annotated request content mime types
+                IEnumerable<string> mediaTypes = _insertRestrictions?.RequestContentTypes;
+                if (mediaTypes != null)
+                {
+                    foreach (string mediaType in mediaTypes)
+                    {
+                        content.Add(mediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        });
+                    }
+                }
+                else
+                {
+                    // Default content type
+                    content.Add(Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                    {
+                        Schema = schema
+                    });
+                }                
+            }            
 
             return content;
         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OpenApi.OData.Operation
             var content = new Dictionary<string, OpenApiMediaType>();
             IEnumerable<string> mediaTypes = _updateRestrictions?.RequestContentTypes;
 
-            // Add the respective content types
+            // Add the annotated request content media types
             if (mediaTypes != null)
             {
                 foreach (string mediaType in mediaTypes)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -64,18 +64,39 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 Required = true,
                 Description = "New property values",
-                Content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = GetOpenApiSchema()
-                        }
-                    }
-                }
+                Content = GetContent()
             };
 
             base.SetRequestBody(operation);
+        }
+
+        protected IDictionary<string, OpenApiMediaType> GetContent()
+        {
+            OpenApiSchema schema = GetOpenApiSchema();
+            var content = new Dictionary<string, OpenApiMediaType>();
+            IEnumerable<string> mediaTypes = _updateRestrictions?.RequestContentTypes;
+
+            // Add the respective content types
+            if (mediaTypes != null)
+            {
+                foreach (string mediaType in mediaTypes)
+                {
+                    content.Add(mediaType, new OpenApiMediaType
+                    {
+                        Schema = schema
+                    });
+                }
+            }
+            else
+            {
+                // Default content type
+                content.Add(Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                {
+                    Schema = schema
+                });
+            };
+
+            return content;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -139,17 +139,16 @@ namespace Microsoft.OpenApi.OData.Operation
             };
         }
 
-        protected IDictionary<string, OpenApiMediaType> GetContent(OpenApiSchema schema = null, IEnumerable<string> mimeTypes = null)
+        protected IDictionary<string, OpenApiMediaType> GetContent(OpenApiSchema schema = null, IEnumerable<string> mediaTypes = null)
         {
             schema ??= GetOpenApiSchema();
             var content = new Dictionary<string, OpenApiMediaType>();
 
-            // Add the respective content types
-            if (mimeTypes != null)
+            if (mediaTypes != null)
             {
-                foreach (string item in mimeTypes)
+                foreach (string mediaType in mediaTypes)
                 {
-                    content.Add(item, new OpenApiMediaType
+                    content.Add(mediaType, new OpenApiMediaType
                     {
                         Schema = schema
                     });

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Any;
@@ -135,6 +136,47 @@ namespace Microsoft.OpenApi.OData.Operation
                 CapabilitiesConstants.DeleteRestrictions => Restriction?.DeleteRestrictions ??
                                         Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions),
                 _ => null,
+            };
+        }
+
+        protected IDictionary<string, OpenApiMediaType> GetContent(OpenApiSchema schema = null, IEnumerable<string> mimeTypes = null)
+        {
+            schema ??= GetOpenApiSchema();
+            var content = new Dictionary<string, OpenApiMediaType>();
+
+            // Add the respective content types
+            if (mimeTypes != null)
+            {
+                foreach (string item in mimeTypes)
+                {
+                    content.Add(item, new OpenApiMediaType
+                    {
+                        Schema = schema
+                    });
+                }
+            }
+            else
+            {
+                // Default content type
+                content.Add(Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                {
+                    Schema = schema
+                });
+            };
+
+            return content;
+        }
+
+        protected OpenApiSchema GetOpenApiSchema()
+        {
+            return new OpenApiSchema
+            {
+                UnresolvedReference = true,
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.Schema,
+                    Id = NavigationProperty.ToEntityType().FullName()
+                }
             };
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
@@ -61,32 +60,11 @@ namespace Microsoft.OpenApi.OData.Operation
                 schema = EdmModelHelper.GetDerivedTypesReferenceSchema(NavigationProperty.ToEntityType(), Context.Model);
             }
 
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    UnresolvedReference = true,
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = NavigationProperty.ToEntityType().FullName()
-                    }
-                };
-            }
-
             operation.RequestBody = new OpenApiRequestBody
             {
                 Required = true,
                 Description = "New navigation property",
-                Content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                }
+                Content = GetContent(schema, _insertRestriction.RequestContentTypes)
             };
 
             base.SetRequestBody(operation);
@@ -102,19 +80,6 @@ namespace Microsoft.OpenApi.OData.Operation
                 schema = EdmModelHelper.GetDerivedTypesReferenceSchema(NavigationProperty.ToEntityType(), Context.Model);
             }
 
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    UnresolvedReference = true,
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = NavigationProperty.ToEntityType().FullName()
-                    }
-                };
-            }
-
             operation.Responses = new OpenApiResponses
             {
                 {
@@ -122,23 +87,14 @@ namespace Microsoft.OpenApi.OData.Operation
                     new OpenApiResponse
                     {
                         Description = "Created navigation property.",
-                        Content = new Dictionary<string, OpenApiMediaType>
-                        {
-                            {
-                                Constants.ApplicationJsonMediaType,
-                                new OpenApiMediaType
-                                {
-                                    Schema = schema
-                                }
-                            }
-                        }
+                        Content = GetContent(schema, _insertRestriction.ResponseContentTypes)
                     }
                 }
             };
             operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
-        }
+        }        
 
         protected override void SetSecurity(OpenApiOperation operation)
         {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OpenApi.OData.Operation
             operation.AddErrorResponses(Context.Settings, false);
 
             base.SetResponses(operation);
-        }        
+        }
 
         protected override void SetSecurity(OpenApiOperation operation)
         {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyPostOperationHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 Required = true,
                 Description = "New navigation property",
-                Content = GetContent(schema, _insertRestriction.RequestContentTypes)
+                Content = GetContent(schema, _insertRestriction?.RequestContentTypes)
             };
 
             base.SetRequestBody(operation);
@@ -87,7 +87,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     new OpenApiResponse
                     {
                         Description = "Created navigation property.",
-                        Content = GetContent(schema, _insertRestriction.ResponseContentTypes)
+                        Content = GetContent(schema, _insertRestriction?.ResponseContentTypes)
                     }
                 }
             };

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 Required = true,
                 Description = "New navigation property values",
-                Content = GetContent(schema, _updateRestriction.RequestContentTypes)
+                Content = GetContent(schema, _updateRestriction?.RequestContentTypes)
             };
 
             base.SetRequestBody(operation);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -50,20 +50,18 @@ namespace Microsoft.OpenApi.OData.Operation
 
         /// <inheritdoc/>
         protected override void SetRequestBody(OpenApiOperation operation)
-        {            
+        {
+            OpenApiSchema schema = null;
+            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(NavigationProperty.ToEntityType(), Context.Model);
+            }
+
             operation.RequestBody = new OpenApiRequestBody
             {
                 Required = true,
                 Description = "New navigation property values",
-                Content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = GetOpenApiSchema()
-                        }
-                    }
-                }
+                Content = GetContent(schema, _updateRestriction.RequestContentTypes)
             };
 
             base.SetRequestBody(operation);
@@ -102,24 +100,6 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 AppendCustomParameters(operation, _updateRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
-        }
-
-        private OpenApiSchema GetOpenApiSchema()
-        {           
-            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
-            {
-                return EdmModelHelper.GetDerivedTypesReferenceSchema(NavigationProperty.ToEntityType(), Context.Model);
-            }
-
-            return new OpenApiSchema
-            {
-                UnresolvedReference = true,
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.Schema,
-                    Id = NavigationProperty.ToEntityType().FullName()
-                }
-            };
-        }
+        }        
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -100,6 +100,6 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 AppendCustomParameters(operation, _updateRestriction.CustomQueryOptions, ParameterLocation.Query);
             }
-        }        
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/InsertRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/InsertRestrictionsType.cs
@@ -79,6 +79,18 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         public bool IsInsertable => Insertable == null || Insertable.Value == true;
 
         /// <summary>
+        /// Lists the MIME types acceptable for the request content
+        /// </summary>
+        /// <remarks>This is not an official OASIS standard property.</remarks>
+        public IList<string> RequestContentTypes { get; private set; }
+
+        /// <summary>
+        /// Lists the MIME types acceptable for the response content
+        /// </summary>
+        /// <remarks>This is not an official OASIS standard property.</remarks>
+        public IList<string> ResponseContentTypes { get; private set; }
+
+        /// <summary>
         /// Test the input navigation property do not allow deep insert.
         /// </summary>
         /// <param name="navigationPropertyPath">The input navigation property path.</param>
@@ -127,6 +139,12 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
 
             // LongDescription
             LongDescription = record.GetString("LongDescription");
+
+            // RequestContentTypes
+            RequestContentTypes = record.GetCollection("RequestContentTypes");
+
+            // ResponseContentTypes
+            ResponseContentTypes = record.GetCollection("ResponseContentTypes");
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/InsertRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/InsertRestrictionsType.cs
@@ -79,13 +79,13 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         public bool IsInsertable => Insertable == null || Insertable.Value == true;
 
         /// <summary>
-        /// Lists the MIME types acceptable for the request content
+        /// Lists the media types acceptable for the request content
         /// </summary>
         /// <remarks>This is not an official OASIS standard property.</remarks>
         public IList<string> RequestContentTypes { get; private set; }
 
         /// <summary>
-        /// Lists the MIME types acceptable for the response content
+        /// Lists the media types acceptable for the response content
         /// </summary>
         /// <remarks>This is not an official OASIS standard property.</remarks>
         public IList<string> ResponseContentTypes { get; private set; }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// <summary>
         /// Gets the navigation properties which do not allow rebinding.
         /// </summary>
-        public IList<string> NonUpdatableNavigationProperties { get; private set; }       
+        public IList<string> NonUpdatableNavigationProperties { get; private set; } 
 
         /// <summary>
         /// Gets the maximum number of navigation properties that can be traversed when addressing the collection or entity to update.

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// <summary>
         /// Gets the navigation properties which do not allow rebinding.
         /// </summary>
-        public IList<string> NonUpdatableNavigationProperties { get; private set; } 
+        public IList<string> NonUpdatableNavigationProperties { get; private set; }
 
         /// <summary>
         /// Gets the maximum number of navigation properties that can be traversed when addressing the collection or entity to update.
@@ -129,13 +129,13 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         public bool IsUpdateMethodPut => UpdateMethod.HasValue && UpdateMethod.Value == HttpMethod.PUT;
 
         /// <summary>
-        /// Lists the MIME types acceptable for the request content
+        /// Lists the media types acceptable for the request content
         /// </summary>
         /// <remarks>This is not an official OASIS standard property.</remarks>
         public IList<string> RequestContentTypes { get; private set; }
 
         /// <summary>
-        /// Lists the MIME types acceptable for the response content
+        /// Lists the media types acceptable for the response content
         /// </summary>
         /// <remarks>This is not an official OASIS standard property.</remarks>
         public IList<string> ResponseContentTypes { get; private set; }
@@ -167,7 +167,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
             TypecastSegmentSupported = record.GetBoolean("TypecastSegmentSupported");
 
             // NonUpdatableNavigationProperties
-            NonUpdatableNavigationProperties = record.GetCollectionPropertyPath("NonUpdatableNavigationProperties");            
+            NonUpdatableNavigationProperties = record.GetCollectionPropertyPath("NonUpdatableNavigationProperties");
 
             // MaxLevels
             MaxLevels = record.GetInteger("MaxLevels");

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         /// <summary>
         /// Gets the navigation properties which do not allow rebinding.
         /// </summary>
-        public IList<string> NonUpdatableNavigationProperties { get; private set; }
+        public IList<string> NonUpdatableNavigationProperties { get; private set; }       
 
         /// <summary>
         /// Gets the maximum number of navigation properties that can be traversed when addressing the collection or entity to update.
@@ -129,6 +129,18 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         public bool IsUpdateMethodPut => UpdateMethod.HasValue && UpdateMethod.Value == HttpMethod.PUT;
 
         /// <summary>
+        /// Lists the MIME types acceptable for the request content
+        /// </summary>
+        /// <remarks>This is not an official OASIS standard property.</remarks>
+        public IList<string> RequestContentTypes { get; private set; }
+
+        /// <summary>
+        /// Lists the MIME types acceptable for the response content
+        /// </summary>
+        /// <remarks>This is not an official OASIS standard property.</remarks>
+        public IList<string> ResponseContentTypes { get; private set; }
+
+        /// <summary>
         /// Init the <see cref="UpdateRestrictionsType"/>.
         /// </summary>
         /// <param name="record">The input record.</param>
@@ -155,7 +167,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
             TypecastSegmentSupported = record.GetBoolean("TypecastSegmentSupported");
 
             // NonUpdatableNavigationProperties
-            NonUpdatableNavigationProperties = record.GetCollectionPropertyPath("NonUpdatableNavigationProperties");
+            NonUpdatableNavigationProperties = record.GetCollectionPropertyPath("NonUpdatableNavigationProperties");            
 
             // MaxLevels
             MaxLevels = record.GetInteger("MaxLevels");
@@ -177,6 +189,12 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
 
             // LongDescription
             LongDescription = record.GetString("LongDescription");
+
+            // RequestContentTypes
+            RequestContentTypes = record.GetCollection("RequestContentTypes");
+
+            // ResponseContentTypes
+            ResponseContentTypes = record.GetCollection("ResponseContentTypes");
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
@@ -177,5 +177,24 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.Empty(putOperation.Security);
             }
         }
+
+        [Fact]
+        public void CreateEntityPutOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
+        {
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            OpenApiConvertSettings settings = new();
+            ODataContext context = new(model, settings);
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("directoryObjects");
+            Assert.NotNull(entitySet);
+
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation.RequestBody);
+            Assert.Equal("multipart/form-data", operation.RequestBody.Content.First().Key);
+        }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("directoryObjects");
             Assert.NotNull(entitySet);
 
-            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()));
+            ODataPath path = new(new ODataNavigationSourceSegment(entitySet), new ODataKeySegment(entitySet.EntityType()));
 
             // Act
             var operation = _operationHandler.CreateOperation(context, path);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -229,15 +229,15 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         }
 
         [Fact]
-        public void CreateEntitySetPostOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
+        public void CreateEntitySetPostOperationReturnsCorrectOperationWithAnnotatedRequestBodyAndResponseContent()
         {
             IEdmModel model = OData.Tests.EdmModelHelper.GraphBetaModel;
             OpenApiConvertSettings settings = new();
             ODataContext context = new(model, settings);
             IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("directoryObjects");
             Assert.NotNull(entitySet);
-            
-            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet));
+
+            ODataPath path = new(new ODataNavigationSourceSegment(entitySet));
 
             // Act
             var operation = _operationHandler.CreateOperation(context, path);
@@ -245,6 +245,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Assert
             Assert.NotNull(operation.RequestBody);
             Assert.Equal("multipart/form-data", operation.RequestBody.Content.First().Key);
+            Assert.NotNull(operation.Responses);
+            Assert.Equal("multipart/form-data", operation.Responses.First().Value.Content.First().Key);
         }
 
         internal static IEdmModel GetEdmModel(string annotation, bool hasStream = false)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Tests;
 using Microsoft.OpenApi.OData.Vocabulary.Core;
+using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
@@ -79,26 +80,22 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 if (!string.IsNullOrEmpty(annotation))
                 {
                     // RequestBody
-                    Assert.Equal(2, post.RequestBody.Content.Keys.Count);
+                    Assert.Single(post.RequestBody.Content.Keys);
                     Assert.True(post.RequestBody.Content.ContainsKey("application/todo"));
-                    Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationJsonMediaType));
 
                     // Response
-                    Assert.Equal(2, post.Responses[statusCode].Content.Keys.Count);
+                    Assert.Single(post.Responses[statusCode].Content.Keys);
                     Assert.True(post.Responses[statusCode].Content.ContainsKey("application/todo"));
-                    Assert.True(post.Responses[statusCode].Content.ContainsKey(Constants.ApplicationJsonMediaType));
                 }
                 else
                 {
                     // RequestBody
-                    Assert.Equal(2, post.RequestBody.Content.Keys.Count);
+                    Assert.Single(post.RequestBody.Content.Keys);
                     Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
-                    Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationJsonMediaType));
 
                     // Response
-                    Assert.Equal(2, post.Responses[statusCode].Content.Keys.Count);
+                    Assert.Single(post.Responses[statusCode].Content.Keys);
                     Assert.True(post.Responses[statusCode].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
-                    Assert.True(post.Responses[statusCode].Content.ContainsKey(Constants.ApplicationJsonMediaType));
                 }
             }
             else
@@ -229,6 +226,25 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             {
                 Assert.Empty(post.Security);
             }
+        }
+
+        [Fact]
+        public void CreateEntitySetPostOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
+        {
+            IEdmModel model = OData.Tests.EdmModelHelper.GraphBetaModel;
+            OpenApiConvertSettings settings = new();
+            ODataContext context = new(model, settings);
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("directoryObjects");
+            Assert.NotNull(entitySet);
+            
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation.RequestBody);
+            Assert.Equal("multipart/form-data", operation.RequestBody.Content.First().Key);
         }
 
         internal static IEdmModel GetEdmModel(string annotation, bool hasStream = false)

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
@@ -79,6 +79,27 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             }
         }
 
+        [Fact]
+        public void CreateNavigationPatchOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
+        {
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            OpenApiConvertSettings settings = new OpenApiConvertSettings();
+            ODataContext context = new ODataContext(model, settings);
+            IEdmSingleton sTon = model.EntityContainer.FindSingleton("identity");
+            Assert.NotNull(sTon);
+            IEdmEntityType entity = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "identityContainer");
+            IEdmNavigationProperty navProperty = entity.DeclaredNavigationProperties().First(c => c.Name == "apiConnectors");
+
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(sTon), new ODataNavigationPropertySegment(navProperty));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation.RequestBody);
+            Assert.Equal("application/xhtml+xml", operation.RequestBody.Content.First().Key);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPatchOperationHandlerTests.cs
@@ -83,14 +83,14 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateNavigationPatchOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
         {
             IEdmModel model = EdmModelHelper.GraphBetaModel;
-            OpenApiConvertSettings settings = new OpenApiConvertSettings();
-            ODataContext context = new ODataContext(model, settings);
+            OpenApiConvertSettings settings = new();
+            ODataContext context = new(model, settings);
             IEdmSingleton sTon = model.EntityContainer.FindSingleton("identity");
             Assert.NotNull(sTon);
             IEdmEntityType entity = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "identityContainer");
             IEdmNavigationProperty navProperty = entity.DeclaredNavigationProperties().First(c => c.Name == "apiConnectors");
 
-            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(sTon), new ODataNavigationPropertySegment(navProperty));
+            ODataPath path = new(new ODataNavigationSourceSegment(sTon), new ODataNavigationPropertySegment(navProperty));
 
             // Act
             var operation = _operationHandler.CreateOperation(context, path);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
@@ -74,14 +74,14 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateNavigationPostOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
         {
             IEdmModel model = EdmModelHelper.GraphBetaModel;
-            OpenApiConvertSettings settings = new OpenApiConvertSettings();
-            ODataContext context = new ODataContext(model, settings);
+            OpenApiConvertSettings settings = new();
+            ODataContext context = new(model, settings);
             IEdmSingleton sTon = model.EntityContainer.FindSingleton("identity");
             Assert.NotNull(sTon);
             IEdmEntityType entity = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "identityContainer");
             IEdmNavigationProperty navProperty = entity.DeclaredNavigationProperties().First(c => c.Name == "apiConnectors");
 
-            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(sTon), new ODataNavigationPropertySegment(navProperty));
+            ODataPath path = new(new ODataNavigationSourceSegment(sTon), new ODataNavigationPropertySegment(navProperty));
 
             // Act
             var operation = _operationHandler.CreateOperation(context, path);

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
@@ -86,8 +86,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             // Act
             var operation = _operationHandler.CreateOperation(context, path);
 
+            // Assert
             Assert.NotNull(operation.RequestBody);
-
             Assert.Equal("application/xhtml+xml", operation.RequestBody.Content.First().Key);
         }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
@@ -70,6 +70,27 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             }
         }
 
+        [Fact]
+        public void CreateNavigationPostOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
+        {
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            OpenApiConvertSettings settings = new OpenApiConvertSettings();
+            ODataContext context = new ODataContext(model, settings);
+            IEdmSingleton sTon = model.EntityContainer.FindSingleton("identity");
+            Assert.NotNull(sTon);
+            IEdmEntityType entity = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "identityContainer");
+            IEdmNavigationProperty navProperty = entity.DeclaredNavigationProperties().First(c => c.Name == "apiConnectors");
+
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(sTon), new ODataNavigationPropertySegment(navProperty));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            Assert.NotNull(operation.RequestBody);
+
+            Assert.Equal("application/xhtml+xml", operation.RequestBody.Content.First().Key);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/405

This PR:
- Introduces two new custom annotation properties: `RequestContentTypes` and `ResponseContentTypes` to help provide means of generating expected request body and response content media types for a given endpoint. The current default is `application/json`
- Updates generation of request body and response content media types of entity sets whose entities have media streams to either generate the annotated media type from the annotated `Org.OData.Core.V1.AcceptableMediaTypes` or default to `application/octet-stream` and not generate the `application/json` media type.
- Adds and updates tests to validate the above.
- Updates release notes.