### PR TITLE
Fetch annotations for paths ending with navigation properties using target path

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmAnnotationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmAnnotationExtensions.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Vocabularies;
-using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Vocabulary;
 using Microsoft.OpenApi.OData.Vocabulary.Authorization;
@@ -287,12 +286,12 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <param name="target">The Edm target.</param>
         /// <param name="linkRel">The link relation type for path operation.</param>
         /// <returns>Null or the links record value (a complex type) for this annotation.</returns>
-        public static Link GetLinkRecord(this IEdmModel model, IEdmVocabularyAnnotatable target, string linkRel)
+        public static LinkType GetLinkRecord(this IEdmModel model, IEdmVocabularyAnnotatable target, string linkRel)
         {
             Utils.CheckArgumentNull(model, nameof(model));
             Utils.CheckArgumentNull(target, nameof(target));
 
-            return model.GetCollection<Link>(target, CoreConstants.Links)?.FirstOrDefault(x => x.Rel == linkRel);
+            return model.GetCollection<LinkType>(target, CoreConstants.Links)?.FirstOrDefault(x => x.Rel == linkRel);
         }
 
         /// <summary>
@@ -302,7 +301,7 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <param name="targetPath">The string representation of the Edm target path.</param>
         /// <param name="linkRel">The link relation type for path operation.</param>
         /// <returns>Null or the links record value (a complex type) for this annotation.</returns>
-        public static Link GetLinkRecord(this IEdmModel model, string targetPath, string linkRel)
+        public static LinkType GetLinkRecord(this IEdmModel model, string targetPath, string linkRel)
         {
             Utils.CheckArgumentNull(model, nameof(model));
             Utils.CheckArgumentNull(targetPath, nameof(targetPath));
@@ -350,6 +349,18 @@ namespace Microsoft.OpenApi.OData.Edm
 
                 return null;
             });
+        }
+
+        public static string GetDescriptionAnnotation(this IEdmModel model, string targetPath)
+        {
+            Utils.CheckArgumentNull(model, nameof(model));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+
+            IEdmTargetPath target = model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return model.GetDescriptionAnnotation(target);
         }
 
         private static T GetOrAddCached<T>(this IEdmModel model, IEdmVocabularyAnnotatable target, string qualifiedName, Func<T> createFunc)

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmAnnotationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmAnnotationExtensions.cs
@@ -164,6 +164,28 @@ namespace Microsoft.OpenApi.OData.Edm
         }
 
         /// <summary>
+        /// Gets the record value (a complex type) for the given target path.
+        /// </summary>
+        /// <typeparam name="T">The CLR mapping type.</typeparam>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <param name="qualifiedName">The Term qualified name.</param>
+        /// <returns></returns>
+        public static T GetRecord<T>(this IEdmModel model, string targetPath, string qualifiedName)
+            where T : IRecord, new()
+        {
+            Utils.CheckArgumentNull(model, nameof(model));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+            Utils.CheckArgumentNull(qualifiedName, nameof(qualifiedName));
+
+            IEdmTargetPath target = model.GetTargetPath(targetPath);
+            if (target == null)
+                return default;
+
+            return model.GetRecord<T>(target, qualifiedName);
+        }
+
+        /// <summary>
         /// Gets the collection of string term value for the given <see cref="IEdmVocabularyAnnotatable"/>.
         /// </summary>
         /// <param name="model">The Edm model.</param>
@@ -259,6 +281,28 @@ namespace Microsoft.OpenApi.OData.Edm
         }
 
         /// <summary>
+        /// Gets the collection of record value (a complex type) for the given targetPath.
+        /// </summary>
+        /// <typeparam name="T">The CLR mapping type.</typeparam>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <param name="qualifiedName">The Term qualified name.</param>
+        /// <returns></returns>
+        public static IEnumerable<T> GetCollection<T>(this IEdmModel model, string targetPath, string qualifiedName)
+            where T : IRecord, new()
+        {
+            Utils.CheckArgumentNull(model, nameof(model));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+            Utils.CheckArgumentNull(qualifiedName, nameof(qualifiedName));
+
+            IEdmTargetPath target = model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return model.GetCollection<T>(target, qualifiedName);
+        }
+
+        /// <summary>
         /// Gets the links record value (a complex type) for the given <see cref="IEdmVocabularyAnnotatable"/>.
         /// </summary>
         /// <param name="model">The Edm model.</param>
@@ -271,6 +315,21 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(target, nameof(target));
 
             return model.GetCollection<Link>(target, CoreConstants.Links)?.FirstOrDefault(x => x.Rel == linkRel);
+        }
+
+        /// <summary>
+        /// Gets the links record value (a complex type) for the given target path.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <param name="linkRel">The link relation type for path operation.</param>
+        /// <returns>Null or the links record value (a complex type) for this annotation.</returns>
+        public static Link GetLinkRecord(this IEdmModel model, string targetPath, string linkRel)
+        {
+            Utils.CheckArgumentNull(model, nameof(model));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+
+            return model.GetCollection<Link>(targetPath, CoreConstants.Links)?.FirstOrDefault(x => x.Rel == linkRel);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/EdmAnnotationExtensions.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/EdmAnnotationExtensions.cs
@@ -281,28 +281,6 @@ namespace Microsoft.OpenApi.OData.Edm
         }
 
         /// <summary>
-        /// Gets the collection of record value (a complex type) for the given targetPath.
-        /// </summary>
-        /// <typeparam name="T">The CLR mapping type.</typeparam>
-        /// <param name="model">The Edm model.</param>
-        /// <param name="targetPath">The string representation of the Edm target path.</param>
-        /// <param name="qualifiedName">The Term qualified name.</param>
-        /// <returns></returns>
-        public static IEnumerable<T> GetCollection<T>(this IEdmModel model, string targetPath, string qualifiedName)
-            where T : IRecord, new()
-        {
-            Utils.CheckArgumentNull(model, nameof(model));
-            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
-            Utils.CheckArgumentNull(qualifiedName, nameof(qualifiedName));
-
-            IEdmTargetPath target = model.GetTargetPath(targetPath);
-            if (target == null)
-                return null;
-
-            return model.GetCollection<T>(target, qualifiedName);
-        }
-
-        /// <summary>
         /// Gets the links record value (a complex type) for the given <see cref="IEdmVocabularyAnnotatable"/>.
         /// </summary>
         /// <param name="model">The Edm model.</param>
@@ -329,7 +307,11 @@ namespace Microsoft.OpenApi.OData.Edm
             Utils.CheckArgumentNull(model, nameof(model));
             Utils.CheckArgumentNull(targetPath, nameof(targetPath));
 
-            return model.GetCollection<Link>(targetPath, CoreConstants.Links)?.FirstOrDefault(x => x.Rel == linkRel);
+            IEdmTargetPath target = model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return model.GetLinkRecord(target, linkRel);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Generator/OpenApiParameterGenerator.cs
@@ -373,6 +373,24 @@ namespace Microsoft.OpenApi.OData.Generator
         }
 
         /// <summary>
+        /// Create the $top parameter for Edm target path.
+        /// </summary>
+        /// <param name="context">The OData context.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <returns></returns>
+        public static OpenApiParameter CreateTop(this ODataContext context, string targetPath)
+        {
+            Utils.CheckArgumentNull(context, nameof(context));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+
+            IEdmTargetPath target = context.Model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return context.CreateTop(target);
+        }
+
+        /// <summary>
         /// Create the $skip parameter.
         /// </summary>
         /// <param name="context">The OData context.</param>
@@ -394,6 +412,24 @@ namespace Microsoft.OpenApi.OData.Generator
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Create the $skip parameter for Edm target path.
+        /// </summary>
+        /// <param name="context">The OData context.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <returns></returns>
+        public static OpenApiParameter CreateSkip(this ODataContext context, string targetPath)
+        {
+            Utils.CheckArgumentNull(context, nameof(context));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+
+            IEdmTargetPath target = context.Model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return context.CreateSkip(target);
         }
 
         /// <summary>
@@ -421,6 +457,24 @@ namespace Microsoft.OpenApi.OData.Generator
         }
 
         /// <summary>
+        /// Create the $search parameter for Edm target path.
+        /// </summary>
+        /// <param name="context">The OData context.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <returns></returns>
+        public static OpenApiParameter CreateSearch(this ODataContext context, string targetPath)
+        {
+            Utils.CheckArgumentNull(context, nameof(context));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+
+            IEdmTargetPath target = context.Model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return context.CreateSearch(target);
+        }
+
+        /// <summary>
         /// Create the $count parameter.
         /// </summary>
         /// <param name="context">The OData context.</param>
@@ -445,6 +499,24 @@ namespace Microsoft.OpenApi.OData.Generator
         }
 
         /// <summary>
+        /// Create the $count parameter for Edm target path.
+        /// </summary>
+        /// <param name="context">The OData context.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <returns></returns>
+        public static OpenApiParameter CreateCount(this ODataContext context, string targetPath)
+        {
+            Utils.CheckArgumentNull(context, nameof(context));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+
+            IEdmTargetPath target = context.Model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return context.CreateCount(target);
+        }
+
+        /// <summary>
         /// Create the $filter parameter.
         /// </summary>
         /// <param name="context">The OData context.</param>
@@ -466,6 +538,24 @@ namespace Microsoft.OpenApi.OData.Generator
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Create the $filter parameter for Edm target path.
+        /// </summary>
+        /// <param name="context">The OData context.</param>
+        /// <param name="targetPath">The string representation of the Edm target path.</param>
+        /// <returns></returns>
+        public static OpenApiParameter CreateFilter(this ODataContext context, string targetPath)
+        {
+            Utils.CheckArgumentNull(context, nameof(context));
+            Utils.CheckArgumentNull(targetPath, nameof(targetPath));
+
+            IEdmTargetPath target = context.Model.GetTargetPath(targetPath);
+            if (target == null)
+                return null;
+
+            return context.CreateFilter(target);
         }
 
         public static OpenApiParameter CreateOrderBy(this ODataContext context, IEdmEntitySet entitySet)

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.20.0" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.21.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -21,8 +21,8 @@
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-- Prefer fetching descriptions and link annotations using Edm target path  #514
-    </PackageReleaseNotes>
+		- Adds support for fetching annotations using Edm target path preferentially #514
+	</PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>
     <OutputPath Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">..\..\bin\Debug\</OutputPath>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,13 +15,13 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-- Generates unique DELETE operation ids of $ref paths for indexed collection navigation properties #513
+- Prefer fetching descriptions and link annotations using Edm target path  #514
     </PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
 
 namespace Microsoft.OpenApi.OData.Operation;
 
@@ -40,5 +41,24 @@ internal abstract class ComplexPropertyBaseOperationHandler : OperationHandler
         }
         
         base.SetTags(operation);
+    }
+
+    /// <inheritdoc/>
+    protected override void SetExternalDocs(OpenApiOperation operation)
+    {
+        if (Context.Settings.ShowExternalDocs)
+        {
+            var externalDocs = Context.Model.GetLinkRecord(TargetPath, CustomLinkRel) ??
+                Context.Model.GetLinkRecord(ComplexPropertySegment.Property, CustomLinkRel);
+
+            if (externalDocs != null)
+            {
+                operation.ExternalDocs = new OpenApiExternalDocs()
+                {
+                    Description = CoreConstants.ExternalDocsDescription,
+                    Url = externalDocs.Href
+                };
+            }
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
@@ -17,8 +17,8 @@ internal abstract class ComplexPropertyBaseOperationHandler : OperationHandler
     /// <inheritdoc/>
     protected override void Initialize(ODataContext context, ODataPath path)
     {
+        base.Initialize(context, path);
         ComplexPropertySegment = path.LastSegment as ODataComplexPropertySegment ?? throw Error.ArgumentNull(nameof(path));
-        base.SetTargetPath();
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyBaseOperationHandler.cs
@@ -18,6 +18,7 @@ internal abstract class ComplexPropertyBaseOperationHandler : OperationHandler
     protected override void Initialize(ODataContext context, ODataPath path)
     {
         ComplexPropertySegment = path.LastSegment as ODataComplexPropertySegment ?? throw Error.ArgumentNull(nameof(path));
+        base.SetTargetPath();
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -26,7 +26,17 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
     {
         base.Initialize(context, path);
 
-        _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.ReadRestrictions);
+        _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+        var complexPropertyReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.ReadRestrictions);
+
+        if (_readRestrictions == null)
+        {
+            _readRestrictions = complexPropertyReadRestrictions;
+        }
+        else
+        {
+            _readRestrictions.MergePropertiesIfNull(complexPropertyReadRestrictions);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyGetOperationHandler.cs
@@ -54,41 +54,40 @@ internal class ComplexPropertyGetOperationHandler : ComplexPropertyBaseOperation
         OpenApiParameter parameter;
         if(ComplexPropertySegment.Property.Type.IsCollection())
         {
-
             // The parameters array contains Parameter Objects for all system query options allowed for this collection,
             // and it does not list system query options not allowed for this collection, see terms
             // Capabilities.TopSupported, Capabilities.SkipSupported, Capabilities.SearchRestrictions,
             // Capabilities.FilterRestrictions, and Capabilities.CountRestrictions
             // $top
-            parameter = Context.CreateTop(ComplexPropertySegment.Property);
+            parameter = Context.CreateTop(TargetPath) ?? Context.CreateTop(ComplexPropertySegment.Property);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $skip
-            parameter = Context.CreateSkip(ComplexPropertySegment.Property);
+            parameter = Context.CreateSkip(TargetPath) ?? Context.CreateSkip(ComplexPropertySegment.Property);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $search
-            parameter = Context.CreateSearch(ComplexPropertySegment.Property);
+            parameter = Context.CreateSearch(TargetPath) ?? Context.CreateSearch(ComplexPropertySegment.Property);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $filter
-            parameter = Context.CreateFilter(ComplexPropertySegment.Property);
+            parameter = Context.CreateFilter(TargetPath) ?? Context.CreateFilter(ComplexPropertySegment.Property);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $count
-            parameter = Context.CreateCount(ComplexPropertySegment.Property);
+            parameter = Context.CreateCount(TargetPath) ?? Context.CreateCount(ComplexPropertySegment.Property);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyPostOperationHandler.cs
@@ -26,7 +26,17 @@ internal class ComplexPropertyPostOperationHandler : ComplexPropertyBaseOperatio
             throw new InvalidOperationException("OData conventions do not support POSTing to a complex property that is not a collection.");
         }
 
-        _insertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.InsertRestrictions);
+        _insertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(TargetPath, CapabilitiesConstants.InsertRestrictions);
+        var complexPropertyInsertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.InsertRestrictions);
+
+        if (_insertRestrictions == null)
+        {
+            _insertRestrictions = complexPropertyInsertRestrictions;
+        }
+        else
+        {
+            _insertRestrictions.MergePropertiesIfNull(complexPropertyInsertRestrictions);
+        }
     }
     /// <inheritdoc />
     public override OperationType OperationType => OperationType.Post;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
@@ -23,7 +23,17 @@ internal abstract class ComplexPropertyUpdateOperationHandler : ComplexPropertyB
     {
         base.Initialize(context, path);
 
-        _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.UpdateRestrictions);
+        _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(TargetPath, CapabilitiesConstants.UpdateRestrictions);
+        var complexPropertyUpdateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(ComplexPropertySegment.Property, CapabilitiesConstants.UpdateRestrictions);
+
+        if (_updateRestrictions == null)
+        {
+            _updateRestrictions = complexPropertyUpdateRestrictions;
+        }
+        else
+        {
+            _updateRestrictions.MergePropertiesIfNull(complexPropertyUpdateRestrictions);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -218,12 +218,5 @@ namespace Microsoft.OpenApi.OData.Operation
                 AppendCustomParameters(operation, readRestrictions.CustomQueryOptions, ParameterLocation.Query);
             }
         }
-
-        protected override void SetTargetPath()
-        {
-            base.SetTargetPath();
-            int lastIndex = TargetPath.LastIndexOf('/');
-            TargetPath = lastIndex > 0 ? TargetPath.Substring(0, lastIndex) : TargetPath;
-        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -199,9 +199,17 @@ namespace Microsoft.OpenApi.OData.Operation
                 return;
             }
 
-            ReadRestrictionsType readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions)
-                ?? Context.Model.GetRecord<ReadRestrictionsType>(annotatable, CapabilitiesConstants.ReadRestrictions);
+            ReadRestrictionsType readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+            ReadRestrictionsType annotatableReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(annotatable, CapabilitiesConstants.ReadRestrictions);
 
+            if (readRestrictions == null)
+            {
+                readRestrictions = annotatableReadRestrictions;
+            }
+            else
+            {
+                readRestrictions.MergePropertiesIfNull(annotatableReadRestrictions);
+            }
             
             if (readRestrictions == null)
             {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/DollarCountGetOperationHandler.cs
@@ -179,13 +179,13 @@ namespace Microsoft.OpenApi.OData.Operation
 
             OpenApiParameter parameter;
 
-            parameter = Context.CreateSearch(annotatable);
+            parameter = Context.CreateSearch(TargetPath) ?? Context.CreateSearch(annotatable);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
-            parameter = Context.CreateFilter(annotatable);
+            parameter = Context.CreateFilter(TargetPath) ?? Context.CreateFilter(annotatable);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
@@ -199,8 +199,10 @@ namespace Microsoft.OpenApi.OData.Operation
                 return;
             }
 
-            ReadRestrictionsType readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(annotatable, CapabilitiesConstants.ReadRestrictions);
+            ReadRestrictionsType readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions)
+                ?? Context.Model.GetRecord<ReadRestrictionsType>(annotatable, CapabilitiesConstants.ReadRestrictions);
 
+            
             if (readRestrictions == null)
             {
                 return;
@@ -215,6 +217,13 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 AppendCustomParameters(operation, readRestrictions.CustomQueryOptions, ParameterLocation.Query);
             }
+        }
+
+        protected override void SetTargetPath()
+        {
+            base.SetTargetPath();
+            int lastIndex = TargetPath.LastIndexOf('/');
+            TargetPath = lastIndex > 0 ? TargetPath.Substring(0, lastIndex) : TargetPath;
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmActionOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmActionOperationHandler.cs
@@ -26,8 +26,19 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.SetBasicInfo(operation);
 
+            InsertRestrictionsType insertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(TargetPath, CapabilitiesConstants.InsertRestrictions);
+            InsertRestrictionsType operationReadRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(EdmOperation, CapabilitiesConstants.InsertRestrictions);
+
+            if (insertRestrictions == null)
+            {
+                insertRestrictions = operationReadRestrictions;
+            }
+            else
+            {
+                insertRestrictions.MergePropertiesIfNull(operationReadRestrictions);
+            }
+
             // Description
-            var insertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(EdmOperation, CapabilitiesConstants.InsertRestrictions);
             if (!string.IsNullOrWhiteSpace(insertRestrictions?.LongDescription))
             {
                 operation.Description = insertRestrictions.LongDescription;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EdmFunctionOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EdmFunctionOperationHandler.cs
@@ -30,8 +30,19 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.SetBasicInfo(operation);
 
+            ReadRestrictionsType readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+            ReadRestrictionsType operationReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(EdmOperation, CapabilitiesConstants.ReadRestrictions);
+
+            if (readRestrictions == null)
+            {
+                readRestrictions = operationReadRestrictions;
+            }
+            else
+            {
+                readRestrictions.MergePropertiesIfNull(operationReadRestrictions);
+            }
+
             // Description
-            var readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(EdmOperation, CapabilitiesConstants.ReadRestrictions);
             if (!string.IsNullOrWhiteSpace(readRestrictions?.LongDescription))
             {
                 operation.Description = readRestrictions.LongDescription;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityDeleteOperationHandler.cs
@@ -29,7 +29,17 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.Initialize(context, path);
 
-            _deleteRestrictions = Context.Model.GetRecord<DeleteRestrictionsType>(EntitySet, CapabilitiesConstants.DeleteRestrictions);
+            _deleteRestrictions = Context.Model.GetRecord<DeleteRestrictionsType>(TargetPath, CapabilitiesConstants.DeleteRestrictions);
+            var entityDeleteRestrictions = Context.Model.GetRecord<DeleteRestrictionsType>(EntitySet, CapabilitiesConstants.DeleteRestrictions);
+
+            if (_deleteRestrictions == null)
+            {
+                _deleteRestrictions = entityDeleteRestrictions;
+            }
+            else
+            {
+                _deleteRestrictions.MergePropertiesIfNull(entityDeleteRestrictions);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -30,7 +30,17 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.Initialize(context, path);
 
-            _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions);
+            _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+            var entityReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions);
+
+            if (_readRestrictions == null)
+            {
+                _readRestrictions = entityReadRestrictions;
+            }
+            else
+            {
+                _readRestrictions.MergePropertiesIfNull(entityReadRestrictions);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
@@ -31,7 +31,17 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.Initialize(context, path);
 
-            _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions);
+            _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+            var entityReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions);
+
+            if (_readRestrictions == null)
+            {
+                _readRestrictions = entityReadRestrictions;
+            }
+            else
+            {
+                _readRestrictions.MergePropertiesIfNull(entityReadRestrictions);
+            }
         }
 
         /// <inheritdoc/>
@@ -75,35 +85,35 @@ namespace Microsoft.OpenApi.OData.Operation
             // Capabilities.TopSupported, Capabilities.SkipSupported, Capabilities.SearchRestrictions,
             // Capabilities.FilterRestrictions, and Capabilities.CountRestrictions
             // $top
-            OpenApiParameter parameter = Context.CreateTop(EntitySet);
+            OpenApiParameter parameter = Context.CreateTop(TargetPath) ?? Context.CreateTop(EntitySet);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $skip
-            parameter = Context.CreateSkip(EntitySet);
+            parameter = Context.CreateSkip(TargetPath) ?? Context.CreateSkip(EntitySet);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $search
-            parameter = Context.CreateSearch(EntitySet);
+            parameter = Context.CreateSearch(TargetPath) ?? Context.CreateSearch(EntitySet);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $filter
-            parameter = Context.CreateFilter(EntitySet);
+            parameter = Context.CreateFilter(TargetPath) ?? Context.CreateFilter(EntitySet);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);
             }
 
             // $count
-            parameter = Context.CreateCount(EntitySet);
+            parameter = Context.CreateCount(TargetPath) ?? Context.CreateCount(EntitySet);
             if (parameter != null)
             {
                 operation.Parameters.Add(parameter);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetOperationHandler.cs
@@ -61,13 +61,19 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetExternalDocs(OpenApiOperation operation)
         {
-            if (Context.Settings.ShowExternalDocs && Context.Model.GetLinkRecord(EntitySet, CustomLinkRel) is Link externalDocs)
+            if (Context.Settings.ShowExternalDocs)
             {
-                operation.ExternalDocs = new OpenApiExternalDocs()
+                var externalDocs = Context.Model.GetLinkRecord(TargetPath, CustomLinkRel) ??
+                    Context.Model.GetLinkRecord(EntitySet, CustomLinkRel);
+
+                if (externalDocs != null)
                 {
-                    Description = CoreConstants.ExternalDocsDescription,
-                    Url = externalDocs.Href
-                };
+                    operation.ExternalDocs = new OpenApiExternalDocs()
+                    {
+                        Description = CoreConstants.ExternalDocsDescription,
+                        Url = externalDocs.Href
+                    };
+                }
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -31,7 +31,17 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.Initialize(context, path);
 
-            _insertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(EntitySet, CapabilitiesConstants.InsertRestrictions);
+            _insertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(TargetPath, CapabilitiesConstants.InsertRestrictions);
+            var entityInsertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(EntitySet, CapabilitiesConstants.InsertRestrictions);
+
+            if (_insertRestrictions == null)
+            {
+                _insertRestrictions = entityInsertRestrictions;
+            }
+            else
+            {
+                _insertRestrictions.MergePropertiesIfNull(entityInsertRestrictions);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -25,7 +25,17 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.Initialize(context, path);
 
-            _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+            _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(TargetPath, CapabilitiesConstants.UpdateRestrictions);
+            var entityUpdateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+
+            if (_updateRestrictions == null)
+            {
+                _updateRestrictions = entityUpdateRestrictions;
+            }
+            else
+            {
+                _updateRestrictions.MergePropertiesIfNull(entityUpdateRestrictions);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -21,24 +21,33 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Get;
-        private IEdmProperty _property = null;
         private ReadRestrictionsType _readRestrictions = null;
 
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            (_, _property) = GetStreamElements();
 
-            if (_property != null)
+            if (Property != null)
             {
-                if (_property is IEdmNavigationProperty)
+                _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+                if (Property is IEdmNavigationProperty)
                 {
-                    _readRestrictions = Context.Model.GetRecord<NavigationRestrictionsType>(_property, CapabilitiesConstants.NavigationRestrictions)?
-                        .RestrictedProperties?.FirstOrDefault()?.ReadRestrictions;
+                    var navigationReadRestrictions = Context.Model.GetRecord<NavigationRestrictionsType>(Property, CapabilitiesConstants.NavigationRestrictions)?
+                            .RestrictedProperties?.FirstOrDefault()?.ReadRestrictions;
+                    if (_readRestrictions != null && navigationReadRestrictions != null)
+                    {
+                        _readRestrictions.MergePropertiesIfNull(navigationReadRestrictions);
+                    }
+                    _readRestrictions ??= navigationReadRestrictions;
                 }
                 else
                 {
-                    _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(_property, CapabilitiesConstants.ReadRestrictions);
+                    var propertyReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(Property, CapabilitiesConstants.ReadRestrictions);
+                    if (_readRestrictions != null && propertyReadRestrictions != null)
+                    {
+                        _readRestrictions.MergePropertiesIfNull(propertyReadRestrictions);
+                    }
+                    _readRestrictions ??= propertyReadRestrictions;
                 }
             }            
         }
@@ -48,8 +57,9 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             // Summary
             string placeholderValue = LastSegmentIsStreamPropertySegment ? Path.LastSegment.Identifier : "media content";
-            operation.Summary = IsNavigationPropertyPath
-                ? $"Get {placeholderValue} for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}"
+            operation.Summary = _readRestrictions?.Description;
+            operation.Summary ??= IsNavigationPropertyPath
+                ? $"Get {placeholderValue} for the navigation property {NavigationProperty.Name} from {NavigationSourceSegment.NavigationSource.Name}"
                 : $"Get {placeholderValue} for {NavigationSourceSegment.EntityType.Name} from {NavigationSourceSegment.Identifier}";
 
             // Description
@@ -57,17 +67,17 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 string description;
 
-                if (_property is IEdmNavigationProperty)
+                if (Property is IEdmNavigationProperty)
                 {
                     description = LastSegmentIsKeySegment
-                        ? _readRestrictions?.ReadByKeyRestrictions?.Description
-                        : _readRestrictions?.Description
-                        ?? Context.Model.GetDescriptionAnnotation(_property);
+                        ? _readRestrictions?.ReadByKeyRestrictions?.LongDescription
+                        : _readRestrictions?.LongDescription
+                        ?? Context.Model.GetDescriptionAnnotation(Property);
                 }
                 else
                 {
                     // Structural property
-                    description = Context.Model.GetDescriptionAnnotation(_property);
+                    description = _readRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
                 }
 
                 operation.Description = description;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -22,26 +22,36 @@ namespace Microsoft.OpenApi.OData.Operation
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Put;
-        private IEdmProperty _property = null;
+        
         private UpdateRestrictionsType _updateRestrictions = null;
 
         protected override void Initialize(ODataContext context, ODataPath path)
         {
             base.Initialize(context, path);
-            (_, _property) = GetStreamElements();
-            
-            if (_property != null) 
+
+            if (Property != null)
             {
-                if (_property is IEdmNavigationProperty)
+                _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(TargetPath, CapabilitiesConstants.UpdateRestrictions);
+                if (Property is IEdmNavigationProperty)
                 {
-                    _updateRestrictions = Context.Model.GetRecord<NavigationRestrictionsType>(_property, CapabilitiesConstants.NavigationRestrictions)?
-                        .RestrictedProperties?.FirstOrDefault()?.UpdateRestrictions;
+                    var navigationUpdateRestrictions = Context.Model.GetRecord<NavigationRestrictionsType>(Property, CapabilitiesConstants.NavigationRestrictions)?
+                            .RestrictedProperties?.FirstOrDefault()?.UpdateRestrictions;
+                    if (_updateRestrictions != null && navigationUpdateRestrictions != null)
+                    {
+                        _updateRestrictions.MergePropertiesIfNull(navigationUpdateRestrictions);
+                    }
+                    _updateRestrictions ??= navigationUpdateRestrictions;
                 }
                 else
                 {
-                    _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(_property, CapabilitiesConstants.UpdateRestrictions);
+                    var propertyUpdateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(Property, CapabilitiesConstants.UpdateRestrictions);
+                    if (_updateRestrictions != null && propertyUpdateRestrictions != null)
+                    {
+                        _updateRestrictions.MergePropertiesIfNull(propertyUpdateRestrictions);
+                    }
+                    _updateRestrictions ??= propertyUpdateRestrictions;
                 }
-            }            
+            }
         }
 
         /// <inheritdoc/>
@@ -49,27 +59,15 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             // Summary
             string placeholderValue = LastSegmentIsStreamPropertySegment ? Path.LastSegment.Identifier : "media content";
-            operation.Summary = IsNavigationPropertyPath
-                ? $"Update {placeholderValue} for the navigation property {NavigationProperty.Name} in {NavigationSource.Name}"
+            operation.Summary = _updateRestrictions?.Description;
+            operation.Summary ??= IsNavigationPropertyPath
+                ? $"Update {placeholderValue} for the navigation property {NavigationProperty.Name} in {NavigationSourceSegment.NavigationSource.Name}"
                 : $"Update {placeholderValue} for {NavigationSourceSegment.EntityType.Name} in {NavigationSourceSegment.Identifier}";
 
             // Description
             if (LastSegmentIsStreamPropertySegment)
             {
-                string description;
-
-                if (_property is IEdmNavigationProperty)
-                {
-
-                    description = _updateRestrictions?.Description ?? Context.Model.GetDescriptionAnnotation(_property);
-                }
-                else
-                {
-                    // Structural property
-                    description = Context.Model.GetDescriptionAnnotation(_property);
-                }
-
-                operation.Description = description;
+                operation.Description = _updateRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
             }
 
             // OperationId

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
@@ -169,31 +169,31 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 // Need to verify that TopSupported or others should be applied to navigation source.
                 // So, how about for the navigation property.
-                OpenApiParameter parameter = Context.CreateTop(NavigationProperty);
+                OpenApiParameter parameter = Context.CreateTop(TargetPath) ?? Context.CreateTop(NavigationProperty);
                 if (parameter != null)
                 {
                     operation.Parameters.Add(parameter);
                 }
 
-                parameter = Context.CreateSkip(NavigationProperty);
+                parameter = Context.CreateSkip(TargetPath) ?? Context.CreateSkip(NavigationProperty);
                 if (parameter != null)
                 {
                     operation.Parameters.Add(parameter);
                 }
 
-                parameter = Context.CreateSearch(NavigationProperty);
+                parameter = Context.CreateSearch(TargetPath) ?? Context.CreateSearch(NavigationProperty);
                 if (parameter != null)
                 {
                     operation.Parameters.Add(parameter);
                 }
 
-                parameter = Context.CreateFilter(NavigationProperty);
+                parameter = Context.CreateFilter(TargetPath) ?? Context.CreateFilter(NavigationProperty);
                 if (parameter != null)
                 {
                     operation.Parameters.Add(parameter);
                 }
 
-                parameter = Context.CreateCount(NavigationProperty);
+                parameter = Context.CreateCount(TargetPath) ?? Context.CreateCount(NavigationProperty);
                 if (parameter != null)
                 {
                     operation.Parameters.Add(parameter);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -129,17 +129,6 @@ namespace Microsoft.OpenApi.OData.Operation
             }
         }
 
-        /// <inheritdoc/>
-        protected override void SetTargetPath()
-        {
-            base.SetTargetPath();
-            if (Path.LastSegment is ODataRefSegment)
-            {
-                int lastIndex = TargetPath.LastIndexOf('/');
-                TargetPath = lastIndex > 0 ? TargetPath.Substring(0, lastIndex) : TargetPath;
-            }
-        }
-
         /// <summary>
         /// Retrieves the CRUD restrictions annotations for the navigation property
         /// in context, given a capability annotation term.

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -137,22 +137,76 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <returns>The restriction annotation, or null if not available.</returns>
         protected IRecord GetRestrictionAnnotation(string annotationTerm)
         {
-            return annotationTerm switch
+            switch (annotationTerm)
             {
-                CapabilitiesConstants.ReadRestrictions => Restriction?.ReadRestrictions ??
-                                        Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions) ??
-                                        Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty, CapabilitiesConstants.ReadRestrictions),
-                CapabilitiesConstants.UpdateRestrictions => Restriction?.UpdateRestrictions ??
-                                        Context.Model.GetRecord<UpdateRestrictionsType>(TargetPath, CapabilitiesConstants.UpdateRestrictions) ??
-                                        Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty, CapabilitiesConstants.UpdateRestrictions),
-                CapabilitiesConstants.InsertRestrictions => Restriction?.InsertRestrictions ??
-                                        Context.Model.GetRecord<InsertRestrictionsType>(TargetPath, CapabilitiesConstants.InsertRestrictions) ??
-                                        Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty, CapabilitiesConstants.InsertRestrictions),
-                CapabilitiesConstants.DeleteRestrictions => Restriction?.DeleteRestrictions ??
-                                        Context.Model.GetRecord<DeleteRestrictionsType>(TargetPath, CapabilitiesConstants.DeleteRestrictions) ??
-                                        Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions),
-                _ => null,
-            };
+                case CapabilitiesConstants.ReadRestrictions:
+                    var readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+                    if (readRestrictions != null && Restriction?.ReadRestrictions != null)
+                    {
+                        readRestrictions.MergePropertiesIfNull(Restriction.ReadRestrictions);
+                    }
+                    readRestrictions ??= Restriction?.ReadRestrictions;
+
+                    var navPropReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(NavigationProperty, CapabilitiesConstants.ReadRestrictions);
+                    if (readRestrictions != null && navPropReadRestrictions != null)
+                    {
+                        readRestrictions.MergePropertiesIfNull(navPropReadRestrictions);
+                    }
+                    readRestrictions ??= navPropReadRestrictions;
+
+                    return readRestrictions;
+                case CapabilitiesConstants.UpdateRestrictions:
+                    var updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(TargetPath, CapabilitiesConstants.UpdateRestrictions);
+                    if (updateRestrictions != null && Restriction?.UpdateRestrictions != null)
+                    {
+                        updateRestrictions.MergePropertiesIfNull(Restriction.UpdateRestrictions);
+                    }
+                    updateRestrictions ??= Restriction?.UpdateRestrictions;
+
+                    var navPropUpdateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(NavigationProperty, CapabilitiesConstants.UpdateRestrictions);
+                    if (updateRestrictions != null && navPropUpdateRestrictions != null)
+                    {
+                        updateRestrictions.MergePropertiesIfNull(navPropUpdateRestrictions);
+                    }
+                    updateRestrictions ??= navPropUpdateRestrictions;
+
+                    return updateRestrictions;
+                case CapabilitiesConstants.InsertRestrictions:
+                    var insertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(TargetPath, CapabilitiesConstants.InsertRestrictions);
+                    if (insertRestrictions != null && Restriction?.InsertRestrictions != null)
+                    {
+                        insertRestrictions.MergePropertiesIfNull(Restriction.InsertRestrictions);
+                    }
+                    insertRestrictions ??= Restriction?.InsertRestrictions;
+
+                    var navPropInsertRestrictions = Context.Model.GetRecord<InsertRestrictionsType>(NavigationProperty, CapabilitiesConstants.InsertRestrictions);
+                    if (insertRestrictions != null && navPropInsertRestrictions != null)
+                    {
+                        insertRestrictions.MergePropertiesIfNull(navPropInsertRestrictions);
+                    }
+                    insertRestrictions ??= navPropInsertRestrictions;
+
+                    return insertRestrictions;
+                case CapabilitiesConstants.DeleteRestrictions:
+                    var deleteRestrictions = Context.Model.GetRecord<DeleteRestrictionsType>(TargetPath, CapabilitiesConstants.DeleteRestrictions);
+                    if (deleteRestrictions != null && Restriction?.DeleteRestrictions != null)
+                    {
+                        deleteRestrictions.MergePropertiesIfNull(Restriction.DeleteRestrictions);
+                    }
+                    deleteRestrictions ??= Restriction?.DeleteRestrictions;
+
+                    var navPropDeleteRestrictions = Context.Model.GetRecord<DeleteRestrictionsType>(NavigationProperty, CapabilitiesConstants.DeleteRestrictions);
+                    if (deleteRestrictions != null && navPropDeleteRestrictions != null)
+                    {
+                        deleteRestrictions.MergePropertiesIfNull(navPropDeleteRestrictions);
+                    }
+                    deleteRestrictions ??= navPropDeleteRestrictions;
+
+                    return deleteRestrictions;
+                default:
+                    return null;
+
+            }
         }
 
         protected IDictionary<string, OpenApiMediaType> GetContent(OpenApiSchema schema = null, IEnumerable<string> mediaTypes = null)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -3,9 +3,10 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OData.Edm;
+using System.Text;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.MicrosoftExtensions;
 using Microsoft.OpenApi.Models;
@@ -32,6 +33,11 @@ namespace Microsoft.OpenApi.OData.Operation
         /// The path parameters in the path
         /// </summary>
         protected IList<OpenApiParameter> PathParameters;
+
+        /// <summary>
+        /// The string representation of the Edm target path for annotations.
+        /// </summary>
+        protected string TargetPath;
 
         /// <inheritdoc/>
         public virtual OpenApiOperation CreateOperation(ODataContext context, ODataPath path)
@@ -122,6 +128,7 @@ namespace Microsoft.OpenApi.OData.Operation
         protected virtual void Initialize(ODataContext context, ODataPath path)
         {
             SetCustomLinkRelType();
+            SetTargetPath();
         }
 
         /// <summary>
@@ -288,6 +295,19 @@ namespace Microsoft.OpenApi.OData.Operation
                     CustomLinkRel = linkRelValue;
                 }
             }
+        }
+
+        /// <summary>
+        /// Set string representation of the Edm Target Path for annotations
+        /// </summary>
+        protected virtual void SetTargetPath()
+        {
+            var targetPath = new StringBuilder(Context.Model.EntityContainer.FullName());
+            foreach (var segment in Path.Segments.Where(segment => segment is not ODataKeySegment))
+            {
+                targetPath.Append($"/{segment.Identifier}");
+            }
+            TargetPath = targetPath.ToString();
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -304,9 +304,8 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             var targetPath = new StringBuilder(Context.Model.EntityContainer.FullName());
 
-            bool skipLastSegment = Path.LastSegment is ODataRefSegment;
+            bool skipLastSegment = Path.LastSegment is ODataRefSegment || Path.LastSegment is ODataDollarCountSegment;
             foreach (var segment in Path.Segments.Where(segment => segment is not ODataKeySegment 
-                && segment is not ODataTypeCastSegment // TODO: Presence of type casts in the TargetPath is currently throwing exceptions in Edm lib. Remove after update.
                 && !(skipLastSegment && segment == Path.LastSegment)))
             {
                 targetPath.Append($"/{segment.Identifier}");

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -285,6 +285,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     OperationType.Get => Path.LastSegment?.Kind ==  ODataSegmentKind.Key ? LinkRelKey.ReadByKey : LinkRelKey.List,
                     OperationType.Post => LinkRelKey.Create,
                     OperationType.Patch => LinkRelKey.Update,
+                    OperationType.Put => LinkRelKey.Update,
                     OperationType.Delete => LinkRelKey.Delete,
                     _ => null,
                 };

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandler.cs
@@ -303,11 +303,16 @@ namespace Microsoft.OpenApi.OData.Operation
         protected virtual void SetTargetPath()
         {
             var targetPath = new StringBuilder(Context.Model.EntityContainer.FullName());
-            foreach (var segment in Path.Segments.Where(segment => segment is not ODataKeySegment))
+
+            bool skipLastSegment = Path.LastSegment is ODataRefSegment;
+            foreach (var segment in Path.Segments.Where(segment => segment is not ODataKeySegment 
+                && segment is not ODataTypeCastSegment // TODO: Presence of type casts in the TargetPath is currently throwing exceptions in Edm lib. Remove after update.
+                && !(skipLastSegment && segment == Path.LastSegment)))
             {
                 targetPath.Append($"/{segment.Identifier}");
             }
             TargetPath = targetPath.ToString();
         }
+
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
@@ -30,7 +30,17 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.Initialize(context, path);
 
-            _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(Singleton, CapabilitiesConstants.ReadRestrictions);
+            _readRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(TargetPath, CapabilitiesConstants.ReadRestrictions);
+            var singletonReadRestrictions = Context.Model.GetRecord<ReadRestrictionsType>(Singleton, CapabilitiesConstants.ReadRestrictions);
+
+            if (_readRestrictions == null)
+            {
+                _readRestrictions = singletonReadRestrictions;
+            }
+            else
+            {
+                _readRestrictions.MergePropertiesIfNull(singletonReadRestrictions);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonOperationHandler.cs
@@ -65,13 +65,19 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetExternalDocs(OpenApiOperation operation)
         {
-            if (Context.Settings.ShowExternalDocs && Context.Model.GetLinkRecord(Singleton, CustomLinkRel) is Link externalDocs)
+            if (Context.Settings.ShowExternalDocs)
             {
-                operation.ExternalDocs = new OpenApiExternalDocs() 
-                { 
-                    Description = CoreConstants.ExternalDocsDescription, 
-                    Url = externalDocs.Href 
-                };
+                var externalDocs = Context.Model.GetLinkRecord(TargetPath, CustomLinkRel) ??
+                    Context.Model.GetLinkRecord(Singleton, CustomLinkRel);
+
+                if (externalDocs != null)
+                {
+                    operation.ExternalDocs = new OpenApiExternalDocs()
+                    {
+                        Description = CoreConstants.ExternalDocsDescription,
+                        Url = externalDocs.Href
+                    };
+                }
             }
         }
     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonPatchOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/SingletonPatchOperationHandler.cs
@@ -30,7 +30,17 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             base.Initialize(context, path);
 
-            _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(Singleton, CapabilitiesConstants.UpdateRestrictions);
+            _updateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(TargetPath, CapabilitiesConstants.UpdateRestrictions);
+            var singletonUpdateRestrictions = Context.Model.GetRecord<UpdateRestrictionsType>(Singleton, CapabilitiesConstants.UpdateRestrictions);
+
+            if (_updateRestrictions == null)
+            {
+                _updateRestrictions = singletonUpdateRestrictions;
+            }
+            else
+            {
+                _updateRestrictions.MergePropertiesIfNull(singletonUpdateRestrictions);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/DeleteRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/DeleteRestrictionsType.cs
@@ -123,5 +123,35 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
             // LongDescription
             LongDescription = record.GetString("LongDescription");
         }
+
+        /// <summary>
+        /// Merges properties of the specified <see cref="DeleteRestrictionsType"/> object into this instance if they are null.
+        /// </summary>
+        /// <param name="source">The <see cref="DeleteRestrictionsType"/> object containing properties to merge.</param>
+        public void MergePropertiesIfNull(DeleteRestrictionsType source)
+        {
+            if (source == null)
+                return;
+
+            Deletable ??= source.Deletable;
+
+            NonDeletableNavigationProperties ??= source.NonDeletableNavigationProperties;
+
+            MaxLevels ??= source.MaxLevels;
+
+            FilterSegmentSupported ??= source.FilterSegmentSupported;
+
+            TypecastSegmentSupported ??= source.TypecastSegmentSupported;
+
+            Permissions ??= source.Permissions;
+
+            CustomHeaders ??= source.CustomHeaders;
+
+            CustomQueryOptions ??= source.CustomQueryOptions;
+
+            Description ??= source.Description;
+
+            LongDescription ??= source.LongDescription;
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/InsertRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/InsertRestrictionsType.cs
@@ -146,5 +146,39 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
             // ResponseContentTypes
             ResponseContentTypes = record.GetCollection("ResponseContentTypes");
         }
+
+        /// <summary>
+        /// Merges properties of the specified <see cref="InsertRestrictionsType"/> object into this instance if they are null.
+        /// </summary>
+        /// <param name="source">The <see cref="InsertRestrictionsType"/> object containing properties to merge.</param>
+        public void MergePropertiesIfNull(InsertRestrictionsType source)
+        {
+            if (source == null)
+                return;
+
+            Insertable ??= source.Insertable;
+
+            NonInsertableNavigationProperties ??= source.NonInsertableNavigationProperties;
+
+            MaxLevels ??= source.MaxLevels;
+
+            TypecastSegmentSupported ??= source.TypecastSegmentSupported;
+
+            Permissions ??= source.Permissions;
+
+            QueryOptions ??= source.QueryOptions;
+
+            CustomHeaders ??= source.CustomHeaders;
+
+            CustomQueryOptions ??= source.CustomQueryOptions;
+
+            Description ??= source.Description;
+
+            LongDescription ??= source.LongDescription;
+
+            RequestContentTypes ??= source.RequestContentTypes;
+
+            ResponseContentTypes ??= source.ResponseContentTypes;
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/OperationRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/OperationRestrictionsType.cs
@@ -37,7 +37,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
         public IList<CustomParameter> CustomQueryOptions { get; private set; }
 
         /// <summary>
-        /// Init the <see cref="SearchRestrictionsType"/>.
+        /// Init the <see cref="OperationRestrictionsType"/>.
         /// </summary>
         /// <param name="record">The input record.</param>
         public void Initialize(IEdmRecordExpression record)
@@ -55,6 +55,24 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
 
             // CustomQueryOptions
             CustomQueryOptions = record.GetCollection<CustomParameter>("CustomQueryOptions");
+        }
+
+        /// <summary>
+        /// Merges properties of the specified <see cref="OperationRestrictionsType"/> object into this instance if they are null.
+        /// </summary>
+        /// <param name="source">The <see cref="OperationRestrictionsType"/> object containing properties to merge.</param>
+        public void MergePropertiesIfNull(OperationRestrictionsType source)
+        {
+            if (source == null)
+                return;
+
+            FilterSegmentSupported ??= source.FilterSegmentSupported;
+
+            Permissions ??= source.Permissions;
+
+            CustomHeaders ??= source.CustomHeaders;
+
+            CustomQueryOptions ??= source.CustomQueryOptions;
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/ReadRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/ReadRestrictionsType.cs
@@ -77,6 +77,29 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
             // LongDescription
             LongDescription = record.GetString("LongDescription");
         }
+
+
+        /// <summary>
+        /// Merges properties of the specified <see cref="ReadRestrictionsBase"/> object into this instance if they are null.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadRestrictionsBase"/> object containing properties to merge.</param>
+        public void MergePropertiesIfNull(ReadRestrictionsBase source)
+        {
+            if (source == null)
+                return;
+
+            Readable ??= source.Readable;
+
+            Permissions ??= source.Permissions;
+
+            CustomHeaders ??= source.CustomHeaders;
+
+            CustomQueryOptions ??= source.CustomQueryOptions;
+
+            Description ??= source.Description;
+
+            LongDescription ??= source.LongDescription;
+        }
     }
 
     /// <summary>
@@ -110,6 +133,20 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
 
             // ReadByKeyRestrictions
             ReadByKeyRestrictions = record.GetRecord<ReadByKeyRestrictions>("ReadByKeyRestrictions");
+        }
+
+        /// <summary>
+        /// Merges properties of the specified <see cref="ReadRestrictionsType"/> object into this instance if they are null.
+        /// </summary>
+        /// <param name="source">The <see cref="ReadRestrictionsType"/> object containing properties to merge.</param>
+        public void MergePropertiesIfNull(ReadRestrictionsType source)
+        {
+            base.MergePropertiesIfNull(source);
+
+            if (source == null)
+                return;
+
+            ReadByKeyRestrictions ??= source.ReadByKeyRestrictions;
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Capabilities/UpdateRestrictionsType.cs
@@ -196,5 +196,47 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Capabilities
             // ResponseContentTypes
             ResponseContentTypes = record.GetCollection("ResponseContentTypes");
         }
+
+        /// <summary>
+        /// Merges properties of the specified <see cref="UpdateRestrictionsType"/> object into this instance if they are null.
+        /// </summary>
+        /// <param name="source">The <see cref="UpdateRestrictionsType"/> object containing properties to merge.</param>
+        public void MergePropertiesIfNull(UpdateRestrictionsType source)
+        {
+            if (source == null)
+                return;
+
+            Updatable ??= source.Updatable;
+
+            Upsertable ??= source.Upsertable;
+
+            DeltaUpdateSupported ??= source.DeltaUpdateSupported;
+
+            UpdateMethod ??= source.UpdateMethod;
+
+            FilterSegmentSupported ??= source.FilterSegmentSupported;
+
+            TypecastSegmentSupported ??= source.TypecastSegmentSupported;
+
+            NonUpdatableNavigationProperties ??= source.NonUpdatableNavigationProperties;
+
+            MaxLevels ??= source.MaxLevels;
+
+            Permissions ??= source.Permissions;
+
+            QueryOptions ??= source.QueryOptions;
+
+            CustomHeaders ??= source.CustomHeaders;
+
+            CustomQueryOptions ??= source.CustomQueryOptions;
+
+            Description ??= source.Description;
+
+            LongDescription ??= source.LongDescription;
+
+            RequestContentTypes ??= source.RequestContentTypes;
+
+            ResponseContentTypes ??= source.ResponseContentTypes;
+        }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/LinkType.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Vocabulary/Core/LinkType.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Core
     /// Complex Type: Org.OData.Core.V1.Link
     /// </summary>
     [Term("Org.OData.Core.V1.Links")]
-    internal class Link : IRecord
+    internal class LinkType : IRecord
     {
         /// <summary>
         /// The link relation type.
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.OData.Vocabulary.Core
         public Uri Href { get; private set; }
 
         /// <summary>
-        /// Init the <see cref="Link"/>.
+        /// Init the <see cref="LinkType"/>.
         /// </summary>
         /// <param name="record"></param>
         public virtual void Initialize(IEdmRecordExpression record)

--- a/src/OoasGui/OoasGui.csproj
+++ b/src/OoasGui/OoasGui.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.20.0" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.21.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyGetOperationHandlerTests.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Tests;
 using Xunit;
 
 namespace Microsoft.OpenApi.OData.Operation.Tests;
@@ -100,4 +101,30 @@ public class ComplexPropertyGetOperationHandlerTests
 			Assert.Null(get.OperationId);
 		}
 	}
+
+    [Fact]
+    public void CreateComplexPropertyGetOperationWithTargetPathAnnotationsReturnsCorrectOperation()
+    {
+        // Arrange
+        IEdmModel model = EdmModelHelper.TripServiceModel;
+        ODataContext context = new(model, new OpenApiConvertSettings());
+        IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+        Assert.NotNull(people);
+
+        IEdmEntityType person = people.EntityType();
+        IEdmProperty complexProperty = person.FindProperty("FavoriteFeature");
+        ODataPath path = new (new ODataNavigationSourceSegment(people), new ODataKeySegment(person), new ODataComplexPropertySegment(complexProperty as IEdmStructuralProperty));
+
+        // Act
+        var operation = _operationHandler.CreateOperation(context, path);
+
+        // Assert
+        Assert.NotNull(operation);
+        Assert.Equal("Get favourite feature", operation.Summary);
+        Assert.Equal("Get the favourite feature of a specific person", operation.Description);
+
+        Assert.NotNull(operation.ExternalDocs);
+        Assert.Equal("Find more info here", operation.ExternalDocs.Description);
+        Assert.Equal("https://learn.microsoft.com/graph/api/person-favorite-feature?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+    }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/DollarCountGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/DollarCountGetOperationHandlerTests.cs
@@ -90,7 +90,11 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             // Assert
             Assert.NotNull(operation.Parameters);
-            Assert.NotEmpty(operation.Parameters);
+            Assert.Equal(4, operation.Parameters.Count);
+            Assert.Equal(new[] { "id", "ConsistencyLevel", "search", "filter" },
+                operation.Parameters.Select(x => x.Name ?? x.Reference.Id).ToList());
+
+            Assert.Equal("Get the number of the resource", operation.Summary);
 
             Assert.Null(operation.RequestBody);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/DollarCountGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/DollarCountGetOperationHandlerTests.cs
@@ -69,6 +69,34 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             }
         }
 
+        [Fact]
+        public void CreateDollarCountGetOperationForNavigationPropertyWithTargetPathAnnotationsReturnsCorrectOperation()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model, new OpenApiConvertSettings());
+            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
+            Assert.NotNull(users);
+
+            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
+            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "appRoleAssignments");
+            ODataPath path = new(new ODataNavigationSourceSegment(users),
+                new ODataKeySegment(users.EntityType()),
+                new ODataNavigationPropertySegment(navProperty),
+                new ODataDollarCountSegment());
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation.Parameters);
+            Assert.NotEmpty(operation.Parameters);
+
+            Assert.Null(operation.RequestBody);
+
+            Assert.Equal(2, operation.Responses.Count);
+        }
+
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, true)]
@@ -114,6 +142,33 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             {
                 Assert.Null(operation.OperationId);
             }
+        }
+
+        [Fact]
+        public void CreateDollarCountGetOperationForNavigationSourceWithTargetPathAnnotationsReturnsCorrectOperation()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model, new OpenApiConvertSettings());
+            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
+            Assert.NotNull(users);
+
+            ODataPath path = new(new ODataNavigationSourceSegment(users),
+                new ODataDollarCountSegment());
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Get the number of the resource", operation.Summary);
+            Assert.NotNull(operation.Parameters);
+            Assert.Equal(3, operation.Parameters.Count);
+            Assert.Equal(new[] { "ConsistencyLevel", "search", "filter" },
+                operation.Parameters.Select(x => x.Name ?? x.Reference.Id).ToList());
+
+            Assert.Null(operation.RequestBody);
+            Assert.Equal(2, operation.Responses.Count);
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -7,7 +7,6 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.Vocabulary.Core;
 using System.Linq;
 using System.Xml.Linq;
 using Xunit;
@@ -184,6 +183,34 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             bool result = CsdlReader.TryParse(XElement.Parse(modelText).CreateReader(), out IEdmModel model, out _);
             Assert.True(result);
             return model;
+        }
+
+        [Fact]
+        public void CreateMediaEntityPropertyGetOperationWithTargetPathAnnotationsReturnsCorrectOperation()
+        {
+            // Arrange
+            IEdmModel model = OData.Tests.EdmModelHelper.TripServiceModel;
+            ODataContext context = new(model, new OpenApiConvertSettings());
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
+
+            IEdmEntityType person = people.EntityType();
+            IEdmStructuralProperty property = person.StructuralProperties().First(c => c.Name == "Photo");
+            ODataPath path = new (new ODataNavigationSourceSegment(people),
+                new ODataKeySegment(person),
+                new ODataStreamPropertySegment(property.Name));
+
+            // Act
+            var operation = _operationalHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Get photo", operation.Summary);
+            Assert.Equal("Get photo of a specific user", operation.Description);
+
+            Assert.NotNull(operation.ExternalDocs);
+            Assert.Equal("Find more info here", operation.ExternalDocs.Description);
+            Assert.Equal("https://learn.microsoft.com/graph/api/person-get-photo?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -159,5 +159,33 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.Null(putOperation2.OperationId);
             }
         }
+
+        [Fact]
+        public void CreateMediaEntityPropertyPutOperationWithTargetPathAnnotationsReturnsCorrectOperation()
+        {
+            // Arrange
+            IEdmModel model = OData.Tests.EdmModelHelper.TripServiceModel;
+            ODataContext context = new(model, new OpenApiConvertSettings());
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
+
+            IEdmEntityType person = people.EntityType();
+            IEdmStructuralProperty property = person.StructuralProperties().First(c => c.Name == "Photo");
+            ODataPath path = new(new ODataNavigationSourceSegment(people),
+                new ODataKeySegment(person),
+                new ODataStreamPropertySegment(property.Name));
+
+            // Act
+            var operation = _operationalHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Update photo", operation.Summary);
+            Assert.Equal("Update photo of a specific user", operation.Description);
+
+            Assert.NotNull(operation.ExternalDocs);
+            Assert.Equal("Find more info here", operation.ExternalDocs.Description);
+            Assert.Equal("https://learn.microsoft.com/graph/api/person-update-photo?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+        }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyDeleteOperationHandlerTests.cs
@@ -70,26 +70,26 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateNavigationDeleteOperationWithTargetPathAnnotationsReturnsCorrectOperation()
         {
             // Arrange
-            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            IEdmModel model = EdmModelHelper.TripServiceModel;
             ODataContext context = new(model, new OpenApiConvertSettings());
-            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
-            Assert.NotNull(users);
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
 
-            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
-            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "appRoleAssignments");
-            ODataPath path = new(new ODataNavigationSourceSegment(users), new ODataKeySegment(users.EntityType()), new ODataNavigationPropertySegment(navProperty));
+            IEdmEntityType person = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Person");
+            IEdmNavigationProperty navProperty = person.DeclaredNavigationProperties().First(c => c.Name == "Friends");
+            ODataPath path = new(new ODataNavigationSourceSegment(people), new ODataKeySegment(people.EntityType()), new ODataNavigationPropertySegment(navProperty));
 
             // Act
             var operation = _operationHandler.CreateOperation(context, path);
 
             // Assert
             Assert.NotNull(operation);
-            Assert.Equal("Delete appRoleAssignment", operation.Summary);
-            Assert.Equal("Delete an appRoleAssignment that has been granted to a user.", operation.Description);
+            Assert.Equal("Delete a friend.", operation.Summary);
+            Assert.Equal("Delete an instance of a friend relationship.", operation.Description);
             
             Assert.NotNull(operation.ExternalDocs);
             Assert.Equal("Find more info here", operation.ExternalDocs.Description);
-            Assert.Equal("https://learn.microsoft.com/graph/api/user-delete-approleassignments?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+            Assert.Equal("https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyDeleteOperationHandlerTests.cs
@@ -65,5 +65,31 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.Null(operation.OperationId);
             }
         }
+
+        [Fact]
+        public void CreateNavigationDeleteOperationWithTargetPathAnnotationsReturnsCorrectOperation()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model, new OpenApiConvertSettings());
+            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
+            Assert.NotNull(users);
+
+            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
+            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "appRoleAssignments");
+            ODataPath path = new(new ODataNavigationSourceSegment(users), new ODataKeySegment(users.EntityType()), new ODataNavigationPropertySegment(navProperty));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Delete appRoleAssignment", operation.Summary);
+            Assert.Equal("Delete an appRoleAssignment that has been granted to a user.", operation.Description);
+            
+            Assert.NotNull(operation.ExternalDocs);
+            Assert.Equal("Find more info here", operation.ExternalDocs.Description);
+            Assert.Equal("https://learn.microsoft.com/graph/api/user-delete-approleassignments?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+        }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
@@ -71,6 +71,32 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         }
 
         [Fact]
+        public void CreateNavigationGetOperationWithTargetPathAnnotationsReturnsCorrectOperation()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new ODataContext(model, new OpenApiConvertSettings());
+            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
+            Assert.NotNull(users);
+
+            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
+            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "appRoleAssignments");
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(users), new ODataKeySegment(users.EntityType()), new ODataNavigationPropertySegment(navProperty));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("List appRoleAssignments granted to a user", operation.Summary);
+            Assert.Equal("Retrieve the list of appRoleAssignments that are currently granted to a user. This operation also returns app role assignments granted to groups that the user is a direct member of.", operation.Description);
+         
+            Assert.NotNull(operation.ExternalDocs);
+            Assert.Equal("Find more info here", operation.ExternalDocs.Description);
+            Assert.Equal("https://learn.microsoft.com/graph/api/user-list-approleassignments?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+        }
+
+        [Fact]
         public void CreateNavigationGetOperationViaComposableFunctionReturnsCorrectOperation()
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyGetOperationHandlerTests.cs
@@ -71,29 +71,33 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         }
 
         [Fact]
-        public void CreateNavigationGetOperationWithTargetPathAnnotationsReturnsCorrectOperation()
+        public void CreateNavigationGetOperationWithTargetPathAnnotationsAndNavigationPropertyAnnotationsReturnsCorrectOperation()
         {
             // Arrange
-            IEdmModel model = EdmModelHelper.GraphBetaModel;
-            ODataContext context = new ODataContext(model, new OpenApiConvertSettings());
-            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
-            Assert.NotNull(users);
+            IEdmModel model = EdmModelHelper.TripServiceModel;
+            ODataContext context = new(model, new OpenApiConvertSettings());
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
 
-            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
-            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "appRoleAssignments");
-            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(users), new ODataKeySegment(users.EntityType()), new ODataNavigationPropertySegment(navProperty));
+            IEdmEntityType person = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Person");
+            IEdmNavigationProperty navProperty = person.DeclaredNavigationProperties().First(c => c.Name == "Friends");
+            ODataPath path = new(new ODataNavigationSourceSegment(people), new ODataKeySegment(people.EntityType()), new ODataNavigationPropertySegment(navProperty));
 
             // Act
             var operation = _operationHandler.CreateOperation(context, path);
 
             // Assert
             Assert.NotNull(operation);
-            Assert.Equal("List appRoleAssignments granted to a user", operation.Summary);
-            Assert.Equal("Retrieve the list of appRoleAssignments that are currently granted to a user. This operation also returns app role assignments granted to groups that the user is a direct member of.", operation.Description);
+            Assert.Equal("List friends", operation.Summary);
+            Assert.Equal("List the friends of a specific person", operation.Description);
          
             Assert.NotNull(operation.ExternalDocs);
             Assert.Equal("Find more info here", operation.ExternalDocs.Description);
-            Assert.Equal("https://learn.microsoft.com/graph/api/user-list-approleassignments?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+            Assert.Equal("https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+
+            Assert.NotNull(operation.Parameters);
+            Assert.Equal(10, operation.Parameters.Count);
+            Assert.Contains(operation.Parameters, x => x.Name == "ConsistencyLevel");
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
@@ -71,6 +71,32 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         }
 
         [Fact]
+        public void CreateNavigationPostOperationWithTargetPathAnnotationsReturnsCorrectOperation()
+        {
+            // Arrange
+            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            ODataContext context = new(model, new OpenApiConvertSettings());
+            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
+            Assert.NotNull(users);
+
+            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
+            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "appRoleAssignments");
+            ODataPath path = new(new ODataNavigationSourceSegment(users), new ODataKeySegment(users.EntityType()), new ODataNavigationPropertySegment(navProperty));
+
+            // Act
+            var operation = _operationHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Grant an appRoleAssignment to a user", operation.Summary);
+            Assert.Equal("Use this API to assign an app role to a user.", operation.Description);
+
+            Assert.NotNull(operation.ExternalDocs);
+            Assert.Equal("Find more info here", operation.ExternalDocs.Description);
+            Assert.Equal("https://learn.microsoft.com/graph/api/user-post-approleassignments?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+        }
+
+        [Fact]
         public void CreateNavigationPostOperationReturnsCorrectOperationWithAnnotatedRequestBodyContent()
         {
             IEdmModel model = EdmModelHelper.GraphBetaModel;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPostOperationHandlerTests.cs
@@ -74,26 +74,26 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         public void CreateNavigationPostOperationWithTargetPathAnnotationsReturnsCorrectOperation()
         {
             // Arrange
-            IEdmModel model = EdmModelHelper.GraphBetaModel;
+            IEdmModel model = EdmModelHelper.TripServiceModel;
             ODataContext context = new(model, new OpenApiConvertSettings());
-            IEdmEntitySet users = model.EntityContainer.FindEntitySet("users");
-            Assert.NotNull(users);
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
 
-            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
-            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "appRoleAssignments");
-            ODataPath path = new(new ODataNavigationSourceSegment(users), new ODataKeySegment(users.EntityType()), new ODataNavigationPropertySegment(navProperty));
+            IEdmEntityType person = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Person");
+            IEdmNavigationProperty navProperty = person.DeclaredNavigationProperties().First(c => c.Name == "Friends");
+            ODataPath path = new(new ODataNavigationSourceSegment(people), new ODataKeySegment(people.EntityType()), new ODataNavigationPropertySegment(navProperty));
 
             // Act
             var operation = _operationHandler.CreateOperation(context, path);
 
             // Assert
             Assert.NotNull(operation);
-            Assert.Equal("Grant an appRoleAssignment to a user", operation.Summary);
-            Assert.Equal("Use this API to assign an app role to a user.", operation.Description);
+            Assert.Equal("Create a friend.", operation.Summary);
+            Assert.Equal("Create a new friend.", operation.Description);
 
             Assert.NotNull(operation.ExternalDocs);
             Assert.Equal("Find more info here", operation.ExternalDocs.Description);
-            Assert.Equal("https://learn.microsoft.com/graph/api/user-post-approleassignments?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+            Assert.Equal("https://learn.microsoft.com/graph/api/person-post-friend?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
         }
 
         [Fact]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefDeleteOperationHandlerTests.cs
@@ -50,6 +50,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             Assert.NotNull(operation.Parameters);
             Assert.NotEmpty(operation.Parameters);
+            Assert.Equal(3, operation.Parameters.Count);
 
             Assert.Null(operation.RequestBody);
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -63,6 +63,7 @@
 				</Property>
 				<Property Name="FavoriteFeature" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature" Nullable="false" />
 				<Property Name="Features" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature)" Nullable="false" />
+				<Property Name="Photo" Type="Edm.Stream"/>
 				<NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)">
 					<Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
 						<Collection>
@@ -73,6 +74,29 @@
 					<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
 						<Record>
 							<PropertyValue Property="Referenceable" Bool="true" />
+						</Record>
+					</Annotation>
+					<Annotation Term="Org.OData.Core.V1.Description" String="Friends of person" />
+					<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+						<Record>
+							<PropertyValue Property="CustomHeaders">
+								<Collection>
+									<Record>
+										<PropertyValue Property="Name" String="ConsistencyLevel" />
+										<PropertyValue Property="Description" String="Indicates the requested consistency level." />
+										<PropertyValue Property="DocumentationURL" String="https://docs.microsoft.com/graph/aad-advanced-queries" />
+										<PropertyValue Property="Required" Bool="false" />
+										<PropertyValue Property="ExampleValues">
+											<Collection>
+												<Record>
+													<PropertyValue Property="Value" String="eventual" />
+													<PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+												</Record>
+											</Collection>
+										</PropertyValue>
+									</Record>
+								</Collection>
+							</PropertyValue>
 						</Record>
 					</Annotation>
 				</NavigationProperty>
@@ -455,6 +479,140 @@
 						<PropertyValue Property="LongDescription" String="Create a new trip." />
 						<PropertyValue Property="Description" String="Create a trip." />
 					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Core.V1.Links">
+					<Collection>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/create" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/list" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/update" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/delete" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/get" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0" />
+						</Record>
+					</Collection>
+				</Annotation>
+			</Annotations>
+			<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/Me">
+				<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Get signed in person" />
+						<PropertyValue Property="LongDescription" String="Retrieve the properties and relationships of Person object." />
+					</Record>
+				</Annotation>
+			</Annotations>
+			<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/People/HomeAddress">
+				<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Get home address" />
+						<PropertyValue Property="LongDescription" String="Get the home address of a specific person" />
+					</Record>
+				</Annotation>
+			</Annotations>
+			<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/People/Friends">
+				<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="List friends" />
+						<PropertyValue Property="LongDescription" String="List the friends of a specific person" />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Delete a friend." />
+						<PropertyValue Property="LongDescription" String="Delete an instance of a friend relationship." />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Create a friend." />
+						<PropertyValue Property="LongDescription" String="Create a new friend." />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Core.V1.Links">
+					<Collection>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/create" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-post-friend?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/list" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/delete" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0" />
+						</Record>
+					</Collection>
+				</Annotation>
+			</Annotations>
+			<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/People/BestFriend/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager">
+				<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Get best friend" />
+						<PropertyValue Property="LongDescription" String="Get the item of type Person cast as Manager" />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Core.V1.Links">
+					<Collection>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/list" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-get-friend-manager?view=graph-rest-1.0" />
+						</Record>
+					</Collection>
+				</Annotation>
+			</Annotations>
+			<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/People/FavoriteFeature">
+				<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Get favourite feature" />
+						<PropertyValue Property="LongDescription" String="Get the favourite feature of a specific person" />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Core.V1.Links">
+					<Collection>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/list" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-favorite-feature?view=graph-rest-1.0" />
+						</Record>
+					</Collection>
+				</Annotation>
+			</Annotations>
+			<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/People/Photo">
+				<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Get photo" />
+						<PropertyValue Property="LongDescription" String="Get photo of a specific user" />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Update photo" />
+						<PropertyValue Property="LongDescription" String="Update photo of a specific user" />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Core.V1.Links">
+					<Collection>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/list" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-get-photo?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/update" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-update-photo?view=graph-rest-1.0" />
+						</Record>
+					</Collection>
 				</Annotation>
 			</Annotations>
 		</Schema>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -407,56 +407,56 @@
           <Annotation Term="Org.OData.Core.V1.Description" String="Resets the data source to default values." />
         </ActionImport>
       </EntityContainer>
-		<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/People/Trips">
-		<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-		  <Record>
-			<PropertyValue Property="CustomHeaders">
-				  <Collection>
-					  <Record>
-						  <PropertyValue Property="Name" String="ConsistencyLevel" />
-						  <PropertyValue Property="Description" String="Indicates the requested consistency level." />
-						  <PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
-						  <PropertyValue Property="Required" Bool="false" />
-						  <PropertyValue Property="ExampleValues">
-							  <Collection>
-								  <Record>
-									  <PropertyValue Property="Value" String="eventual" />
-									  <PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
-								  </Record>
-							  </Collection>
-						  </PropertyValue>
-					  </Record>
-				  </Collection>
-			  </PropertyValue>
-			<PropertyValue Property="LongDescription" String="Retrieve a list of trips." />
-			<PropertyValue Property="Description" String="List trips." />
-			<PropertyValue Property="ReadByKeyRestrictions">
-			  <Record>
-				<PropertyValue Property="LongDescription" String="Retrieve the properties of a trip." />
-				<PropertyValue Property="Description" String="Get a trip." />
-			  </Record>
-			</PropertyValue>
-		  </Record>
-		</Annotation>
-		<Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-		  <Record>
-			<PropertyValue Property="LongDescription" String="Delete an instance of a trip." />
-			<PropertyValue Property="Description" String="Delete a trip." />
-		  </Record>
-		</Annotation>
-		<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-		  <Record>
-			<PropertyValue Property="LongDescription" String="Update an instance of a trip." />
-			<PropertyValue Property="Description" String="Update a trip." />
-		  </Record>
-		</Annotation>
-		<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-		  <Record>
-			<PropertyValue Property="LongDescription" String="Create a new trip." />
-			<PropertyValue Property="Description" String="Create a trip." />
-		  </Record>
-		</Annotation>		
-      </Annotations>
+		<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person/Trips">
+			<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+				<Record>
+					<PropertyValue Property="CustomHeaders">
+						<Collection>
+							<Record>
+								<PropertyValue Property="Name" String="ConsistencyLevel" />
+								<PropertyValue Property="Description" String="Indicates the requested consistency level." />
+								<PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
+								<PropertyValue Property="Required" Bool="false" />
+								<PropertyValue Property="ExampleValues">
+									<Collection>
+										<Record>
+											<PropertyValue Property="Value" String="eventual" />
+											<PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+										</Record>
+									</Collection>
+								</PropertyValue>
+							</Record>
+						</Collection>
+					</PropertyValue>
+					<PropertyValue Property="LongDescription" String="Retrieve a list of trips." />
+					<PropertyValue Property="Description" String="List trips." />
+					<PropertyValue Property="ReadByKeyRestrictions">
+						<Record>
+							<PropertyValue Property="LongDescription" String="Retrieve the properties of a trip." />
+							<PropertyValue Property="Description" String="Get a trip." />
+						</Record>
+					</PropertyValue>
+				</Record>
+			</Annotation>
+			<Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+				<Record>
+					<PropertyValue Property="LongDescription" String="Delete an instance of a trip." />
+					<PropertyValue Property="Description" String="Delete a trip." />
+				</Record>
+			</Annotation>
+			<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+				<Record>
+					<PropertyValue Property="LongDescription" String="Update an instance of a trip." />
+					<PropertyValue Property="Description" String="Update a trip." />
+				</Record>
+			</Annotation>
+			<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+				<Record>
+					<PropertyValue Property="LongDescription" String="Create a new trip." />
+					<PropertyValue Property="Description" String="Create a trip." />
+				</Record>
+			</Annotation>
+		</Annotations>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -407,7 +407,7 @@
           <Annotation Term="Org.OData.Core.V1.Description" String="Resets the data source to default values." />
         </ActionImport>
       </EntityContainer>
-      <Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person/Trips">
+		<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Container/People/Trips">
 		<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
 		  <Record>
 			<PropertyValue Property="CustomHeaders">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -1,462 +1,462 @@
 <?xml version="1.0" encoding="utf-8"?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" xmlns:ags="http://aggregator.microsoft.com/internal">
-<edmx:DataServices>
-    <Schema Namespace="Microsoft.OData.Service.Sample.TrippinInMemory.Models" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-      <ComplexType Name="InnerError">
-        <Property Name="Date" Type="Edm.DateTimeOffset" />
-        <Property Name="RequestId" Type="Edm.String" />
-      </ComplexType>
-      <EntityType Name="Person">
-        <Key>
-          <PropertyRef Name="UserName" />
-        </Key>
-        <Property Name="UserName" Type="Edm.String" Nullable="false" />
-        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
-        <Property Name="LastName" Type="Edm.String" />
-        <Property Name="MiddleName" Type="Edm.String" />
-        <Property Name="Gender" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender" Nullable="false" />
-        <Property Name="Age" Type="Edm.Int64" />
-        <Property Name="Emails" Type="Collection(Edm.String)" />
-        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location)">
-          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
-            <Collection>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation</String>
-            </Collection>
-          </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-			<Record>
-				<PropertyValue Property="Readable" Bool="true" />
-			</Record>
-		  </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-			<Record>
-				<PropertyValue Property="Updatable" Bool="true" />
-			</Record>
-		  </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-			<Record>
-				<PropertyValue Property="Insertable" Bool="true" />
-			</Record>
-		  </Annotation>		
-        </Property>
-        <Property Name="HomeAddress" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
-          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
-            <Collection>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation</String>
-            </Collection>
-          </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-			<Record>
-				<PropertyValue Property="Readable" Bool="true" />
-			</Record>
-		  </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-			<Record>
-				<PropertyValue Property="Updatable" Bool="true" />
-			</Record>
-		  </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-			<Record>
-				<PropertyValue Property="Insertable" Bool="true" />
-			</Record>
-		  </Annotation>
-		</Property>
-        <Property Name="FavoriteFeature" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature" Nullable="false" />
-        <Property Name="Features" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature)" Nullable="false" />
-        <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)">
-          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
-            <Collection>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
-            </Collection>
-          </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-			 <Record>
-				<PropertyValue Property="Referenceable" Bool="true" />
-			 </Record>
-		  </Annotation>
-        </NavigationProperty>
-        <NavigationProperty Name="BestFriend" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
-          <Annotation Term="Org.OData.Core.V1.Description" String="The best friend." />
-          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
-            <Collection>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
-            </Collection>
-          </Annotation>
-          <Annotation Term="Org.OData.Core.V1.Revisions">
-            <Collection>
-              <Record>
-                <PropertyValue Date="2021-08-24" Property="Date" />
-                <PropertyValue Property="Description" String="The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API." />
-                <PropertyValue Property="Kind">
-                  <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
-                </PropertyValue>
-                <PropertyValue Date="2023-03-15" Property="RemovalDate" />
-                <PropertyValue Property="Version" String="2021-05/bestfriend" />
-              </Record>
-            </Collection>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-          <Record>
-            <PropertyValue Property="Referenceable" Bool="true" />
-            <PropertyValue Property="RestrictedProperties">
-              <Collection>
-                <Record>
-                  <PropertyValue Property="UpdateRestrictions">
-                    <Record>
-                      <PropertyValue Property="LongDescription" String="Update an instance of a best friend." />
-                      <PropertyValue Property="Description" String="Update the best friend." />
-					  <PropertyValue Property="Updatable" Bool="true" />
-                    </Record>
-                  </PropertyValue>
-                </Record>
-              </Collection>
-            </PropertyValue>
-          </Record>
-          </Annotation>
-        </NavigationProperty>
-        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" ContainsTarget="true">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Collection of trips." />
-        </NavigationProperty>
-      </EntityType>
-      <EntityType Name="Airline">
-        <Key>
-          <PropertyRef Name="AirlineCode" />
-        </Key>
-        <Property Name="AirlineCode" Type="Edm.String" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="Airport">
-        <Key>
-          <PropertyRef Name="IcaoCode" />
-        </Key>
-        <Property Name="Name" Type="Edm.String" />
-        <Property Name="IcaoCode" Type="Edm.String" Nullable="false" />
-        <Property Name="IataCode" Type="Edm.String" />
-        <Property Name="Location" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation">
-          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-            <Record>
-              <PropertyValue Property="UpdateMethod">
-                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
-              </PropertyValue>
-			  <PropertyValue Property="Updatable" Bool="true" />
-            </Record>
-          </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-			<Record>
-				<PropertyValue Property="Readable" Bool="true" />
-			</Record>
-		  </Annotation>
-        </Property>
-      </EntityType>
-      <ComplexType Name="Location">
-        <Property Name="Address" Type="Edm.String" />
-        <Property Name="City" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.City" />
-      </ComplexType>
-      <ComplexType Name="City">
-        <Property Name="Name" Type="Edm.String" />
-        <Property Name="CountryRegion" Type="Edm.String" />
-        <Property Name="Region" Type="Edm.String" />
-      </ComplexType>
-      <ComplexType Name="AirportLocation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
-        <Property Name="Loc" Type="Edm.GeographyPoint" />
-        <NavigationProperty Name="EmergencyAuthority" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
-          <Annotation Term="Org.OData.Core.V1.Description" String="The person to contact in case of a crisis at this location." />
-		  <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-			<Record>
-				<PropertyValue Property="Referenceable" Bool="true" />
-			</Record>
-		  </Annotation>
-        </NavigationProperty>
-      </ComplexType>
-      <ComplexType Name="EventLocation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
-        <Property Name="BuildingInfo" Type="Edm.String" />
-      </ComplexType>
-      <EntityType Name="Trip">
-        <Key>
-          <PropertyRef Name="TripId" />
-        </Key>
-        <Property Name="TripId" Type="Edm.Int32" Nullable="false" />
-        <Property Name="ShareId" Type="Edm.Guid" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" />
-        <Property Name="Budget" Type="Edm.Single" Nullable="false" />
-        <Property Name="Description" Type="Edm.String" />
-        <Property Name="Tags" Type="Collection(Edm.String)" />
-        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
-        <NavigationProperty Name="PlanItems" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem)" >
-			<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-				<Record>
-					<PropertyValue Property="Referenceable" Bool="true" />
-				</Record>
-			</Annotation>
-		</NavigationProperty>
-      </EntityType>
-      <EntityType Name="PlanItem">
-        <Key>
-          <PropertyRef Name="PlanItemId" />
-        </Key>
-        <Property Name="PlanItemId" Type="Edm.Int32" Nullable="false" />
-        <Property Name="ConfirmationCode" Type="Edm.String" />
-        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="Duration" Type="Edm.Duration" Nullable="false" />
-      </EntityType>
-      <EntityType Name="Event" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem">
-        <Property Name="OccursAt" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation" />
-        <Property Name="Description" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="PublicTransportation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem">
-        <Property Name="SeatNumber" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="Flight" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PublicTransportation">
-        <Property Name="FlightNumber" Type="Edm.String" />
-        <NavigationProperty Name="Airline" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
-        <NavigationProperty Name="From" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
-        <NavigationProperty Name="To" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
-      </EntityType>
-      <EntityType Name="Employee" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" ags:IsHidden="true" ags:WorkloadName="People">
-        <Property Name="Cost" Type="Edm.Int64" Nullable="false" />
-        <NavigationProperty Name="Peers" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" >
-			<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-				<Record>
-					<PropertyValue Property="Referenceable" Bool="true" />
-				</Record>
-			</Annotation>
-	    </NavigationProperty>
-      </EntityType>
-      <EntityType Name="Manager" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
-        <Property Name="Budget" Type="Edm.Int64" Nullable="false" />
-        <Property Name="BossOffice" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location" />
-		<NavigationProperty Name="DirectReports" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" >
-			<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-				<Record>
-					<PropertyValue Property="Referenceable" Bool="true" />
-				</Record>
-			</Annotation>
-		</NavigationProperty>
-      </EntityType>
-      <EnumType Name="PersonGender">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Gender of the person." />
-        <Member Name="Male" Value="0">
-          <Annotation Term="Org.OData.Core.V1.Description" String="The Male gender." />
-        </Member>
-        <Member Name="Female" Value="1">
-          <Annotation Term="Org.OData.Core.V1.Description" String="The Female gender." />
-        </Member>
-        <Member Name="Unknow" Value="2">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Unknown gender or prefers not to say." />
-      </Member>
-    </EnumType>
-      <EnumType Name="Feature" IsFlags="true">
-        <Member Name="Feature1" Value="0" />
-        <Member Name="Feature2" Value="1" />
-        <Member Name="Feature3" Value="2" />
-        <Member Name="Feature4" Value="4" />
-      </EnumType>
-      <Function Name="GetPersonWithMostFriends">
-        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-      </Function>
-      <Function Name="GetNearestAirport">
-        <Parameter Name="lat" Type="Edm.Double" Nullable="false" />
-        <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
-        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
-      </Function>
-      <Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person">
-        <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
-      </Function>
-      <Function Name="GetFriendsTrips" IsBound="true" ags:IsHidden="true" ags:WorkloadName="People">
-        <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
-        <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" />
-        <Annotation Term="Org.OData.Core.V1.Revisions">
-          <Collection>
-            <Record>
-              <PropertyValue Date="2021-08-24" Property="Date" />
-              <PropertyValue Property="Description" String="The GetFriendsTrips API is deprecated and will stop returning data on March 2023. Please use the new trips API on friends." />
-              <PropertyValue Property="Kind">
-                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
-              </PropertyValue>
-              <PropertyValue Date="2023-03-15" Property="RemovalDate" />
-              <PropertyValue Property="Version" String="2021-05/trips" />
-            </Record>
-          </Collection>
-        </Annotation>
-      </Function>
-      <Function Name="GetInvolvedPeople" IsBound="true">
-        <Parameter Name="trip" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip" />
-        <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" />
-      </Function>
-      <Action Name="ResetDataSource" />
-      <Function Name="UpdatePersonLastName" IsBound="true">
-        <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <Parameter Name="lastName" Type="Edm.String" Nullable="false" Unicode="false" />
-        <ReturnType Type="Edm.Boolean" Nullable="false" />
-      </Function>
-      <Action Name="Hire" IsBound="true">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Hires someone for the company." />
-        <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager" />
-        <Parameter Name="hire" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-      </Action>
-      <Action Name="ShareTrip" IsBound="true" ags:IsHidden="true" ags:WorkloadName="People">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Details of the shared trip." />
-        <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
-        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
-      </Action>
-      <Action Name="GetPeersForTrip" IsBound="true">
-        <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
-        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
-        <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" />
-      </Action>
-      <EntityContainer Name="Container">
-        <EntitySet Name="People" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
-          <NavigationPropertyBinding Path="Friends" Target="People" />
-          <NavigationPropertyBinding Path="BestFriend" Target="People" />
-          <NavigationPropertyBinding Path="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers" Target="People" />
-          <NavigationPropertyBinding Path="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports" Target="People" />
-          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
-            <Collection>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
-            </Collection>
-          </Annotation>
-          <Annotation Term="Org.OData.Core.V1.Revisions">
-            <Collection>
-              <Record>
-                <PropertyValue Date="2021-08-24" Property="Date" />
-                <PropertyValue Property="Description" String="The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API." />
-                <PropertyValue Property="Kind">
-                  <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
-                </PropertyValue>
-                <PropertyValue Date="2023-03-15" Property="RemovalDate" />
-                <PropertyValue Property="Version" String="2021-05/people" />
-              </Record>
-            </Collection>
-          </Annotation>
-		  <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-				<Record>
-					<PropertyValue Property="CustomHeaders">
+	<edmx:DataServices>
+		<Schema Namespace="Microsoft.OData.Service.Sample.TrippinInMemory.Models" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+			<ComplexType Name="InnerError">
+				<Property Name="Date" Type="Edm.DateTimeOffset" />
+				<Property Name="RequestId" Type="Edm.String" />
+			</ComplexType>
+			<EntityType Name="Person">
+				<Key>
+					<PropertyRef Name="UserName" />
+				</Key>
+				<Property Name="UserName" Type="Edm.String" Nullable="false" />
+				<Property Name="FirstName" Type="Edm.String" Nullable="false" />
+				<Property Name="LastName" Type="Edm.String" />
+				<Property Name="MiddleName" Type="Edm.String" />
+				<Property Name="Gender" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender" Nullable="false" />
+				<Property Name="Age" Type="Edm.Int64" />
+				<Property Name="Emails" Type="Collection(Edm.String)" />
+				<Property Name="AddressInfo" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location)">
+					<Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
 						<Collection>
-							<Record>
-								<PropertyValue Property="Name" String="ConsistencyLevel" />
-								<PropertyValue Property="Description" String="Indicates the requested consistency level." />
-								<PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
-								<PropertyValue Property="Required" Bool="false" />
-								<PropertyValue Property="ExampleValues">
-									<Collection>
-										<Record>
-											<PropertyValue Property="Value" String="eventual" />
-											<PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
-										</Record>
-									</Collection>
-								</PropertyValue>
-							</Record>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation</String>
 						</Collection>
-					</PropertyValue>
-				</Record>
-			</Annotation>
-        </EntitySet>
-        <EntitySet Name="Airlines" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline">
-          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
-            <Collection>
-              <PropertyPath>Name</PropertyPath>
-            </Collection>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-            <Record>
-              <PropertyValue Property="UpdateMethod">
-                <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
-              </PropertyValue>
-            </Record>
-          </Annotation>
-        </EntitySet>
-        <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport">
-          <NavigationPropertyBinding Path="Location/EmergencyAuthority" Target="People" />
-        </EntitySet>
-        <EntitySet Name="NewComePeople" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
-        <Singleton Name="Me" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
-          <Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
-            <Collection>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
-              <String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
-            </Collection>
-          </Annotation>
-          <Annotation Term="Org.OData.Core.V1.Revisions">
-            <Collection>
-              <Record>
-                <PropertyValue Date="2021-08-24" Property="Date" />
-                <PropertyValue Property="Description" String="The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API." />
-                <PropertyValue Property="Kind">
-                  <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
-                </PropertyValue>
-                <PropertyValue Date="2023-03-15" Property="RemovalDate" />
-                <PropertyValue Property="Version" String="2021-05/me" />
-              </Record>
-            </Collection>
-          </Annotation>
-        </Singleton>
-        <FunctionImport Name="GetPersonWithMostFriends" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPersonWithMostFriends" EntitySet="People">
-          <Annotation Term="Org.OData.Core.V1.Description" String="The person with most friends." />
-        </FunctionImport>
-        <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetNearestAirport" EntitySet="Airports" ags:IsHidden="true"/>
-        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.Service.Sample.TrippinInMemory.Models.ResetDataSource" ags:IsHidden="true">
-          <Annotation Term="Org.OData.Core.V1.Description" String="Resets the data source to default values." />
-        </ActionImport>
-      </EntityContainer>
-		<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person/Trips">
-			<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
-				<Record>
-					<PropertyValue Property="CustomHeaders">
-						<Collection>
-							<Record>
-								<PropertyValue Property="Name" String="ConsistencyLevel" />
-								<PropertyValue Property="Description" String="Indicates the requested consistency level." />
-								<PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
-								<PropertyValue Property="Required" Bool="false" />
-								<PropertyValue Property="ExampleValues">
-									<Collection>
-										<Record>
-											<PropertyValue Property="Value" String="eventual" />
-											<PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
-										</Record>
-									</Collection>
-								</PropertyValue>
-							</Record>
-						</Collection>
-					</PropertyValue>
-					<PropertyValue Property="LongDescription" String="Retrieve a list of trips." />
-					<PropertyValue Property="Description" String="List trips." />
-					<PropertyValue Property="ReadByKeyRestrictions">
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
 						<Record>
-							<PropertyValue Property="LongDescription" String="Retrieve the properties of a trip." />
-							<PropertyValue Property="Description" String="Get a trip." />
+							<PropertyValue Property="Readable" Bool="true" />
 						</Record>
-					</PropertyValue>
-				</Record>
-			</Annotation>
-			<Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-				<Record>
-					<PropertyValue Property="LongDescription" String="Delete an instance of a trip." />
-					<PropertyValue Property="Description" String="Delete a trip." />
-				</Record>
-			</Annotation>
-			<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-				<Record>
-					<PropertyValue Property="LongDescription" String="Update an instance of a trip." />
-					<PropertyValue Property="Description" String="Update a trip." />
-				</Record>
-			</Annotation>
-			<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-				<Record>
-					<PropertyValue Property="LongDescription" String="Create a new trip." />
-					<PropertyValue Property="Description" String="Create a trip." />
-				</Record>
-			</Annotation>
-		</Annotations>
-    </Schema>
-  </edmx:DataServices>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+						<Record>
+							<PropertyValue Property="Updatable" Bool="true" />
+						</Record>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+						<Record>
+							<PropertyValue Property="Insertable" Bool="true" />
+						</Record>
+					</Annotation>
+				</Property>
+				<Property Name="HomeAddress" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
+					<Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+						<Collection>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation</String>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+						<Record>
+							<PropertyValue Property="Readable" Bool="true" />
+						</Record>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+						<Record>
+							<PropertyValue Property="Updatable" Bool="true" />
+						</Record>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+						<Record>
+							<PropertyValue Property="Insertable" Bool="true" />
+						</Record>
+					</Annotation>
+				</Property>
+				<Property Name="FavoriteFeature" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature" Nullable="false" />
+				<Property Name="Features" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature)" Nullable="false" />
+				<NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)">
+					<Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+						<Collection>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+						<Record>
+							<PropertyValue Property="Referenceable" Bool="true" />
+						</Record>
+					</Annotation>
+				</NavigationProperty>
+				<NavigationProperty Name="BestFriend" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+					<Annotation Term="Org.OData.Core.V1.Description" String="The best friend." />
+					<Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+						<Collection>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Core.V1.Revisions">
+						<Collection>
+							<Record>
+								<PropertyValue Date="2021-08-24" Property="Date" />
+								<PropertyValue Property="Description" String="The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API." />
+								<PropertyValue Property="Kind">
+									<EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+								</PropertyValue>
+								<PropertyValue Date="2023-03-15" Property="RemovalDate" />
+								<PropertyValue Property="Version" String="2021-05/bestfriend" />
+							</Record>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+						<Record>
+							<PropertyValue Property="Referenceable" Bool="true" />
+							<PropertyValue Property="RestrictedProperties">
+								<Collection>
+									<Record>
+										<PropertyValue Property="UpdateRestrictions">
+											<Record>
+												<PropertyValue Property="LongDescription" String="Update an instance of a best friend." />
+												<PropertyValue Property="Description" String="Update the best friend." />
+												<PropertyValue Property="Updatable" Bool="true" />
+											</Record>
+										</PropertyValue>
+									</Record>
+								</Collection>
+							</PropertyValue>
+						</Record>
+					</Annotation>
+				</NavigationProperty>
+				<NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" ContainsTarget="true">
+					<Annotation Term="Org.OData.Core.V1.Description" String="Collection of trips." />
+				</NavigationProperty>
+			</EntityType>
+			<EntityType Name="Airline">
+				<Key>
+					<PropertyRef Name="AirlineCode" />
+				</Key>
+				<Property Name="AirlineCode" Type="Edm.String" Nullable="false" />
+				<Property Name="Name" Type="Edm.String" />
+			</EntityType>
+			<EntityType Name="Airport">
+				<Key>
+					<PropertyRef Name="IcaoCode" />
+				</Key>
+				<Property Name="Name" Type="Edm.String" />
+				<Property Name="IcaoCode" Type="Edm.String" Nullable="false" />
+				<Property Name="IataCode" Type="Edm.String" />
+				<Property Name="Location" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportLocation">
+					<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+						<Record>
+							<PropertyValue Property="UpdateMethod">
+								<EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+							</PropertyValue>
+							<PropertyValue Property="Updatable" Bool="true" />
+						</Record>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+						<Record>
+							<PropertyValue Property="Readable" Bool="true" />
+						</Record>
+					</Annotation>
+				</Property>
+			</EntityType>
+			<ComplexType Name="Location">
+				<Property Name="Address" Type="Edm.String" />
+				<Property Name="City" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.City" />
+			</ComplexType>
+			<ComplexType Name="City">
+				<Property Name="Name" Type="Edm.String" />
+				<Property Name="CountryRegion" Type="Edm.String" />
+				<Property Name="Region" Type="Edm.String" />
+			</ComplexType>
+			<ComplexType Name="AirportLocation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
+				<Property Name="Loc" Type="Edm.GeographyPoint" />
+				<NavigationProperty Name="EmergencyAuthority" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+					<Annotation Term="Org.OData.Core.V1.Description" String="The person to contact in case of a crisis at this location." />
+					<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+						<Record>
+							<PropertyValue Property="Referenceable" Bool="true" />
+						</Record>
+					</Annotation>
+				</NavigationProperty>
+			</ComplexType>
+			<ComplexType Name="EventLocation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location">
+				<Property Name="BuildingInfo" Type="Edm.String" />
+			</ComplexType>
+			<EntityType Name="Trip">
+				<Key>
+					<PropertyRef Name="TripId" />
+				</Key>
+				<Property Name="TripId" Type="Edm.Int32" Nullable="false" />
+				<Property Name="ShareId" Type="Edm.Guid" Nullable="false" />
+				<Property Name="Name" Type="Edm.String" />
+				<Property Name="Budget" Type="Edm.Single" Nullable="false" />
+				<Property Name="Description" Type="Edm.String" />
+				<Property Name="Tags" Type="Collection(Edm.String)" />
+				<Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+				<Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+				<NavigationProperty Name="PlanItems" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem)" >
+					<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+						<Record>
+							<PropertyValue Property="Referenceable" Bool="true" />
+						</Record>
+					</Annotation>
+				</NavigationProperty>
+			</EntityType>
+			<EntityType Name="PlanItem">
+				<Key>
+					<PropertyRef Name="PlanItemId" />
+				</Key>
+				<Property Name="PlanItemId" Type="Edm.Int32" Nullable="false" />
+				<Property Name="ConfirmationCode" Type="Edm.String" />
+				<Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+				<Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+				<Property Name="Duration" Type="Edm.Duration" Nullable="false" />
+			</EntityType>
+			<EntityType Name="Event" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem">
+				<Property Name="OccursAt" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocation" />
+				<Property Name="Description" Type="Edm.String" />
+			</EntityType>
+			<EntityType Name="PublicTransportation" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PlanItem">
+				<Property Name="SeatNumber" Type="Edm.String" />
+			</EntityType>
+			<EntityType Name="Flight" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PublicTransportation">
+				<Property Name="FlightNumber" Type="Edm.String" />
+				<NavigationProperty Name="Airline" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
+				<NavigationProperty Name="From" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
+				<NavigationProperty Name="To" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
+			</EntityType>
+			<EntityType Name="Employee" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" ags:IsHidden="true" ags:WorkloadName="People">
+				<Property Name="Cost" Type="Edm.Int64" Nullable="false" />
+				<NavigationProperty Name="Peers" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" >
+					<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+						<Record>
+							<PropertyValue Property="Referenceable" Bool="true" />
+						</Record>
+					</Annotation>
+				</NavigationProperty>
+			</EntityType>
+			<EntityType Name="Manager" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+				<Property Name="Budget" Type="Edm.Int64" Nullable="false" />
+				<Property Name="BossOffice" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location" />
+				<NavigationProperty Name="DirectReports" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" >
+					<Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+						<Record>
+							<PropertyValue Property="Referenceable" Bool="true" />
+						</Record>
+					</Annotation>
+				</NavigationProperty>
+			</EntityType>
+			<EnumType Name="PersonGender">
+				<Annotation Term="Org.OData.Core.V1.Description" String="Gender of the person." />
+				<Member Name="Male" Value="0">
+					<Annotation Term="Org.OData.Core.V1.Description" String="The Male gender." />
+				</Member>
+				<Member Name="Female" Value="1">
+					<Annotation Term="Org.OData.Core.V1.Description" String="The Female gender." />
+				</Member>
+				<Member Name="Unknow" Value="2">
+					<Annotation Term="Org.OData.Core.V1.Description" String="Unknown gender or prefers not to say." />
+				</Member>
+			</EnumType>
+			<EnumType Name="Feature" IsFlags="true">
+				<Member Name="Feature1" Value="0" />
+				<Member Name="Feature2" Value="1" />
+				<Member Name="Feature3" Value="2" />
+				<Member Name="Feature4" Value="4" />
+			</EnumType>
+			<Function Name="GetPersonWithMostFriends">
+				<ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+			</Function>
+			<Function Name="GetNearestAirport">
+				<Parameter Name="lat" Type="Edm.Double" Nullable="false" />
+				<Parameter Name="lon" Type="Edm.Double" Nullable="false" />
+				<ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport" />
+			</Function>
+			<Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person">
+				<Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+				<ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
+			</Function>
+			<Function Name="GetFriendsTrips" IsBound="true" ags:IsHidden="true" ags:WorkloadName="People">
+				<Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+				<Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
+				<ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)" />
+				<Annotation Term="Org.OData.Core.V1.Revisions">
+					<Collection>
+						<Record>
+							<PropertyValue Date="2021-08-24" Property="Date" />
+							<PropertyValue Property="Description" String="The GetFriendsTrips API is deprecated and will stop returning data on March 2023. Please use the new trips API on friends." />
+							<PropertyValue Property="Kind">
+								<EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+							</PropertyValue>
+							<PropertyValue Date="2023-03-15" Property="RemovalDate" />
+							<PropertyValue Property="Version" String="2021-05/trips" />
+						</Record>
+					</Collection>
+				</Annotation>
+			</Function>
+			<Function Name="GetInvolvedPeople" IsBound="true">
+				<Parameter Name="trip" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip" />
+				<ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" />
+			</Function>
+			<Action Name="ResetDataSource" />
+			<Function Name="UpdatePersonLastName" IsBound="true">
+				<Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+				<Parameter Name="lastName" Type="Edm.String" Nullable="false" Unicode="false" />
+				<ReturnType Type="Edm.Boolean" Nullable="false" />
+			</Function>
+			<Action Name="Hire" IsBound="true">
+				<Annotation Term="Org.OData.Core.V1.Description" String="Hires someone for the company." />
+				<Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager" />
+				<Parameter Name="hire" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+			</Action>
+			<Action Name="ShareTrip" IsBound="true" ags:IsHidden="true" ags:WorkloadName="People">
+				<Annotation Term="Org.OData.Core.V1.Description" String="Details of the shared trip." />
+				<Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+				<Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
+				<Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+			</Action>
+			<Action Name="GetPeersForTrip" IsBound="true">
+				<Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+				<Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
+				<Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+				<ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)" />
+			</Action>
+			<EntityContainer Name="Container">
+				<EntitySet Name="People" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+					<NavigationPropertyBinding Path="Friends" Target="People" />
+					<NavigationPropertyBinding Path="BestFriend" Target="People" />
+					<NavigationPropertyBinding Path="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers" Target="People" />
+					<NavigationPropertyBinding Path="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports" Target="People" />
+					<Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+						<Collection>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Core.V1.Revisions">
+						<Collection>
+							<Record>
+								<PropertyValue Date="2021-08-24" Property="Date" />
+								<PropertyValue Property="Description" String="The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API." />
+								<PropertyValue Property="Kind">
+									<EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+								</PropertyValue>
+								<PropertyValue Date="2023-03-15" Property="RemovalDate" />
+								<PropertyValue Property="Version" String="2021-05/people" />
+							</Record>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+						<Record>
+							<PropertyValue Property="CustomHeaders">
+								<Collection>
+									<Record>
+										<PropertyValue Property="Name" String="ConsistencyLevel" />
+										<PropertyValue Property="Description" String="Indicates the requested consistency level." />
+										<PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
+										<PropertyValue Property="Required" Bool="false" />
+										<PropertyValue Property="ExampleValues">
+											<Collection>
+												<Record>
+													<PropertyValue Property="Value" String="eventual" />
+													<PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+												</Record>
+											</Collection>
+										</PropertyValue>
+									</Record>
+								</Collection>
+							</PropertyValue>
+						</Record>
+					</Annotation>
+				</EntitySet>
+				<EntitySet Name="Airlines" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline">
+					<Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+						<Collection>
+							<PropertyPath>Name</PropertyPath>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+						<Record>
+							<PropertyValue Property="UpdateMethod">
+								<EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+							</PropertyValue>
+						</Record>
+					</Annotation>
+				</EntitySet>
+				<EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport">
+					<NavigationPropertyBinding Path="Location/EmergencyAuthority" Target="People" />
+				</EntitySet>
+				<EntitySet Name="NewComePeople" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person" />
+				<Singleton Name="Me" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+					<Annotation Term="Org.OData.Validation.V1.DerivedTypeConstraint">
+						<Collection>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee</String>
+							<String>Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager</String>
+						</Collection>
+					</Annotation>
+					<Annotation Term="Org.OData.Core.V1.Revisions">
+						<Collection>
+							<Record>
+								<PropertyValue Date="2021-08-24" Property="Date" />
+								<PropertyValue Property="Description" String="The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API." />
+								<PropertyValue Property="Kind">
+									<EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+								</PropertyValue>
+								<PropertyValue Date="2023-03-15" Property="RemovalDate" />
+								<PropertyValue Property="Version" String="2021-05/me" />
+							</Record>
+						</Collection>
+					</Annotation>
+				</Singleton>
+				<FunctionImport Name="GetPersonWithMostFriends" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPersonWithMostFriends" EntitySet="People">
+					<Annotation Term="Org.OData.Core.V1.Description" String="The person with most friends." />
+				</FunctionImport>
+				<FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetNearestAirport" EntitySet="Airports" ags:IsHidden="true"/>
+				<ActionImport Name="ResetDataSource" Action="Microsoft.OData.Service.Sample.TrippinInMemory.Models.ResetDataSource" ags:IsHidden="true">
+					<Annotation Term="Org.OData.Core.V1.Description" String="Resets the data source to default values." />
+				</ActionImport>
+			</EntityContainer>
+			<Annotations Target="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person/Trips">
+				<Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+					<Record>
+						<PropertyValue Property="CustomHeaders">
+							<Collection>
+								<Record>
+									<PropertyValue Property="Name" String="ConsistencyLevel" />
+									<PropertyValue Property="Description" String="Indicates the requested consistency level." />
+									<PropertyValue Property="DocumentationURL" String="https://docs.tripservice.com/advanced-queries" />
+									<PropertyValue Property="Required" Bool="false" />
+									<PropertyValue Property="ExampleValues">
+										<Collection>
+											<Record>
+												<PropertyValue Property="Value" String="eventual" />
+												<PropertyValue Property="Description" String="$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'." />
+											</Record>
+										</Collection>
+									</PropertyValue>
+								</Record>
+							</Collection>
+						</PropertyValue>
+						<PropertyValue Property="LongDescription" String="Retrieve a list of trips." />
+						<PropertyValue Property="Description" String="List trips." />
+						<PropertyValue Property="ReadByKeyRestrictions">
+							<Record>
+								<PropertyValue Property="LongDescription" String="Retrieve the properties of a trip." />
+								<PropertyValue Property="Description" String="Get a trip." />
+							</Record>
+						</PropertyValue>
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+					<Record>
+						<PropertyValue Property="LongDescription" String="Delete an instance of a trip." />
+						<PropertyValue Property="Description" String="Delete a trip." />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+					<Record>
+						<PropertyValue Property="LongDescription" String="Update an instance of a trip." />
+						<PropertyValue Property="Description" String="Update a trip." />
+					</Record>
+				</Annotation>
+				<Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+					<Record>
+						<PropertyValue Property="LongDescription" String="Create a new trip." />
+						<PropertyValue Property="Description" String="Create a trip." />
+					</Record>
+				</Annotation>
+			</Annotations>
+		</Schema>
+	</edmx:DataServices>
 </edmx:Edmx>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1087,6 +1087,79 @@
       },
       "x-description": "Casts the previous resource to EventLocation."
     },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/Photo": {
+      "get": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Get Photo for the navigation property EmergencyAuthority from Airports",
+        "operationId": "Airports.GetEmergencyAuthorityPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "The unique identifier of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Update Photo for the navigation property EmergencyAuthority in Airports",
+        "operationId": "Airports.UpdateEmergencyAuthorityPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "The unique identifier of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Airport entity."
+    },
     "/Airports/$count": {
       "get": {
         "tags": [
@@ -1183,7 +1256,8 @@
         "tags": [
           "Me.Person"
         ],
-        "summary": "Get Me",
+        "summary": "Get signed in person",
+        "description": "Retrieve the properties and relationships of Person object.",
         "operationId": "Me.Person.GetPerson",
         "produces": [
           "application/json"
@@ -2158,14 +2232,96 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/Me/BestFriend/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from Me",
+        "operationId": "Me.GetBestFriendPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.UpdateBestFriendPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Friends": {
       "get": {
         "tags": [
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.ListFriends",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -2726,6 +2882,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -2785,6 +2953,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -2824,6 +3004,93 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/Me/Friends/{UserName}/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from Me",
+        "operationId": "Me.GetFriendsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in Me",
+        "operationId": "Me.UpdateFriendsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Friends/$count": {
       "get": {
         "tags": [
@@ -2832,6 +3099,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount-182b",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -2863,8 +3142,21 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.ListRefFriends",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -2984,6 +3276,18 @@
         "operationId": "Me.ListFriends.AsEmployee",
         "parameters": [
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -3053,6 +3357,18 @@
         "operationId": "Me.Friends.GetCount.AsEmployee-884b",
         "parameters": [
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -3085,6 +3401,18 @@
         "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
         "operationId": "Me.ListFriends.AsManager",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -3154,6 +3482,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount.AsManager-9376",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -3507,6 +3847,18 @@
         "operationId": "Me.AsEmployee.AddressInfo.GetCount-8488",
         "parameters": [
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -3561,6 +3913,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.AddressInfo.GetCount.AsEventLocation-9375",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -3940,6 +4304,18 @@
         "operationId": "Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de",
         "parameters": [
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -3994,6 +4370,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -4181,14 +4569,96 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from Me",
+        "operationId": "Me.GetBestFriendPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.UpdateBestFriendPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
       "get": {
         "tags": [
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsEmployee.ListFriends",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -4495,6 +4965,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -4566,6 +5048,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -4749,6 +5243,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -4788,6 +5294,93 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from Me",
+        "operationId": "Me.GetFriendsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in Me",
+        "operationId": "Me.UpdateFriendsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
       "get": {
         "tags": [
@@ -4796,6 +5389,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.AsEmployee.Friends.GetCount-0cb7",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -4827,8 +5432,21 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsEmployee.ListRefFriends",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -4948,6 +5566,18 @@
         "operationId": "Me.ListFriends.AsManager",
         "parameters": [
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -5016,6 +5646,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount.AsManager-85ff",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -5462,6 +6104,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -5533,6 +6187,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -5696,6 +6362,93 @@
       },
       "x-description": "Casts the previous resource to EventLocation."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Peers from Me",
+        "operationId": "Me.GetPeersPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Peers in Me",
+        "operationId": "Me.UpdatePeersPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
         "tags": [
@@ -5854,6 +6607,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.ListTrips",
         "parameters": [
           {
@@ -5934,6 +6691,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.CreateTrips",
         "consumes": [
           "application/json"
@@ -5985,6 +6746,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.GetTrips",
         "produces": [
           "application/json"
@@ -6046,6 +6811,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.UpdateTrips",
         "consumes": [
           "application/json"
@@ -6095,6 +6864,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.DeleteTrips",
         "parameters": [
           {
@@ -7692,6 +8465,75 @@
       },
       "x-description": "Casts the previous resource to Employee."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from Me",
+        "operationId": "Me.GetBestFriendPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.UpdateBestFriendPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
         "tags": [
@@ -8260,6 +9102,93 @@
       },
       "x-description": "Casts the previous resource to EventLocation."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property DirectReports from Me",
+        "operationId": "Me.GetDirectReportsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property DirectReports in Me",
+        "operationId": "Me.UpdateDirectReportsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
         "tags": [
@@ -8417,8 +9346,21 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsManager.ListFriends",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -8979,6 +9921,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -9018,6 +9972,93 @@
       },
       "x-description": "Casts the previous resource to Employee."
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from Me",
+        "operationId": "Me.GetFriendsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in Me",
+        "operationId": "Me.UpdateFriendsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
       "get": {
         "tags": [
@@ -9026,6 +10067,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.AsManager.Friends.GetCount-60a7",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -9057,8 +10110,21 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsManager.ListRefFriends",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/top"
           },
@@ -9178,6 +10244,18 @@
         "operationId": "Me.ListFriends.AsEmployee",
         "parameters": [
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -9246,6 +10324,18 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount.AsEmployee-6a35",
         "parameters": [
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/parameters/search"
           },
@@ -9435,6 +10525,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.ListTrips",
         "parameters": [
           {
@@ -9515,6 +10609,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.CreateTrips",
         "consumes": [
           "application/json"
@@ -9566,6 +10664,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.GetTrips",
         "produces": [
           "application/json"
@@ -9627,6 +10729,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.UpdateTrips",
         "consumes": [
           "application/json"
@@ -9676,6 +10782,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.DeleteTrips",
         "parameters": [
           {
@@ -10267,6 +11377,75 @@
       },
       "x-description": "Provides operations to call the UpdatePersonLastName method."
     },
+    "/Me/Photo": {
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for Person from Me",
+        "operationId": "Me.Person.GetPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for Person in Me",
+        "operationId": "Me.Person.UpdatePhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/Me/Trips": {
       "get": {
         "tags": [
@@ -10274,6 +11453,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.ListTrips",
         "parameters": [
           {
@@ -10354,6 +11537,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.CreateTrips",
         "consumes": [
           "application/json"
@@ -10405,6 +11592,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.GetTrips",
         "produces": [
           "application/json"
@@ -10466,6 +11657,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.UpdateTrips",
         "consumes": [
           "application/json"
@@ -10515,6 +11710,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.DeleteTrips",
         "parameters": [
           {
@@ -12337,12 +13536,100 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/NewComePeople/{UserName}/BestFriend/Photo": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from NewComePeople",
+        "operationId": "NewComePeople.GetBestFriendPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "put": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in NewComePeople",
+        "operationId": "NewComePeople.UpdateBestFriendPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/NewComePeople/{UserName}/Friends": {
       "get": {
         "tags": [
           "NewComePeople.Person"
         ],
         "summary": "Get Friends from NewComePeople",
+        "description": "Friends of person",
         "operationId": "NewComePeople.ListFriends",
         "parameters": [
           {
@@ -12352,6 +13639,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -12944,6 +14243,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -13004,6 +14315,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -13036,6 +14359,95 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Photo": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from NewComePeople",
+        "operationId": "NewComePeople.GetFriendsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in NewComePeople",
+        "operationId": "NewComePeople.UpdateFriendsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/NewComePeople/{UserName}/Friends/$count": {
       "get": {
         "tags": [
@@ -13051,6 +14463,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -13076,6 +14500,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get ref of Friends from NewComePeople",
+        "description": "Friends of person",
         "operationId": "NewComePeople.ListRefFriends",
         "parameters": [
           {
@@ -13085,6 +14510,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -13208,6 +14645,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -13278,6 +14727,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -13310,6 +14771,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -13380,6 +14853,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -13777,6 +15262,79 @@
       },
       "x-description": "Provides operations to call the UpdatePersonLastName method."
     },
+    "/NewComePeople/{UserName}/Photo": {
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Photo for Person from NewComePeople",
+        "operationId": "NewComePeople.Person.GetPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update Photo for Person in NewComePeople",
+        "operationId": "NewComePeople.Person.UpdatePhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/NewComePeople/{UserName}/Trips": {
       "get": {
         "tags": [
@@ -13784,6 +15342,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.ListTrips",
         "parameters": [
           {
@@ -13865,6 +15427,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.CreateTrips",
         "consumes": [
           "application/json"
@@ -13913,6 +15479,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.GetTrips",
         "produces": [
           "application/json"
@@ -13975,6 +15545,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.UpdateTrips",
         "consumes": [
           "application/json"
@@ -14025,6 +15599,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.DeleteTrips",
         "parameters": [
           {
@@ -15873,7 +17451,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "summary": "Get best friend",
+        "description": "Get the item of type Person cast as Manager",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-get-friend-manager?view=graph-rest-1.0"
+        },
         "operationId": "People.GetBestFriend.AsManager",
         "produces": [
           "application/json"
@@ -15927,12 +17510,104 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/People/{UserName}/BestFriend/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from People",
+        "operationId": "People.GetBestFriendPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in People",
+        "operationId": "People.UpdateBestFriendPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Friends": {
       "get": {
         "tags": [
           "People.Person"
         ],
-        "summary": "Get Friends from People",
+        "summary": "List friends",
+        "description": "List the friends of a specific person",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0"
+        },
         "operationId": "People.ListFriends",
         "parameters": [
           {
@@ -15942,6 +17617,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -16014,7 +17701,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete ref of navigation property Friends for People",
+        "summary": "Delete a friend.",
+        "description": "Delete an instance of a friend relationship.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0"
+        },
         "operationId": "People.friends.DeleteRefPerson",
         "parameters": [
           {
@@ -16591,6 +18283,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -16658,6 +18362,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -16697,6 +18413,109 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/People/{UserName}/Friends/{UserName1}/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from People",
+        "operationId": "People.GetFriendsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in People",
+        "operationId": "People.UpdateFriendsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Friends/$count": {
       "get": {
         "tags": [
@@ -16712,6 +18531,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -16743,7 +18574,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get ref of Friends from People",
+        "summary": "List friends",
+        "description": "List the friends of a specific person",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0"
+        },
         "operationId": "People.ListRefFriends",
         "parameters": [
           {
@@ -16753,6 +18589,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -16800,7 +18648,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Create new navigation property ref to Friends for People",
+        "summary": "Create a friend.",
+        "description": "Create a new friend.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-post-friend?view=graph-rest-1.0"
+        },
         "operationId": "People.CreateRefFriends",
         "parameters": [
           {
@@ -16836,7 +18689,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete ref of navigation property Friends for People",
+        "summary": "Delete a friend.",
+        "description": "Delete an instance of a friend relationship.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0"
+        },
         "operationId": "People.DeleteRefFriends",
         "parameters": [
           {
@@ -16895,6 +18753,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -16974,6 +18844,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -17013,6 +18895,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -17092,6 +18986,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -17121,7 +19027,8 @@
         "tags": [
           "People.Location"
         ],
-        "summary": "Get HomeAddress property value",
+        "summary": "Get home address",
+        "description": "Get the home address of a specific person",
         "operationId": "People.GetHomeAddress",
         "produces": [
           "application/json"
@@ -17522,6 +19429,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -17593,6 +19512,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -18047,6 +19978,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -18118,6 +20061,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -18340,12 +20295,100 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from People",
+        "operationId": "People.GetBestFriendPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in People",
+        "operationId": "People.UpdateBestFriendPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
       "get": {
         "tags": [
           "People.Person"
         ],
         "summary": "Get Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsEmployee.ListFriends",
         "parameters": [
           {
@@ -18355,6 +20398,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -18702,6 +20757,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -18789,6 +20856,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -19004,6 +21083,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -19043,6 +21134,109 @@
       },
       "x-description": "Casts the previous resource to Manager."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from People",
+        "operationId": "People.GetFriendsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in People",
+        "operationId": "People.UpdateFriendsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
       "get": {
         "tags": [
@@ -19058,6 +21252,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -19090,6 +21296,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsEmployee.ListRefFriends",
         "parameters": [
           {
@@ -19099,6 +21306,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -19243,6 +21462,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -19318,6 +21549,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -19839,6 +22082,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/search"
           },
           {
@@ -19926,6 +22181,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -20112,6 +22379,109 @@
         }
       },
       "x-description": "Casts the previous resource to EventLocation."
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Peers from People",
+        "operationId": "People.GetPeersPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Peers in People",
+        "operationId": "People.UpdatePeersPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count": {
       "get": {
@@ -20303,6 +22673,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.ListTrips",
         "parameters": [
           {
@@ -20391,6 +22765,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.CreateTrips",
         "consumes": [
           "application/json"
@@ -20450,6 +22828,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.GetTrips",
         "produces": [
           "application/json"
@@ -20519,6 +22901,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.UpdateTrips",
         "consumes": [
           "application/json"
@@ -20576,6 +22962,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.DeleteTrips",
         "parameters": [
           {
@@ -22467,6 +24857,93 @@
       },
       "x-description": "Casts the previous resource to Employee."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from People",
+        "operationId": "People.GetBestFriendPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in People",
+        "operationId": "People.UpdateBestFriendPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "get": {
         "tags": [
@@ -23123,6 +25600,109 @@
       },
       "x-description": "Casts the previous resource to EventLocation."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property DirectReports from People",
+        "operationId": "People.GetDirectReportsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property DirectReports in People",
+        "operationId": "People.UpdateDirectReportsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "get": {
         "tags": [
@@ -23312,6 +25892,7 @@
           "People.Person"
         ],
         "summary": "Get Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsManager.ListFriends",
         "parameters": [
           {
@@ -23321,6 +25902,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -23970,6 +26563,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "in": "query",
             "name": "$select",
             "description": "Select properties to be returned",
@@ -24009,6 +26614,109 @@
       },
       "x-description": "Casts the previous resource to Employee."
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from People",
+        "operationId": "People.GetFriendsPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in People",
+        "operationId": "People.UpdateFriendsPhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
       "get": {
         "tags": [
@@ -24024,6 +26732,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -24056,6 +26776,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsManager.ListRefFriends",
         "parameters": [
           {
@@ -24065,6 +26786,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/top"
@@ -24209,6 +26942,18 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/parameters/top"
           },
           {
@@ -24284,6 +27029,18 @@
             "required": true,
             "type": "string",
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "ConsistencyLevel",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "type": "string",
+            "x-examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/parameters/search"
@@ -24508,6 +27265,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.ListTrips",
         "parameters": [
           {
@@ -24596,6 +27357,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.CreateTrips",
         "consumes": [
           "application/json"
@@ -24655,6 +27420,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.GetTrips",
         "produces": [
           "application/json"
@@ -24724,6 +27493,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.UpdateTrips",
         "consumes": [
           "application/json"
@@ -24781,6 +27554,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.DeleteTrips",
         "parameters": [
           {
@@ -25460,6 +28237,103 @@
       },
       "x-description": "Provides operations to call the UpdatePersonLastName method."
     },
+    "/People/{UserName}/Photo": {
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get photo",
+        "description": "Get photo of a specific user",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-get-photo?view=graph-rest-1.0"
+        },
+        "operationId": "People.Person.GetPhoto",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update photo",
+        "description": "Update photo of a specific user",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-update-photo?view=graph-rest-1.0"
+        },
+        "operationId": "People.Person.UpdatePhoto",
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "New media content.",
+            "required": true,
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "x-description": "Provides operations to manage the media for the Person entity."
+    },
     "/People/{UserName}/Trips": {
       "get": {
         "tags": [
@@ -25467,6 +28341,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.ListTrips",
         "parameters": [
           {
@@ -25555,6 +28433,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.CreateTrips",
         "consumes": [
           "application/json"
@@ -25614,6 +28496,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.GetTrips",
         "produces": [
           "application/json"
@@ -25683,6 +28569,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.UpdateTrips",
         "consumes": [
           "application/json"
@@ -25740,6 +28630,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.DeleteTrips",
         "parameters": [
           {
@@ -26707,7 +29601,12 @@
             "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
           }
         },
+        "Photo": {
+          "format": "base64url",
+          "type": "string"
+        },
         "Friends": {
+          "description": "Friends of person",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -712,6 +712,56 @@ paths:
         default:
           $ref: '#/responses/error'
     x-description: Casts the previous resource to EventLocation.
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/Photo':
+    get:
+      tags:
+        - Airports.Person
+      summary: Get Photo for the navigation property EmergencyAuthority from Airports
+      operationId: Airports.GetEmergencyAuthorityPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: The unique identifier of Airport
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+    put:
+      tags:
+        - Airports.Person
+      summary: Update Photo for the navigation property EmergencyAuthority in Airports
+      operationId: Airports.UpdateEmergencyAuthorityPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: The unique identifier of Airport
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to manage the media for the Airport entity.
   /Airports/$count:
     get:
       tags:
@@ -775,7 +825,8 @@ paths:
     get:
       tags:
         - Me.Person
-      summary: Get Me
+      summary: Get signed in person
+      description: Retrieve the properties and relationships of Person object.
       operationId: Me.Person.GetPerson
       produces:
         - application/json
@@ -1433,13 +1484,71 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Manager.
+  /Me/BestFriend/Photo:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property BestFriend from Me
+      operationId: Me.GetBestFriendPhoto
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property BestFriend in Me
+      operationId: Me.UpdateBestFriendPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Friends:
     get:
       tags:
         - Me.Person
       summary: Get Friends from Me
+      description: Friends of person
       operationId: Me.ListFriends
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -1817,6 +1926,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -1858,6 +1975,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -1884,6 +2009,68 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Manager.
+  '/Me/Friends/{UserName}/Photo':
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Friends from Me
+      operationId: Me.GetFriendsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Friends in Me
+      operationId: Me.UpdateFriendsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Friends/$count:
     get:
       tags:
@@ -1891,6 +2078,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount-182b
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -1910,8 +2105,17 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
+      description: Friends of person
       operationId: Me.ListRefFriends
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -1989,6 +2193,14 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsEmployee
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -2031,6 +2243,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsEmployee-884b
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -2052,6 +2272,14 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsManager
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -2094,6 +2322,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsManager-9376
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -2329,6 +2565,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsEmployee.AddressInfo.GetCount-8488
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -2366,6 +2610,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AddressInfo.GetCount.AsEventLocation-9375
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -2622,6 +2874,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -2659,6 +2919,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -2785,13 +3053,71 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Manager.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property BestFriend from Me
+      operationId: Me.GetBestFriendPhoto
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property BestFriend in Me
+      operationId: Me.UpdateBestFriendPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends:
     get:
       tags:
         - Me.Person
       summary: Get Friends from Me
+      description: Friends of person
       operationId: Me.AsEmployee.ListFriends
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -2994,6 +3320,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3044,6 +3378,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3169,6 +3511,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -3195,6 +3545,68 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Manager.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Photo':
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Friends from Me
+      operationId: Me.GetFriendsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Friends in Me
+      operationId: Me.UpdateFriendsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count:
     get:
       tags:
@@ -3202,6 +3614,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsEmployee.Friends.GetCount-0cb7
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3221,8 +3641,17 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
+      description: Friends of person
       operationId: Me.AsEmployee.ListRefFriends
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -3300,6 +3729,14 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsManager
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -3342,6 +3779,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsManager-85ff
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3639,6 +4084,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3689,6 +4142,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -3799,6 +4260,68 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/Photo':
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Peers from Me
+      operationId: Me.GetPeersPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Peers in Me
+      operationId: Me.UpdatePeersPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     get:
       tags:
@@ -3903,6 +4426,9 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.ListTrips
       parameters:
         - in: header
@@ -3953,6 +4479,9 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.CreateTrips
       consumes:
         - application/json
@@ -3989,6 +4518,9 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.GetTrips
       produces:
         - application/json
@@ -4033,6 +4565,9 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.UpdateTrips
       consumes:
         - application/json
@@ -4069,6 +4604,9 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.DeleteTrips
       parameters:
         - in: path
@@ -5145,6 +5683,55 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Employee.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property BestFriend from Me
+      operationId: Me.GetBestFriendPhoto
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property BestFriend in Me
+      operationId: Me.UpdateBestFriendPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     get:
       tags:
@@ -5527,6 +6114,68 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to EventLocation.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/Photo':
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property DirectReports from Me
+      operationId: Me.GetDirectReportsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property DirectReports in Me
+      operationId: Me.UpdateDirectReportsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     get:
       tags:
@@ -5630,8 +6279,17 @@ paths:
       tags:
         - Me.Person
       summary: Get Friends from Me
+      description: Friends of person
       operationId: Me.AsManager.ListFriends
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -6009,6 +6667,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -6035,6 +6701,68 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Casts the previous resource to Employee.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Photo':
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Friends from Me
+      operationId: Me.GetFriendsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Friends in Me
+      operationId: Me.UpdateFriendsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count:
     get:
       tags:
@@ -6042,6 +6770,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsManager.Friends.GetCount-60a7
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -6061,8 +6797,17 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
+      description: Friends of person
       operationId: Me.AsManager.ListRefFriends
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -6140,6 +6885,14 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsEmployee
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -6182,6 +6935,14 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsEmployee-6a35
       parameters:
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -6311,6 +7072,9 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: Me.AsManager.ListTrips
       parameters:
         - in: header
@@ -6361,6 +7125,9 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: Me.AsManager.CreateTrips
       consumes:
         - application/json
@@ -6397,6 +7164,9 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: Me.AsManager.GetTrips
       produces:
         - application/json
@@ -6441,6 +7211,9 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: Me.AsManager.UpdateTrips
       consumes:
         - application/json
@@ -6477,6 +7250,9 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: Me.AsManager.DeleteTrips
       parameters:
         - in: path
@@ -6880,12 +7656,64 @@ paths:
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the UpdatePersonLastName method.
+  /Me/Photo:
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for Person from Me
+      operationId: Me.Person.GetPhoto
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for Person in Me
+      operationId: Me.Person.UpdatePhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    x-description: Provides operations to manage the media for the Person entity.
   /Me/Trips:
     get:
       tags:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: Me.ListTrips
       parameters:
         - in: header
@@ -6936,6 +7764,9 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: Me.CreateTrips
       consumes:
         - application/json
@@ -6972,6 +7803,9 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: Me.GetTrips
       produces:
         - application/json
@@ -7016,6 +7850,9 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: Me.UpdateTrips
       consumes:
         - application/json
@@ -7052,6 +7889,9 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: Me.DeleteTrips
       parameters:
         - in: path
@@ -8281,11 +9121,74 @@ paths:
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     x-description: Casts the previous resource to Manager.
+  '/NewComePeople/{UserName}/BestFriend/Photo':
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Photo for the navigation property BestFriend from NewComePeople
+      operationId: NewComePeople.GetBestFriendPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    put:
+      tags:
+        - NewComePeople.Person
+      summary: Update Photo for the navigation property BestFriend in NewComePeople
+      operationId: NewComePeople.UpdateBestFriendPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/NewComePeople/{UserName}/Friends':
     get:
       tags:
         - NewComePeople.Person
       summary: Get Friends from NewComePeople
+      description: Friends of person
       operationId: NewComePeople.ListFriends
       parameters:
         - in: path
@@ -8294,6 +9197,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -8684,6 +9595,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -8725,6 +9644,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -8745,6 +9672,68 @@ paths:
         default:
           $ref: '#/responses/error'
     x-description: Casts the previous resource to Manager.
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Photo':
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Photo for the navigation property Friends from NewComePeople
+      operationId: NewComePeople.GetFriendsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+    put:
+      tags:
+        - NewComePeople.Person
+      summary: Update Photo for the navigation property Friends in NewComePeople
+      operationId: NewComePeople.UpdateFriendsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to manage the media for the Person entity.
   '/NewComePeople/{UserName}/Friends/$count':
     get:
       tags:
@@ -8758,6 +9747,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -8771,6 +9768,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get ref of Friends from NewComePeople
+      description: Friends of person
       operationId: NewComePeople.ListRefFriends
       parameters:
         - in: path
@@ -8779,6 +9777,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -8856,6 +9862,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -8898,6 +9912,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -8919,6 +9941,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -8961,6 +9991,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -9221,12 +10259,65 @@ paths:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the UpdatePersonLastName method.
+  '/NewComePeople/{UserName}/Photo':
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Photo for Person from NewComePeople
+      operationId: NewComePeople.Person.GetPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+    put:
+      tags:
+        - NewComePeople.Person
+      summary: Update Photo for Person in NewComePeople
+      operationId: NewComePeople.Person.UpdatePhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    x-description: Provides operations to manage the media for the Person entity.
   '/NewComePeople/{UserName}/Trips':
     get:
       tags:
         - NewComePeople.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: NewComePeople.ListTrips
       parameters:
         - in: path
@@ -9277,6 +10368,9 @@ paths:
         - NewComePeople.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: NewComePeople.CreateTrips
       consumes:
         - application/json
@@ -9310,6 +10404,9 @@ paths:
         - NewComePeople.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: NewComePeople.GetTrips
       produces:
         - application/json
@@ -9354,6 +10451,9 @@ paths:
         - NewComePeople.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: NewComePeople.UpdateTrips
       consumes:
         - application/json
@@ -9390,6 +10490,9 @@ paths:
         - NewComePeople.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: NewComePeople.DeleteTrips
       parameters:
         - in: path
@@ -10641,7 +11744,11 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      summary: Get best friend
+      description: Get the item of type Person cast as Manager
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-get-friend-manager?view=graph-rest-1.0
       operationId: People.GetBestFriend.AsManager
       produces:
         - application/json
@@ -10678,11 +11785,77 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/BestFriend/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property BestFriend from People
+      operationId: People.GetBestFriendPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property BestFriend in People
+      operationId: People.UpdateBestFriendPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Friends':
     get:
       tags:
         - People.Person
-      summary: Get Friends from People
+      summary: List friends
+      description: List the friends of a specific person
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0
       operationId: People.ListFriends
       parameters:
         - in: path
@@ -10691,6 +11864,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -10734,7 +11915,11 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete ref of navigation property Friends for People
+      summary: Delete a friend.
+      description: Delete an instance of a friend relationship.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0
       operationId: People.friends.DeleteRefPerson
       parameters:
         - in: path
@@ -11134,6 +12319,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -11181,6 +12374,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -11207,6 +12408,80 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/Friends/{UserName1}/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Friends from People
+      operationId: People.GetFriendsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Friends in People
+      operationId: People.UpdateFriendsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Friends/$count':
     get:
       tags:
@@ -11220,6 +12495,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -11238,7 +12521,11 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get ref of Friends from People
+      summary: List friends
+      description: List the friends of a specific person
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0
       operationId: People.ListRefFriends
       parameters:
         - in: path
@@ -11247,6 +12534,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -11273,7 +12568,11 @@ paths:
     post:
       tags:
         - People.Person
-      summary: Create new navigation property ref to Friends for People
+      summary: Create a friend.
+      description: Create a new friend.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-post-friend?view=graph-rest-1.0
       operationId: People.CreateRefFriends
       parameters:
         - in: path
@@ -11298,7 +12597,11 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete ref of navigation property Friends for People
+      summary: Delete a friend.
+      description: Delete an instance of a friend relationship.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0
       operationId: People.DeleteRefFriends
       parameters:
         - in: path
@@ -11342,6 +12645,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -11390,6 +12701,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -11417,6 +12736,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -11465,6 +12792,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -11483,7 +12818,8 @@ paths:
     get:
       tags:
         - People.Location
-      summary: Get HomeAddress property value
+      summary: Get home address
+      description: Get the home address of a specific person
       operationId: People.GetHomeAddress
       produces:
         - application/json
@@ -11757,6 +13093,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -11807,6 +13151,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -12118,6 +13470,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -12168,6 +13528,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -12319,11 +13687,74 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property BestFriend from People
+      operationId: People.GetBestFriendPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property BestFriend in People
+      operationId: People.UpdateBestFriendPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends':
     get:
       tags:
         - People.Person
       summary: Get Friends from People
+      description: Friends of person
       operationId: People.AsEmployee.ListFriends
       parameters:
         - in: path
@@ -12332,6 +13763,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -12564,6 +14003,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -12626,6 +14073,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -12775,6 +14230,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -12801,6 +14264,80 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Manager.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Friends from People
+      operationId: People.GetFriendsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Friends in People
+      operationId: People.UpdateFriendsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count':
     get:
       tags:
@@ -12814,6 +14351,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -12833,6 +14378,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
+      description: Friends of person
       operationId: People.AsEmployee.ListRefFriends
       parameters:
         - in: path
@@ -12841,6 +14387,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -12936,6 +14490,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -12984,6 +14546,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -13336,6 +14906,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -13398,6 +14976,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -13526,6 +15112,80 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Peers from People
+      operationId: People.GetPeersPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Peers in People
+      operationId: People.UpdatePeersPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count':
     get:
       tags:
@@ -13654,6 +15314,9 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.ListTrips
       parameters:
         - in: path
@@ -13710,6 +15373,9 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.CreateTrips
       consumes:
         - application/json
@@ -13752,6 +15418,9 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.GetTrips
       produces:
         - application/json
@@ -13802,6 +15471,9 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.UpdateTrips
       consumes:
         - application/json
@@ -13844,6 +15516,9 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.DeleteTrips
       parameters:
         - in: path
@@ -15137,6 +16812,68 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Employee.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property BestFriend from People
+      operationId: People.GetBestFriendPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property BestFriend in People
+      operationId: People.UpdateBestFriendPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
       tags:
@@ -15585,6 +17322,80 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to EventLocation.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property DirectReports from People
+      operationId: People.GetDirectReportsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property DirectReports in People
+      operationId: People.UpdateDirectReportsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     get:
       tags:
@@ -15712,6 +17523,7 @@ paths:
       tags:
         - People.Person
       summary: Get Friends from People
+      description: Friends of person
       operationId: People.AsManager.ListFriends
       parameters:
         - in: path
@@ -15720,6 +17532,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -16163,6 +17983,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - in: query
           name: $select
           description: Select properties to be returned
@@ -16189,6 +18017,80 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Casts the previous resource to Employee.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Friends from People
+      operationId: People.GetFriendsPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Friends in People
+      operationId: People.UpdateFriendsPhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count':
     get:
       tags:
@@ -16202,6 +18104,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -16221,6 +18131,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
+      description: Friends of person
       operationId: People.AsManager.ListRefFriends
       parameters:
         - in: path
@@ -16229,6 +18140,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -16324,6 +18243,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/top'
         - $ref: '#/parameters/skip'
         - $ref: '#/parameters/search'
@@ -16372,6 +18299,14 @@ paths:
           required: true
           type: string
           x-ms-docs-key-type: Person
+        - in: header
+          name: ConsistencyLevel
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          type: string
+          x-examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/filter'
       responses:
@@ -16526,6 +18461,9 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: People.AsManager.ListTrips
       parameters:
         - in: path
@@ -16582,6 +18520,9 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: People.AsManager.CreateTrips
       consumes:
         - application/json
@@ -16624,6 +18565,9 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: People.AsManager.GetTrips
       produces:
         - application/json
@@ -16674,6 +18618,9 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: People.AsManager.UpdateTrips
       consumes:
         - application/json
@@ -16716,6 +18663,9 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: People.AsManager.DeleteTrips
       parameters:
         - in: path
@@ -17185,12 +19135,85 @@ paths:
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
     x-description: Provides operations to call the UpdatePersonLastName method.
+  '/People/{UserName}/Photo':
+    get:
+      tags:
+        - People.Person
+      summary: Get photo
+      description: Get photo of a specific user
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-get-photo?view=graph-rest-1.0
+      operationId: People.Person.GetPhoto
+      produces:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          schema:
+            format: binary
+            type: string
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update photo
+      description: Update photo of a specific user
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-update-photo?view=graph-rest-1.0
+      operationId: People.Person.UpdatePhoto
+      consumes:
+        - application/octet-stream
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: body
+          name: body
+          description: New media content.
+          required: true
+          schema:
+            format: binary
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Trips':
     get:
       tags:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: People.ListTrips
       parameters:
         - in: path
@@ -17247,6 +19270,9 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: People.CreateTrips
       consumes:
         - application/json
@@ -17289,6 +19315,9 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: People.GetTrips
       produces:
         - application/json
@@ -17339,6 +19368,9 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: People.UpdateTrips
       consumes:
         - application/json
@@ -17381,6 +19413,9 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: People.DeleteTrips
       parameters:
         - in: path
@@ -18028,7 +20063,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'
+      Photo:
+        format: base64url
+        type: string
       Friends:
+        description: Friends of person
         type: array
         items:
           $ref: '#/definitions/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1228,6 +1228,83 @@
         }
       }
     },
+    "/Airports/{IcaoCode}/Location/EmergencyAuthority/Photo": {
+      "description": "Provides operations to manage the media for the Airport entity.",
+      "get": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Get Photo for the navigation property EmergencyAuthority from Airports",
+        "operationId": "Airports.GetEmergencyAuthorityPhoto",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "The unique identifier of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Update Photo for the navigation property EmergencyAuthority in Airports",
+        "operationId": "Airports.UpdateEmergencyAuthorityPhoto",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "The unique identifier of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Airports/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -1369,7 +1446,8 @@
         "tags": [
           "Me.Person"
         ],
-        "summary": "Get Me",
+        "summary": "Get signed in person",
+        "description": "Retrieve the properties and relationships of Person object.",
         "operationId": "Me.Person.GetPerson",
         "parameters": [
           {
@@ -2416,6 +2494,73 @@
         }
       }
     },
+    "/Me/BestFriend/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from Me",
+        "operationId": "Me.GetBestFriendPhoto",
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.UpdateBestFriendPhoto",
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Friends": {
       "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -2423,8 +2568,23 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.ListFriends",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -3046,6 +3206,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -3118,6 +3292,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -3170,6 +3358,97 @@
         }
       }
     },
+    "/Me/Friends/{UserName}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from Me",
+        "operationId": "Me.GetFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in Me",
+        "operationId": "Me.UpdateFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Friends/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -3179,6 +3458,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount-182b",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -3210,8 +3503,23 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.ListRefFriends",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -3338,6 +3646,20 @@
         "operationId": "Me.ListFriends.AsEmployee",
         "parameters": [
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -3422,6 +3744,20 @@
         "operationId": "Me.Friends.GetCount.AsEmployee-884b",
         "parameters": [
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -3454,6 +3790,20 @@
         "summary": "Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection",
         "operationId": "Me.ListFriends.AsManager",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -3538,6 +3888,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount.AsManager-9376",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -3923,6 +4287,20 @@
         "operationId": "Me.AsEmployee.AddressInfo.GetCount-8488",
         "parameters": [
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -3977,6 +4355,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.AddressInfo.GetCount.AsEventLocation-9375",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -4378,6 +4770,20 @@
         "operationId": "Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de",
         "parameters": [
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -4432,6 +4838,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -4637,6 +5057,73 @@
         }
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from Me",
+        "operationId": "Me.GetBestFriendPhoto",
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.UpdateBestFriendPhoto",
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
       "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -4644,8 +5131,23 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsEmployee.ListFriends",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -4994,6 +5496,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -5069,6 +5585,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -5267,6 +5797,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -5319,6 +5863,97 @@
         }
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from Me",
+        "operationId": "Me.GetFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in Me",
+        "operationId": "Me.UpdateFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -5328,6 +5963,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.AsEmployee.Friends.GetCount-0cb7",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -5359,8 +6008,23 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsEmployee.ListRefFriends",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -5487,6 +6151,20 @@
         "operationId": "Me.ListFriends.AsManager",
         "parameters": [
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -5570,6 +6248,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount.AsManager-85ff",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -6066,6 +6758,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -6141,6 +6847,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -6305,6 +7025,97 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Peers from Me",
+        "operationId": "Me.GetPeersPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Peers in Me",
+        "operationId": "Me.UpdatePeersPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -6485,6 +7296,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.ListTrips",
         "parameters": [
           {
@@ -6582,6 +7397,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.CreateTrips",
         "requestBody": {
           "description": "New navigation property",
@@ -6631,6 +7450,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.GetTrips",
         "parameters": [
           {
@@ -6705,6 +7528,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.UpdateTrips",
         "parameters": [
           {
@@ -6755,6 +7582,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsEmployee.DeleteTrips",
         "parameters": [
           {
@@ -8503,6 +9334,73 @@
         }
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from Me",
+        "operationId": "Me.GetBestFriendPhoto",
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.UpdateBestFriendPhoto",
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
       "get": {
@@ -9137,6 +10035,97 @@
         }
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property DirectReports from Me",
+        "operationId": "Me.GetDirectReportsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property DirectReports in Me",
+        "operationId": "Me.UpdateDirectReportsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -9302,8 +10291,23 @@
           "Me.Person"
         ],
         "summary": "Get Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsManager.ListFriends",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -9925,6 +10929,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -9977,6 +10995,97 @@
         }
       }
     },
+    "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from Me",
+        "operationId": "Me.GetFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in Me",
+        "operationId": "Me.UpdateFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -9986,6 +11095,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.AsManager.Friends.GetCount-60a7",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -10017,8 +11140,23 @@
           "Me.Person"
         ],
         "summary": "Get ref of Friends from Me",
+        "description": "Friends of person",
         "operationId": "Me.AsManager.ListRefFriends",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/top"
           },
@@ -10145,6 +11283,20 @@
         "operationId": "Me.ListFriends.AsEmployee",
         "parameters": [
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -10228,6 +11380,20 @@
         "summary": "Get the number of the resource",
         "operationId": "Me.Friends.GetCount.AsEmployee-6a35",
         "parameters": [
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
           {
             "$ref": "#/components/parameters/search"
           },
@@ -10430,6 +11596,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.ListTrips",
         "parameters": [
           {
@@ -10527,6 +11697,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.CreateTrips",
         "requestBody": {
           "description": "New navigation property",
@@ -10576,6 +11750,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.GetTrips",
         "parameters": [
           {
@@ -10650,6 +11828,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.UpdateTrips",
         "parameters": [
           {
@@ -10700,6 +11882,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.AsManager.DeleteTrips",
         "parameters": [
           {
@@ -11354,6 +12540,73 @@
         "x-ms-docs-operation-type": "function"
       }
     },
+    "/Me/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Get Photo for Person from Me",
+        "operationId": "Me.Person.GetPhoto",
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "put": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Update Photo for Person in Me",
+        "operationId": "Me.Person.UpdatePhoto",
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      }
+    },
     "/Me/Trips": {
       "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -11362,6 +12615,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.ListTrips",
         "parameters": [
           {
@@ -11459,6 +12716,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.CreateTrips",
         "requestBody": {
           "description": "New navigation property",
@@ -11508,6 +12769,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.GetTrips",
         "parameters": [
           {
@@ -11582,6 +12847,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.UpdateTrips",
         "parameters": [
           {
@@ -11632,6 +12901,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "Me.DeleteTrips",
         "parameters": [
           {
@@ -13675,6 +14948,97 @@
         }
       }
     },
+    "/NewComePeople/{UserName}/BestFriend/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from NewComePeople",
+        "operationId": "NewComePeople.GetBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
+      "put": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in NewComePeople",
+        "operationId": "NewComePeople.UpdateBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      }
+    },
     "/NewComePeople/{UserName}/Friends": {
       "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -13682,6 +15046,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get Friends from NewComePeople",
+        "description": "Friends of person",
         "operationId": "NewComePeople.ListFriends",
         "parameters": [
           {
@@ -13693,6 +15058,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -14372,6 +15751,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -14447,6 +15840,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -14492,6 +15899,103 @@
         }
       }
     },
+    "/NewComePeople/{UserName}/Friends/{UserName1}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from NewComePeople",
+        "operationId": "NewComePeople.GetFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in NewComePeople",
+        "operationId": "NewComePeople.UpdateFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/NewComePeople/{UserName}/Friends/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -14510,6 +16014,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -14535,6 +16053,7 @@
           "NewComePeople.Person"
         ],
         "summary": "Get ref of Friends from NewComePeople",
+        "description": "Friends of person",
         "operationId": "NewComePeople.ListRefFriends",
         "parameters": [
           {
@@ -14546,6 +16065,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -14684,6 +16217,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -14771,6 +16318,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -14805,6 +16366,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -14892,6 +16467,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -15342,6 +16931,83 @@
         "x-ms-docs-operation-type": "function"
       }
     },
+    "/NewComePeople/{UserName}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Get Photo for Person from NewComePeople",
+        "operationId": "NewComePeople.Person.GetPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Update Photo for Person in NewComePeople",
+        "operationId": "NewComePeople.Person.UpdatePhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/NewComePeople/{UserName}/Trips": {
       "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -15350,6 +17016,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.ListTrips",
         "parameters": [
           {
@@ -15450,6 +17120,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.CreateTrips",
         "parameters": [
           {
@@ -15500,6 +17174,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.GetTrips",
         "parameters": [
           {
@@ -15577,6 +17255,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.UpdateTrips",
         "parameters": [
           {
@@ -15630,6 +17312,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "NewComePeople.DeleteTrips",
         "parameters": [
           {
@@ -17701,7 +19387,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager",
+        "summary": "Get best friend",
+        "description": "Get the item of type Person cast as Manager",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-get-friend-manager?view=graph-rest-1.0"
+        },
         "operationId": "People.GetBestFriend.AsManager",
         "parameters": [
           {
@@ -17767,13 +19458,109 @@
         }
       }
     },
+    "/People/{UserName}/BestFriend/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from People",
+        "operationId": "People.GetBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in People",
+        "operationId": "People.UpdateBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Friends": {
       "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
         "tags": [
           "People.Person"
         ],
-        "summary": "Get Friends from People",
+        "summary": "List friends",
+        "description": "List the friends of a specific person",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0"
+        },
         "operationId": "People.ListFriends",
         "parameters": [
           {
@@ -17785,6 +19572,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -17872,7 +19673,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete ref of navigation property Friends for People",
+        "summary": "Delete a friend.",
+        "description": "Delete an instance of a friend relationship.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0"
+        },
         "operationId": "People.friends.DeleteRefPerson",
         "parameters": [
           {
@@ -18517,6 +20323,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -18599,6 +20419,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -18651,6 +20485,117 @@
         }
       }
     },
+    "/People/{UserName}/Friends/{UserName1}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from People",
+        "operationId": "People.GetFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in People",
+        "operationId": "People.UpdateFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Friends/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -18669,6 +20614,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -18700,7 +20659,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Get ref of Friends from People",
+        "summary": "List friends",
+        "description": "List the friends of a specific person",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0"
+        },
         "operationId": "People.ListRefFriends",
         "parameters": [
           {
@@ -18712,6 +20676,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -18764,7 +20742,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Create new navigation property ref to Friends for People",
+        "summary": "Create a friend.",
+        "description": "Create a new friend.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-post-friend?view=graph-rest-1.0"
+        },
         "operationId": "People.CreateRefFriends",
         "parameters": [
           {
@@ -18802,7 +20785,12 @@
         "tags": [
           "People.Person"
         ],
-        "summary": "Delete ref of navigation property Friends for People",
+        "summary": "Delete a friend.",
+        "description": "Delete an instance of a friend relationship.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0"
+        },
         "operationId": "People.DeleteRefFriends",
         "parameters": [
           {
@@ -18869,6 +20857,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -18965,6 +20967,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -19006,6 +21022,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -19102,6 +21132,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -19130,7 +21174,8 @@
         "tags": [
           "People.Location"
         ],
-        "summary": "Get HomeAddress property value",
+        "summary": "Get home address",
+        "description": "Get the home address of a specific person",
         "operationId": "People.GetHomeAddress",
         "parameters": [
           {
@@ -19586,6 +21631,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -19661,6 +21720,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -20161,6 +22234,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -20236,6 +22323,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -20486,6 +22587,97 @@
         }
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from People",
+        "operationId": "People.GetBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in People",
+        "operationId": "People.UpdateBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
       "description": "Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -20493,6 +22685,7 @@
           "People.Person"
         ],
         "summary": "Get Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsEmployee.ListFriends",
         "parameters": [
           {
@@ -20504,6 +22697,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -20903,6 +23110,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -20998,6 +23219,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -21236,6 +23471,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -21288,6 +23537,117 @@
         }
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from People",
+        "operationId": "People.GetFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in People",
+        "operationId": "People.UpdateFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -21306,6 +23666,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -21338,6 +23712,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsEmployee.ListRefFriends",
         "parameters": [
           {
@@ -21349,6 +23724,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -21508,6 +23897,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -21600,6 +24003,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -22191,6 +24608,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/search"
           },
           {
@@ -22286,6 +24717,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -22480,6 +24925,117 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Peers from People",
+        "operationId": "People.GetPeersPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Peers in People",
+        "operationId": "People.UpdatePeersPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -22702,6 +25258,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.ListTrips",
         "parameters": [
           {
@@ -22809,6 +25369,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.CreateTrips",
         "parameters": [
           {
@@ -22870,6 +25434,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.GetTrips",
         "parameters": [
           {
@@ -22954,6 +25522,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.UpdateTrips",
         "parameters": [
           {
@@ -23014,6 +25586,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsEmployee.DeleteTrips",
         "parameters": [
           {
@@ -25138,6 +27714,97 @@
         }
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property BestFriend from People",
+        "operationId": "People.GetBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property BestFriend in People",
+        "operationId": "People.UpdateBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
       "description": "Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.",
       "get": {
@@ -25882,6 +28549,117 @@
         }
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property DirectReports from People",
+        "operationId": "People.GetDirectReportsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property DirectReports in People",
+        "operationId": "People.UpdateDirectReportsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -26089,6 +28867,7 @@
           "People.Person"
         ],
         "summary": "Get Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsManager.ListFriends",
         "parameters": [
           {
@@ -26100,6 +28879,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -26832,6 +29625,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Select properties to be returned",
@@ -26884,6 +29691,117 @@
         }
       }
     },
+    "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get Photo for the navigation property Friends from People",
+        "operationId": "People.GetFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update Photo for the navigation property Friends in People",
+        "operationId": "People.UpdateFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count": {
       "description": "Provides operations to count the resources in the collection.",
       "get": {
@@ -26902,6 +29820,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -26934,6 +29866,7 @@
           "People.Person"
         ],
         "summary": "Get ref of Friends from People",
+        "description": "Friends of person",
         "operationId": "People.AsManager.ListRefFriends",
         "parameters": [
           {
@@ -26945,6 +29878,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/top"
@@ -27104,6 +30051,20 @@
             "x-ms-docs-key-type": "Person"
           },
           {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
+          },
+          {
             "$ref": "#/components/parameters/top"
           },
           {
@@ -27196,6 +30157,20 @@
               "type": "string"
             },
             "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "ConsistencyLevel",
+            "in": "header",
+            "description": "Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "example-1": {
+                "description": "$search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.",
+                "value": "eventual"
+              }
+            }
           },
           {
             "$ref": "#/components/parameters/search"
@@ -27445,6 +30420,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.ListTrips",
         "parameters": [
           {
@@ -27552,6 +30531,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.CreateTrips",
         "parameters": [
           {
@@ -27613,6 +30596,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.GetTrips",
         "parameters": [
           {
@@ -27697,6 +30684,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.UpdateTrips",
         "parameters": [
           {
@@ -27757,6 +30748,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.AsManager.DeleteTrips",
         "parameters": [
           {
@@ -28523,6 +31518,107 @@
         "x-ms-docs-operation-type": "function"
       }
     },
+    "/People/{UserName}/Photo": {
+      "description": "Provides operations to manage the media for the Person entity.",
+      "get": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Get photo",
+        "description": "Get photo of a specific user",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-get-photo?view=graph-rest-1.0"
+        },
+        "operationId": "People.Person.GetPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved media content",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "put": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Update photo",
+        "description": "Update photo of a specific user",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-update-photo?view=graph-rest-1.0"
+        },
+        "operationId": "People.Person.UpdatePhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          }
+        ],
+        "requestBody": {
+          "description": "New media content.",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      }
+    },
     "/People/{UserName}/Trips": {
       "description": "Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.",
       "get": {
@@ -28531,6 +31627,10 @@
         ],
         "summary": "List trips.",
         "description": "Retrieve a list of trips.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.ListTrips",
         "parameters": [
           {
@@ -28638,6 +31738,10 @@
         ],
         "summary": "Create a trip.",
         "description": "Create a new trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.CreateTrips",
         "parameters": [
           {
@@ -28699,6 +31803,10 @@
         ],
         "summary": "Get a trip.",
         "description": "Retrieve the properties of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.GetTrips",
         "parameters": [
           {
@@ -28783,6 +31891,10 @@
         ],
         "summary": "Update a trip.",
         "description": "Update an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.UpdateTrips",
         "parameters": [
           {
@@ -28843,6 +31955,10 @@
         ],
         "summary": "Delete a trip.",
         "description": "Delete an instance of a trip.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0"
+        },
         "operationId": "People.DeleteTrips",
         "parameters": [
           {
@@ -29946,11 +33062,17 @@
               "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature"
             }
           },
+          "Photo": {
+            "type": "string",
+            "format": "base64url",
+            "nullable": true
+          },
           "Friends": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"
             },
+            "description": "Friends of person",
             "x-ms-navigationProperty": true
           },
           "BestFriend": {
@@ -31189,6 +34311,7 @@
           },
           "LastName": "String",
           "MiddleName": "String",
+          "Photo": "Stream",
           "Trips": [
             {
               "@odata.type": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -802,6 +802,57 @@ paths:
           $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
         default:
           $ref: '#/components/responses/error'
+  '/Airports/{IcaoCode}/Location/EmergencyAuthority/Photo':
+    description: Provides operations to manage the media for the Airport entity.
+    get:
+      tags:
+        - Airports.Person
+      summary: Get Photo for the navigation property EmergencyAuthority from Airports
+      operationId: Airports.GetEmergencyAuthorityPhoto
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: The unique identifier of Airport
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - Airports.Person
+      summary: Update Photo for the navigation property EmergencyAuthority in Airports
+      operationId: Airports.UpdateEmergencyAuthorityPhoto
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: The unique identifier of Airport
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
   /Airports/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -882,7 +933,8 @@ paths:
     get:
       tags:
         - Me.Person
-      summary: Get Me
+      summary: Get signed in person
+      description: Retrieve the properties and relationships of Person object.
       operationId: Me.Person.GetPerson
       parameters:
         - name: $select
@@ -1594,14 +1646,71 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/BestFriend/Photo:
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property BestFriend from Me
+      operationId: Me.GetBestFriendPhoto
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property BestFriend in Me
+      operationId: Me.UpdateBestFriendPhoto
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Friends:
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
       tags:
         - Me.Person
       summary: Get Friends from Me
+      description: Friends of person
       operationId: Me.ListFriends
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -2019,6 +2128,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -2069,6 +2187,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -2104,6 +2231,69 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Friends/{UserName}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Friends from Me
+      operationId: Me.GetFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Friends in Me
+      operationId: Me.UpdateFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Friends/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -2112,6 +2302,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount-182b
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -2131,8 +2330,18 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
+      description: Friends of person
       operationId: Me.ListRefFriends
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -2216,6 +2425,15 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsEmployee
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -2270,6 +2488,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsEmployee-884b
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -2291,6 +2518,15 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsManager
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -2345,6 +2581,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsManager-9376
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -2604,6 +2849,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsEmployee.AddressInfo.GetCount-8488
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -2641,6 +2895,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AddressInfo.GetCount.AsEventLocation-9375
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -2914,6 +3177,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsEmployee.BestFriend.AddressInfo.GetCount-81de
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -2951,6 +3223,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.BestFriend.AddressInfo.GetCount.AsEventLocation-842c
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -3090,14 +3371,71 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo:
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property BestFriend from Me
+      operationId: Me.GetBestFriendPhoto
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property BestFriend in Me
+      operationId: Me.UpdateBestFriendPhoto
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends:
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
       tags:
         - Me.Person
       summary: Get Friends from Me
+      description: Friends of person
       operationId: Me.AsEmployee.ListFriends
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -3329,6 +3667,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -3381,6 +3728,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -3515,6 +3871,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -3550,6 +3915,69 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Friends from Me
+      operationId: Me.GetFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Friends in Me
+      operationId: Me.UpdateFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -3558,6 +3986,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsEmployee.Friends.GetCount-0cb7
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -3577,8 +4014,18 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
+      description: Friends of person
       operationId: Me.AsEmployee.ListRefFriends
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -3662,6 +4109,15 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsManager
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -3716,6 +4172,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsManager-85ff
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -4048,6 +4513,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -4100,6 +4574,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -4219,6 +4702,69 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Peers from Me
+      operationId: Me.GetPeersPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Peers in Me
+      operationId: Me.UpdatePeersPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -4330,6 +4876,9 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.ListTrips
       parameters:
         - name: ConsistencyLevel
@@ -4393,6 +4942,9 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.CreateTrips
       requestBody:
         description: New navigation property
@@ -4427,6 +4979,9 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.GetTrips
       parameters:
         - name: TripId
@@ -4480,6 +5035,9 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.UpdateTrips
       parameters:
         - name: TripId
@@ -4516,6 +5074,9 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: Me.AsEmployee.DeleteTrips
       parameters:
         - name: TripId
@@ -5700,6 +6261,53 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo:
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property BestFriend from Me
+      operationId: Me.GetBestFriendPhoto
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property BestFriend in Me
+      operationId: Me.UpdateBestFriendPhoto
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -6125,6 +6733,69 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property DirectReports from Me
+      operationId: Me.GetDirectReportsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property DirectReports in Me
+      operationId: Me.UpdateDirectReportsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -6235,8 +6906,18 @@ paths:
       tags:
         - Me.Person
       summary: Get Friends from Me
+      description: Friends of person
       operationId: Me.AsManager.ListFriends
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -6654,6 +7335,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -6689,6 +7379,69 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+  '/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for the navigation property Friends from Me
+      operationId: Me.GetFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for the navigation property Friends in Me
+      operationId: Me.UpdateFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -6697,6 +7450,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.AsManager.Friends.GetCount-60a7
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -6716,8 +7478,18 @@ paths:
       tags:
         - Me.Person
       summary: Get ref of Friends from Me
+      description: Friends of person
       operationId: Me.AsManager.ListRefFriends
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -6801,6 +7573,15 @@ paths:
       summary: Get the items of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee in the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person collection
       operationId: Me.ListFriends.AsEmployee
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -6855,6 +7636,15 @@ paths:
       summary: Get the number of the resource
       operationId: Me.Friends.GetCount.AsEmployee-6a35
       parameters:
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -6991,6 +7781,9 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: Me.AsManager.ListTrips
       parameters:
         - name: ConsistencyLevel
@@ -7054,6 +7847,9 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: Me.AsManager.CreateTrips
       requestBody:
         description: New navigation property
@@ -7088,6 +7884,9 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: Me.AsManager.GetTrips
       parameters:
         - name: TripId
@@ -7141,6 +7940,9 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: Me.AsManager.UpdateTrips
       parameters:
         - name: TripId
@@ -7177,6 +7979,9 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: Me.AsManager.DeleteTrips
       parameters:
         - name: TripId
@@ -7623,6 +8428,53 @@ paths:
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
       x-ms-docs-operation-type: function
+  /Me/Photo:
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - Me.Person
+      summary: Get Photo for Person from Me
+      operationId: Me.Person.GetPhoto
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    put:
+      tags:
+        - Me.Person
+      summary: Update Photo for Person in Me
+      operationId: Me.Person.UpdatePhoto
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Trips:
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -7630,6 +8482,9 @@ paths:
         - Me.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: Me.ListTrips
       parameters:
         - name: ConsistencyLevel
@@ -7693,6 +8548,9 @@ paths:
         - Me.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: Me.CreateTrips
       requestBody:
         description: New navigation property
@@ -7727,6 +8585,9 @@ paths:
         - Me.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: Me.GetTrips
       parameters:
         - name: TripId
@@ -7780,6 +8641,9 @@ paths:
         - Me.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: Me.UpdateTrips
       parameters:
         - name: TripId
@@ -7816,6 +8680,9 @@ paths:
         - Me.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: Me.DeleteTrips
       parameters:
         - name: TripId
@@ -9188,12 +10055,76 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+  '/NewComePeople/{UserName}/BestFriend/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Photo for the navigation property BestFriend from NewComePeople
+      operationId: NewComePeople.GetBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    put:
+      tags:
+        - NewComePeople.Person
+      summary: Update Photo for the navigation property BestFriend in NewComePeople
+      operationId: NewComePeople.UpdateBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
       tags:
         - NewComePeople.Person
       summary: Get Friends from NewComePeople
+      description: Friends of person
       operationId: NewComePeople.ListFriends
       parameters:
         - name: UserName
@@ -9203,6 +10134,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -9646,6 +10586,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -9697,6 +10646,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -9726,6 +10684,71 @@ paths:
                 $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager'
         default:
           $ref: '#/components/responses/error'
+  '/NewComePeople/{UserName}/Friends/{UserName1}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Photo for the navigation property Friends from NewComePeople
+      operationId: NewComePeople.GetFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - NewComePeople.Person
+      summary: Update Photo for the navigation property Friends in NewComePeople
+      operationId: NewComePeople.UpdateFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Friends/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -9741,6 +10764,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -9754,6 +10786,7 @@ paths:
       tags:
         - NewComePeople.Person
       summary: Get ref of Friends from NewComePeople
+      description: Friends of person
       operationId: NewComePeople.ListRefFriends
       parameters:
         - name: UserName
@@ -9763,6 +10796,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -9850,6 +10892,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -9905,6 +10956,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -9927,6 +10987,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -9982,6 +11051,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -10275,6 +11353,57 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: function
+  '/NewComePeople/{UserName}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - NewComePeople.Person
+      summary: Get Photo for Person from NewComePeople
+      operationId: NewComePeople.Person.GetPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - NewComePeople.Person
+      summary: Update Photo for Person in NewComePeople
+      operationId: NewComePeople.Person.UpdatePhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
   '/NewComePeople/{UserName}/Trips':
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -10282,6 +11411,9 @@ paths:
         - NewComePeople.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: NewComePeople.ListTrips
       parameters:
         - name: UserName
@@ -10346,6 +11478,9 @@ paths:
         - NewComePeople.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: NewComePeople.CreateTrips
       parameters:
         - name: UserName
@@ -10379,6 +11514,9 @@ paths:
         - NewComePeople.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: NewComePeople.GetTrips
       parameters:
         - name: UserName
@@ -10433,6 +11571,9 @@ paths:
         - NewComePeople.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: NewComePeople.UpdateTrips
       parameters:
         - name: UserName
@@ -10470,6 +11611,9 @@ paths:
         - NewComePeople.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: NewComePeople.DeleteTrips
       parameters:
         - name: UserName
@@ -11863,7 +13007,11 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get the item of type Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person as Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager
+      summary: Get best friend
+      description: Get the item of type Person cast as Manager
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-get-friend-manager?view=graph-rest-1.0
       operationId: People.GetBestFriend.AsManager
       parameters:
         - name: UserName
@@ -11908,12 +13056,79 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/BestFriend/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property BestFriend from People
+      operationId: People.GetBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property BestFriend in People
+      operationId: People.UpdateBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
       tags:
         - People.Person
-      summary: Get Friends from People
+      summary: List friends
+      description: List the friends of a specific person
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0
       operationId: People.ListFriends
       parameters:
         - name: UserName
@@ -11923,6 +13138,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -11978,7 +13202,11 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete ref of navigation property Friends for People
+      summary: Delete a friend.
+      description: Delete an instance of a friend relationship.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0
       operationId: People.friends.DeleteRefPerson
       parameters:
         - name: UserName
@@ -12417,6 +13645,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -12474,6 +13711,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -12509,6 +13755,83 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Friends/{UserName1}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Friends from People
+      operationId: People.GetFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Friends in People
+      operationId: People.UpdateFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -12524,6 +13847,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -12542,7 +13874,11 @@ paths:
     get:
       tags:
         - People.Person
-      summary: Get ref of Friends from People
+      summary: List friends
+      description: List the friends of a specific person
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-list-friends?view=graph-rest-1.0
       operationId: People.ListRefFriends
       parameters:
         - name: UserName
@@ -12552,6 +13888,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -12582,7 +13927,11 @@ paths:
     post:
       tags:
         - People.Person
-      summary: Create new navigation property ref to Friends for People
+      summary: Create a friend.
+      description: Create a new friend.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-post-friend?view=graph-rest-1.0
       operationId: People.CreateRefFriends
       parameters:
         - name: UserName
@@ -12609,7 +13958,11 @@ paths:
     delete:
       tags:
         - People.Person
-      summary: Delete ref of navigation property Friends for People
+      summary: Delete a friend.
+      description: Delete an instance of a friend relationship.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-delete-friend?view=graph-rest-1.0
       operationId: People.DeleteRefFriends
       parameters:
         - name: UserName
@@ -12657,6 +14010,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -12718,6 +14080,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -12746,6 +14117,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -12807,6 +14187,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -12824,7 +14213,8 @@ paths:
     get:
       tags:
         - People.Location
-      summary: Get HomeAddress property value
+      summary: Get home address
+      description: Get the home address of a specific person
       operationId: People.GetHomeAddress
       parameters:
         - name: UserName
@@ -13134,6 +14524,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -13186,6 +14585,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -13526,6 +14934,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -13578,6 +14995,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -13747,12 +15173,76 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/BestFriend/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property BestFriend from People
+      operationId: People.GetBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property BestFriend in People
+      operationId: People.UpdateBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
       tags:
         - People.Person
       summary: Get Friends from People
+      description: Friends of person
       operationId: People.AsEmployee.ListFriends
       parameters:
         - name: UserName
@@ -13762,6 +15252,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -14028,6 +15527,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -14094,6 +15602,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -14256,6 +15773,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -14291,6 +15817,83 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/{UserName1}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Friends from People
+      operationId: People.GetFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Friends in People
+      operationId: People.UpdateFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -14306,6 +15909,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -14325,6 +15937,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
+      description: Friends of person
       operationId: People.AsEmployee.ListRefFriends
       parameters:
         - name: UserName
@@ -14334,6 +15947,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -14439,6 +16061,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -14500,6 +16131,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -14897,6 +16537,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -14963,6 +16612,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -15095,6 +16753,83 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Microsoft.OData.Service.Sample.TrippinInMemory.Models.EventLocationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Peers/{UserName1}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Peers from People
+      operationId: People.GetPeersPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Peers in People
+      operationId: People.UpdatePeersPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
         default:
           $ref: '#/components/responses/error'
       deprecated: true
@@ -15243,6 +16978,9 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.ListTrips
       parameters:
         - name: UserName
@@ -15313,6 +17051,9 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.CreateTrips
       parameters:
         - name: UserName
@@ -15355,6 +17096,9 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.GetTrips
       parameters:
         - name: UserName
@@ -15415,6 +17159,9 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.UpdateTrips
       parameters:
         - name: UserName
@@ -15458,6 +17205,9 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: People.AsEmployee.DeleteTrips
       parameters:
         - name: UserName
@@ -16900,6 +18650,69 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/BestFriend/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property BestFriend from People
+      operationId: People.GetBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property BestFriend in People
+      operationId: People.UpdateBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -17402,6 +19215,83 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/{UserName1}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property DirectReports from People
+      operationId: People.GetDirectReportsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property DirectReports in People
+      operationId: People.UpdateDirectReportsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -17541,6 +19431,7 @@ paths:
       tags:
         - People.Person
       summary: Get Friends from People
+      description: Friends of person
       operationId: People.AsManager.ListFriends
       parameters:
         - name: UserName
@@ -17550,6 +19441,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -18044,6 +19944,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - name: $select
           in: query
           description: Select properties to be returned
@@ -18079,6 +19988,83 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+  '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/{UserName1}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get Photo for the navigation property Friends from People
+      operationId: People.GetFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update Photo for the navigation property Friends in People
+      operationId: People.UpdateFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/Friends/$count':
     description: Provides operations to count the resources in the collection.
     get:
@@ -18094,6 +20080,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -18113,6 +20108,7 @@ paths:
       tags:
         - People.Person
       summary: Get ref of Friends from People
+      description: Friends of person
       operationId: People.AsManager.ListRefFriends
       parameters:
         - name: UserName
@@ -18122,6 +20118,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -18227,6 +20232,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/search'
@@ -18288,6 +20302,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: Person
+        - name: ConsistencyLevel
+          in: header
+          description: 'Indicates the requested consistency level. Documentation URL: https://docs.microsoft.com/graph/aad-advanced-queries'
+          schema:
+            type: string
+          examples:
+            example-1:
+              description: $search and $count queries require the client to set the ConsistencyLevel HTTP header to 'eventual'.
+              value: eventual
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
       responses:
@@ -18455,6 +20478,9 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: People.AsManager.ListTrips
       parameters:
         - name: UserName
@@ -18525,6 +20551,9 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: People.AsManager.CreateTrips
       parameters:
         - name: UserName
@@ -18567,6 +20596,9 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: People.AsManager.GetTrips
       parameters:
         - name: UserName
@@ -18627,6 +20659,9 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: People.AsManager.UpdateTrips
       parameters:
         - name: UserName
@@ -18670,6 +20705,9 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: People.AsManager.DeleteTrips
       parameters:
         - name: UserName
@@ -19194,6 +21232,77 @@ paths:
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
       x-ms-docs-operation-type: function
+  '/People/{UserName}/Photo':
+    description: Provides operations to manage the media for the Person entity.
+    get:
+      tags:
+        - People.Person
+      summary: Get photo
+      description: Get photo of a specific user
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-get-photo?view=graph-rest-1.0
+      operationId: People.Person.GetPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      responses:
+        '200':
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    put:
+      tags:
+        - People.Person
+      summary: Update photo
+      description: Update photo of a specific user
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-update-photo?view=graph-rest-1.0
+      operationId: People.Person.UpdatePhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Trips':
     description: Provides operations to manage the Trips property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -19201,6 +21310,9 @@ paths:
         - People.Trip
       summary: List trips.
       description: Retrieve a list of trips.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-list-trips?view=graph-rest-1.0
       operationId: People.ListTrips
       parameters:
         - name: UserName
@@ -19271,6 +21383,9 @@ paths:
         - People.Trip
       summary: Create a trip.
       description: Create a new trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-post-trips?view=graph-rest-1.0
       operationId: People.CreateTrips
       parameters:
         - name: UserName
@@ -19313,6 +21428,9 @@ paths:
         - People.Trip
       summary: Get a trip.
       description: Retrieve the properties of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-get-trips?view=graph-rest-1.0
       operationId: People.GetTrips
       parameters:
         - name: UserName
@@ -19373,6 +21491,9 @@ paths:
         - People.Trip
       summary: Update a trip.
       description: Update an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-update-trips?view=graph-rest-1.0
       operationId: People.UpdateTrips
       parameters:
         - name: UserName
@@ -19416,6 +21537,9 @@ paths:
         - People.Trip
       summary: Delete a trip.
       description: Delete an instance of a trip.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/user-delete-trips?view=graph-rest-1.0
       operationId: People.DeleteTrips
       parameters:
         - name: UserName
@@ -20151,10 +22275,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'
+        Photo:
+          type: string
+          format: base64url
+          nullable: true
         Friends:
           type: array
           items:
             $ref: '#/components/schemas/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person'
+          description: Friends of person
           x-ms-navigationProperty: true
         BestFriend:
           anyOf:
@@ -20933,6 +23062,7 @@ components:
           '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location
         LastName: String
         MiddleName: String
+        Photo: Stream
         Trips:
           - '@odata.type': Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip
         UserName: String (identifier)

--- a/tool/UpdateDocs/UpdateDocs.csproj
+++ b/tool/UpdateDocs/UpdateDocs.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.20.0" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.21.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #514 

This PR:
 - Enables fetching of path descriptions, summary and external doc links using path as annotation target as the default for fetching annotations from CSDL
 - If annotations for path are not found, check annotations for type of last segment of the path e.g. navigation property, complex property etc
 - Tests to ensure that annotations with path as target are properly picked up