### PR TITLE
Add `delete` operations for media entities

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,13 +15,12 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.2</Version>
+    <Version>1.6.3</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-		- Adds support for fetching annotations using Edm target path preferentially #514
 		- Add delete operations to media entities #522
 	</PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>

--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -22,6 +22,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
 		- Adds support for fetching annotations using Edm target path preferentially #514
+		- Add delete operations to media entities #522
 	</PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityDeleteOperationHandler.cs
@@ -4,10 +4,7 @@ using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Generator;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Microsoft.OpenApi.OData.Operation
 {
@@ -58,10 +55,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 : $"Delete {placeholderValue} for {NavigationSourceSegment.EntityType.Name} in {NavigationSourceSegment.Identifier}";
 
             // Description
-            if (LastSegmentIsStreamPropertySegment)
-            {
-                operation.Description = _deleteRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
-            }
+            operation.Description = _deleteRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
 
             // OperationId
             if (Context.Settings.EnableOperationId)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityDeleteOperationHandler.cs
@@ -1,0 +1,133 @@
+﻿using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.OpenApi.OData.Operation
+{
+    internal class MediaEntityDeleteOperationHandler : MediaEntityOperationalHandler
+    {
+        /// <inheritdoc/>
+        public override OperationType OperationType => OperationType.Delete;
+
+        private DeleteRestrictionsType _deleteRestrictions;
+
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+
+            if (Property != null)
+            {
+                _deleteRestrictions = Context.Model.GetRecord<DeleteRestrictionsType>(TargetPath, CapabilitiesConstants.DeleteRestrictions);
+                if (Property is IEdmNavigationProperty)
+                {
+                    var navigationDeleteRestrictions = Context.Model.GetRecord<NavigationRestrictionsType>(Property, CapabilitiesConstants.NavigationRestrictions)?
+                            .RestrictedProperties?.FirstOrDefault()?.DeleteRestrictions;
+                    if (_deleteRestrictions != null && navigationDeleteRestrictions != null)
+                    {
+                        _deleteRestrictions.MergePropertiesIfNull(navigationDeleteRestrictions);
+                    }
+                    _deleteRestrictions ??= navigationDeleteRestrictions;
+                }
+                else
+                {
+                    var propertyDeleteRestrictions = Context.Model.GetRecord<DeleteRestrictionsType>(Property, CapabilitiesConstants.DeleteRestrictions);
+                    if (_deleteRestrictions != null && propertyDeleteRestrictions != null)
+                    {
+                        _deleteRestrictions.MergePropertiesIfNull(propertyDeleteRestrictions);
+                    }
+                    _deleteRestrictions ??= propertyDeleteRestrictions;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            // Summary
+            string placeholderValue = LastSegmentIsStreamPropertySegment ? Path.LastSegment.Identifier : "media content";
+            operation.Summary = _deleteRestrictions?.Description;
+            operation.Summary ??= IsNavigationPropertyPath
+                ? $"Delete {placeholderValue} for the navigation property {NavigationProperty.Name} in {NavigationSourceSegment.NavigationSource.Name}"
+                : $"Delete {placeholderValue} for {NavigationSourceSegment.EntityType.Name} in {NavigationSourceSegment.Identifier}";
+
+            // Description
+            if (LastSegmentIsStreamPropertySegment)
+            {
+                operation.Description = _deleteRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
+            }
+
+            // OperationId
+            if (Context.Settings.EnableOperationId)
+            {
+                string identifier = LastSegmentIsStreamPropertySegment ? Path.LastSegment.Identifier : "Content";
+                operation.OperationId = GetOperationId("Delete", identifier);
+            }
+
+            base.SetBasicInfo(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetParameters(OpenApiOperation operation)
+        {
+            base.SetParameters(operation);
+
+            operation.Parameters.Add(new OpenApiParameter
+            {
+                Name = "If-Match",
+                In = ParameterLocation.Header,
+                Description = "ETag",
+                Schema = new OpenApiSchema
+                {
+                    Type = "string"
+                }
+            });
+        }
+
+        /// <inheritdoc/>
+        protected override void SetResponses(OpenApiOperation operation)
+        {
+            // Response for Delete methods should be 204 No Content
+            OpenApiConvertSettings settings = Context.Settings.Clone();
+            settings.UseSuccessStatusCodeRange = false;
+
+            operation.AddErrorResponses(settings, true);
+            base.SetResponses(operation);
+        }
+
+        protected override void SetSecurity(OpenApiOperation operation)
+        {
+            if (_deleteRestrictions == null || _deleteRestrictions.Permissions == null)
+            {
+                return;
+            }
+
+            operation.Security = Context.CreateSecurityRequirements(_deleteRestrictions.Permissions).ToList();
+        }
+
+        /// <inheritdoc/>
+        protected override void AppendCustomParameters(OpenApiOperation operation)
+        {
+            if (_deleteRestrictions == null)
+            {
+                return;
+            }
+
+            if (_deleteRestrictions.CustomHeaders != null)
+            {
+                AppendCustomParameters(operation, _deleteRestrictions.CustomHeaders, ParameterLocation.Header);
+            }
+
+            if (_deleteRestrictions.CustomQueryOptions != null)
+            {
+                AppendCustomParameters(operation, _deleteRestrictions.CustomQueryOptions, ParameterLocation.Query);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -63,25 +63,22 @@ namespace Microsoft.OpenApi.OData.Operation
                 : $"Get {placeholderValue} for {NavigationSourceSegment.EntityType.Name} from {NavigationSourceSegment.Identifier}";
 
             // Description
-            if (LastSegmentIsStreamPropertySegment)
+            string description;
+
+            if (Property is IEdmNavigationProperty)
             {
-                string description;
-
-                if (Property is IEdmNavigationProperty)
-                {
-                    description = LastSegmentIsKeySegment
-                        ? _readRestrictions?.ReadByKeyRestrictions?.LongDescription
-                        : _readRestrictions?.LongDescription
-                        ?? Context.Model.GetDescriptionAnnotation(Property);
-                }
-                else
-                {
-                    // Structural property
-                    description = _readRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
-                }
-
-                operation.Description = description;
+                description = LastSegmentIsKeySegment
+                    ? _readRestrictions?.ReadByKeyRestrictions?.LongDescription
+                    : _readRestrictions?.LongDescription
+                    ?? Context.Model.GetDescriptionAnnotation(Property);
             }
+            else
+            {
+                // Structural property
+                description = _readRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
+            }
+
+            operation.Description = description;
 
             // OperationId
             if (Context.Settings.EnableOperationId)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -65,10 +65,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 : $"Update {placeholderValue} for {NavigationSourceSegment.EntityType.Name} in {NavigationSourceSegment.Identifier}";
 
             // Description
-            if (LastSegmentIsStreamPropertySegment)
-            {
-                operation.Description = _updateRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
-            }
+             operation.Description = _updateRestrictions?.LongDescription ?? Context.Model.GetDescriptionAnnotation(Property);
 
             // OperationId
             if (Context.Settings.EnableOperationId)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyDeleteOperationHandler.cs
@@ -88,6 +88,7 @@ namespace Microsoft.OpenApi.OData.Operation
             base.SetResponses(operation);
         }
 
+        /// <inheritdoc/>
         protected override void AppendCustomParameters(OpenApiOperation operation)
         {
             if (_deleteRestriction == null)

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -73,11 +73,12 @@ namespace Microsoft.OpenApi.OData.Operation
                 {OperationType.Delete, new RefDeleteOperationHandler() }
             }},
 
-            // media entity operation (Get|Put)
+            // media entity operation (Get|Put|Delete)
             {ODataPathKind.MediaEntity, new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new MediaEntityGetOperationHandler() },
-                {OperationType.Put, new MediaEntityPutOperationHandler() }
+                {OperationType.Put, new MediaEntityPutOperationHandler() },
+                {OperationType.Delete, new MediaEntityDeleteOperationHandler() }
             }},
 
             // $metadata operation (Get)

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/MediaEntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/MediaEntityPathItemHandler.cs
@@ -50,6 +50,15 @@ namespace Microsoft.OpenApi.OData.PathItem
             {
                 AddOperation(item, OperationType.Put);
             }
+
+            DeleteRestrictionsType delete = EntitySet != null
+                ? Context.Model.GetRecord<DeleteRestrictionsType>(EntitySet)
+                : Context.Model.GetRecord<DeleteRestrictionsType>(Singleton);
+
+            if (delete == null || delete.IsDeletable)
+            {
+                AddOperation(item, OperationType.Delete);
+            }
         }
 
         /// <inheritdoc/>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityDeleteOperationHandlerTests.cs
@@ -4,10 +4,11 @@
 // ------------------------------------------------------------
 
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.Vocabulary.Core;
 using System.Linq;
+using System.Xml.Linq;
 using Xunit;
 
 namespace Microsoft.OpenApi.OData.Operation.Tests
@@ -16,21 +17,12 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
     {
         private readonly MediaEntityDeleteOperationHandler _operationalHandler = new MediaEntityDeleteOperationHandler();
 
-        [Theory]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        [InlineData(true, true)]
-        [InlineData(false, true)]
-        public void CreateMediaEntityDeleteOperationReturnsCorrectOperation(bool enableOperationId, bool useSuccessStatusCodeRange)
+        [Fact]
+        public void CreateMediaEntityPropertyDeleteOperationWithTargetPathAnnotationsReturnsCorrectOperation()
         {
             // Arrange
             IEdmModel model = OData.Tests.EdmModelHelper.TripServiceModel;
-            OpenApiConvertSettings settings = new OpenApiConvertSettings
-            {
-                EnableOperationId = enableOperationId,
-                UseSuccessStatusCodeRange = useSuccessStatusCodeRange
-            };
-            ODataContext context = new(model, settings);
+            ODataContext context = new(model, new OpenApiConvertSettings());
             IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
             Assert.NotNull(people);
 
@@ -64,14 +56,165 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Equal(2, operation.Responses.Count);
             Assert.Equal(new string[] { "204", "default" }, operation.Responses.Select(e => e.Key));
 
-            if (enableOperationId)
+            Assert.Equal("People.Person.DeletePhoto", operation.OperationId);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        public void CreateMediaEntityDeleteOperationReturnsCorrectOperation(bool enableOperationId, bool useSuccessStatusCodeRange)
+        {
+            // Arrange
+            string annotation = $@"
+            <Annotation Term=""Org.OData.Capabilities.V1.NavigationRestrictions"">
+              <Record>
+                <PropertyValue Property=""RestrictedProperties"">
+                  <Collection>
+                    <Record>
+                        <PropertyValue Property=""DeleteRestrictions"">
+                            <Record>
+                                <PropertyValue Property=""Description"" String=""Delete photo"" />
+						        <PropertyValue Property=""LongDescription"" String=""Delete photo in Todo"" />
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                  </Collection>
+                </PropertyValue>
+              </Record>  
+            </Annotation>";
+
+            // Assert
+            VerifyMediaEntityDeleteOperation("", enableOperationId, useSuccessStatusCodeRange);
+            VerifyMediaEntityDeleteOperation(annotation, enableOperationId, useSuccessStatusCodeRange);
+        }
+
+        private void VerifyMediaEntityDeleteOperation(string annotation, bool enableOperationId, bool useSuccessStatusCodeRange)
+        {
+            // Arrange
+            IEdmModel model = GetEdmModel(annotation);
+            OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
-                Assert.Equal("People.Person.DeletePhoto", operation.OperationId);
+                EnableOperationId = enableOperationId,
+                UseSuccessStatusCodeRange = useSuccessStatusCodeRange
+            };
+
+            ODataContext context = new(model, settings);
+            IEdmEntitySet todos = model.EntityContainer.FindEntitySet("Todos");
+            IEdmSingleton me = model.EntityContainer.FindSingleton("me");
+            Assert.NotNull(todos);
+
+            IEdmEntityType todo = todos.EntityType();
+            IEdmStructuralProperty structuralProperty = todo.StructuralProperties().First(c => c.Name == "Logo");
+            ODataPath path = new(new ODataNavigationSourceSegment(todos),
+                new ODataKeySegment(todo),
+                new ODataStreamPropertySegment(structuralProperty.Name));
+
+            IEdmEntityType user = me.EntityType();
+            IEdmNavigationProperty navProperty = user.NavigationProperties().First(c => c.Name == "photo");
+            ODataPath path2 = new(new ODataNavigationSourceSegment(me),
+                new ODataNavigationPropertySegment(navProperty),
+                new ODataStreamContentSegment());
+
+            IEdmStructuralProperty structuralProperty2 = todo.StructuralProperties().First(c => c.Name == "Content");
+            ODataPath path3 = new(new ODataNavigationSourceSegment(todos),
+                new ODataKeySegment(todo),
+                new ODataStreamPropertySegment(structuralProperty2.Name));
+
+            // Act
+            var deleteOperation = _operationalHandler.CreateOperation(context, path);
+            var deleteOperation2 = _operationalHandler.CreateOperation(context, path2);
+            var deleteOperation3 = _operationalHandler.CreateOperation(context, path3);
+
+            // Assert
+            Assert.NotNull(deleteOperation);
+            Assert.NotNull(deleteOperation2);
+            Assert.NotNull(deleteOperation3);
+            Assert.Equal("Delete Logo for Todo in Todos", deleteOperation.Summary);
+            if (!string.IsNullOrEmpty(annotation))
+            {
+                Assert.Equal("Delete photo", deleteOperation2.Summary);
+                Assert.Equal("Delete photo in Todo", deleteOperation2.Description);
             }
             else
             {
-                Assert.Null(operation.OperationId);
+                Assert.Equal("Delete media content for the navigation property photo in me", deleteOperation2.Summary);
+                Assert.Null(deleteOperation2.Description);
             }
+            Assert.NotNull(deleteOperation.Tags);
+            Assert.NotNull(deleteOperation2.Tags);
+
+            var tag = Assert.Single(deleteOperation.Tags);
+            var tag2 = Assert.Single(deleteOperation2.Tags);
+            var tag3 = Assert.Single(deleteOperation3.Tags);
+            Assert.Equal("Todos.Todo", tag.Name);
+            Assert.Equal("me.profilePhoto", tag2.Name);
+            Assert.Equal("Todos.Todo", tag3.Name);
+
+            Assert.Null(deleteOperation.RequestBody);
+            Assert.Null(deleteOperation2.RequestBody);
+            Assert.Null(deleteOperation3.RequestBody);
+
+            Assert.NotNull(deleteOperation.Responses);
+            Assert.NotNull(deleteOperation2.Responses);
+            Assert.NotNull(deleteOperation3.Responses);
+
+            Assert.Equal(2, deleteOperation.Responses.Count);
+            Assert.Equal(2, deleteOperation2.Responses.Count);
+            Assert.Equal(2, deleteOperation3.Responses.Count);
+
+            Assert.Equal(new[] { Constants.StatusCode204, "default" }, deleteOperation.Responses.Select(r => r.Key));
+            Assert.Equal(new[] { Constants.StatusCode204, "default" }, deleteOperation2.Responses.Select(r => r.Key));
+            Assert.Equal(new[] { Constants.StatusCode204, "default" }, deleteOperation3.Responses.Select(r => r.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("Todos.Todo.DeleteLogo", deleteOperation.OperationId);
+                Assert.Equal("me.DeletePhotoContent", deleteOperation2.OperationId);
+            }
+            else
+            {
+                Assert.Null(deleteOperation.OperationId);
+                Assert.Null(deleteOperation2.OperationId);
+            }
+        }
+
+        public static IEdmModel GetEdmModel(string annotation)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""microsoft.graph"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Todo"" HasStream=""true"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Logo"" Type=""Edm.Stream""/>
+        <Property Name=""Content"" Type=""Edm.Stream""/>
+        <Property Name = ""Description"" Type = ""Edm.String"" />
+      </EntityType>
+      <EntityType Name=""user"" OpenType=""true"">
+        <NavigationProperty Name = ""photo"" Type = ""microsoft.graph.profilePhoto"" >
+            {0}
+        </NavigationProperty>   
+      </EntityType>
+      <EntityType Name=""profilePhoto"" HasStream=""true"">
+        <Property Name = ""height"" Type = ""Edm.Int32"" />
+        <Property Name = ""width"" Type = ""Edm.Int32"" />
+      </EntityType >
+      <EntityContainer Name =""GraphService"">
+        <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+        <Singleton Name=""me"" Type=""microsoft.graph.user"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string modelText = string.Format(template, annotation);
+
+            bool result = CsdlReader.TryParse(XElement.Parse(modelText).CreateReader(), out IEdmModel model, out _);
+            Assert.True(result);
+            return model;
         }
     }
 }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityDeleteOperationHandlerTests.cs
@@ -1,0 +1,77 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Vocabulary.Core;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests
+{
+    public class MediaEntityDeleteOperationHandlerTests
+    {
+        private readonly MediaEntityDeleteOperationHandler _operationalHandler = new MediaEntityDeleteOperationHandler();
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public void CreateMediaEntityDeleteOperationReturnsCorrectOperation(bool enableOperationId, bool useSuccessStatusCodeRange)
+        {
+            // Arrange
+            IEdmModel model = OData.Tests.EdmModelHelper.TripServiceModel;
+            OpenApiConvertSettings settings = new OpenApiConvertSettings
+            {
+                EnableOperationId = enableOperationId,
+                UseSuccessStatusCodeRange = useSuccessStatusCodeRange
+            };
+            ODataContext context = new(model, settings);
+            IEdmEntitySet people = model.EntityContainer.FindEntitySet("People");
+            Assert.NotNull(people);
+
+            IEdmEntityType person = people.EntityType();
+            IEdmStructuralProperty property = person.StructuralProperties().First(c => c.Name == "Photo");
+            ODataPath path = new(new ODataNavigationSourceSegment(people),
+                new ODataKeySegment(person),
+                new ODataStreamPropertySegment(property.Name));
+
+            // Act
+            var operation = _operationalHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(operation);
+            Assert.Equal("Delete photo", operation.Summary);
+            Assert.Equal("Delete photo of a specific user", operation.Description);
+
+            Assert.NotNull(operation.ExternalDocs);
+            Assert.Equal("Find more info here", operation.ExternalDocs.Description);
+            Assert.Equal("https://learn.microsoft.com/graph/api/person-delete-photo?view=graph-rest-1.0", operation.ExternalDocs.Url.ToString());
+
+            Assert.NotNull(operation.Tags);
+            var tag = Assert.Single(operation.Tags);
+            Assert.Equal("People.Person", tag.Name);
+
+            Assert.NotNull(operation.Parameters);
+            Assert.NotEmpty(operation.Parameters);
+
+            Assert.Null(operation.RequestBody);
+
+            Assert.Equal(2, operation.Responses.Count);
+            Assert.Equal(["204", "default"], operation.Responses.Select(e => e.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("People.Person.DeletePhoto", operation.OperationId);
+            }
+            else
+            {
+                Assert.Null(operation.OperationId);
+            }
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityDeleteOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityDeleteOperationHandlerTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             Assert.Null(operation.RequestBody);
 
             Assert.Equal(2, operation.Responses.Count);
-            Assert.Equal(["204", "default"], operation.Responses.Select(e => e.Key));
+            Assert.Equal(new string[] { "204", "default" }, operation.Responses.Select(e => e.Key));
 
             if (enableOperationId)
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/MediaEntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/MediaEntityPathItemHandlerTests.cs
@@ -88,19 +88,19 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
             Assert.NotNull(pathItem2.Operations);
             Assert.NotEmpty(pathItem.Operations);
             Assert.NotEmpty(pathItem2.Operations);
-            Assert.Equal(2, pathItem.Operations.Count);
-            Assert.Equal(2, pathItem2.Operations.Count);
-            Assert.Equal(new OperationType[] { OperationType.Get, OperationType.Put },
+            Assert.Equal(3, pathItem.Operations.Count);
+            Assert.Equal(3, pathItem2.Operations.Count);
+            Assert.Equal(new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete },
                 pathItem.Operations.Select(o => o.Key));
-            Assert.Equal(new OperationType[] { OperationType.Get, OperationType.Put },
+            Assert.Equal(new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete },
                 pathItem2.Operations.Select(o => o.Key));
             Assert.NotEmpty(pathItem.Description);
         }
 
         [Theory]
-        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put })]
-        [InlineData(false, new OperationType[] { OperationType.Put })]
-        public void CreateMediaEntityPathItemWorksForReadByKeyRestrictionsCapablities(bool readable, OperationType[] expected)
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
+        [InlineData(false, new OperationType[] { OperationType.Put, OperationType.Delete })]
+        public void CreateMediaEntityPathItemWorksForReadByKeyRestrictionsCapabilities(bool readable, OperationType[] expected)
         {
             // Arrange
             string annotation = $@"
@@ -120,15 +120,33 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Theory]
-        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put })]
-        [InlineData(false, new OperationType[] { OperationType.Get })]
-        public void CreateMediaEntityPathItemWorksForUpdateRestrictionsCapablities(bool updatable, OperationType[] expected)
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
+        [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Delete })]
+        public void CreateMediaEntityPathItemWorksForUpdateRestrictionsCapabilities(bool updatable, OperationType[] expected)
         {
             // Arrange
             string annotation = $@"
 <Annotation Term=""Org.OData.Capabilities.V1.UpdateRestrictions"">
   <Record>
     <PropertyValue Property=""Updatable"" Bool=""{updatable}"" />
+  </Record>
+</Annotation>";
+
+            // Assert
+            VerifyPathItemOperationsForStreamPropertySegment(annotation, expected);
+            VerifyPathItemOperationsForStreamContentSegment(annotation, expected);
+        }
+
+        [Theory]
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
+        [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Put })]
+        public void CreateMediaEntityPathItemWorksForDeleteRestrictionsCapabilities(bool deletable, OperationType[] expected)
+        {
+            // Arrange
+            string annotation = $@"
+<Annotation Term=""Org.OData.Capabilities.V1.DeleteRestrictions"">
+  <Record>
+    <PropertyValue Property=""Deletable"" Bool=""{deletable}"" />
   </Record>
 </Annotation>";
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OData.xml
@@ -602,6 +602,12 @@
 						<PropertyValue Property="LongDescription" String="Update photo of a specific user" />
 					</Record>
 				</Annotation>
+				<Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+					<Record>
+						<PropertyValue Property="Description" String="Delete photo" />
+						<PropertyValue Property="LongDescription" String="Delete photo of a specific user" />
+					</Record>
+				</Annotation>
 				<Annotation Term="Org.OData.Core.V1.Links">
 					<Collection>
 						<Record>
@@ -611,6 +617,10 @@
 						<Record>
 							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/update" />
 							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-update-photo?view=graph-rest-1.0" />
+						</Record>
+						<Record>
+							<PropertyValue Property="rel" String="https://graph.microsoft.com/rels/docs/delete" />
+							<PropertyValue Property="href" String="https://learn.microsoft.com/graph/api/person-delete-photo?view=graph-rest-1.0" />
 						</Record>
 					</Collection>
 				</Annotation>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1158,6 +1158,37 @@
           }
         }
       },
+      "delete": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Delete Photo for the navigation property EmergencyAuthority in Airports",
+        "operationId": "Airports.DeleteEmergencyAuthorityPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "IcaoCode",
+            "description": "The unique identifier of Airport",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
       "x-description": "Provides operations to manage the media for the Airport entity."
     },
     "/Airports/$count": {
@@ -2299,6 +2330,36 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
       "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/Me/Friends": {
@@ -3071,6 +3132,44 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in Me",
+        "operationId": "Me.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -4636,6 +4735,36 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
       "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
@@ -5361,6 +5490,44 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in Me",
+        "operationId": "Me.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -6429,6 +6596,44 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Peers in Me",
+        "operationId": "Me.DeletePeersPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -8532,6 +8737,36 @@
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
       },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
       "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
@@ -9169,6 +9404,44 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property DirectReports in Me",
+        "operationId": "Me.DeleteDirectReportsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -10039,6 +10312,44 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in Me",
+        "operationId": "Me.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -11426,6 +11737,36 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for Person in Me",
+        "operationId": "Me.Person.DeletePhoto",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -13621,6 +13962,44 @@
           "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
       },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in NewComePeople",
+        "operationId": "NewComePeople.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
+      },
       "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/NewComePeople/{UserName}/Friends": {
@@ -14435,6 +14814,45 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in NewComePeople",
+        "operationId": "NewComePeople.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -15322,6 +15740,37 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete Photo for Person in NewComePeople",
+        "operationId": "NewComePeople.Person.DeletePhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -17595,6 +18044,44 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in People",
+        "operationId": "People.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
       "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/People/{UserName}/Friends": {
@@ -18496,6 +18983,52 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in People",
+        "operationId": "People.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -20380,6 +20913,44 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in People",
+        "operationId": "People.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
       "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
@@ -21217,6 +21788,52 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in People",
+        "operationId": "People.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -22463,6 +23080,52 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Peers in People",
+        "operationId": "People.DeletePeersPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -24942,6 +25605,44 @@
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
       },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in People",
+        "operationId": "People.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
       "x-description": "Provides operations to manage the media for the Person entity."
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
@@ -25683,6 +26384,52 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property DirectReports in People",
+        "operationId": "People.DeleteDirectReportsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -26697,6 +27444,52 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in People",
+        "operationId": "People.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "path",
+            "name": "UserName1",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {
@@ -28314,6 +29107,49 @@
               "format": "binary",
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete photo",
+        "description": "Delete photo of a specific user",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-delete-photo?view=graph-rest-1.0"
+        },
+        "operationId": "People.Person.DeletePhoto",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "UserName",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "type": "string",
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "in": "header",
+            "name": "If-Match",
+            "description": "ETag",
+            "type": "string"
           }
         ],
         "responses": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -761,6 +761,27 @@ paths:
           description: Success
         default:
           $ref: '#/responses/error'
+    delete:
+      tags:
+        - Airports.Person
+      summary: Delete Photo for the navigation property EmergencyAuthority in Airports
+      operationId: Airports.DeleteEmergencyAuthorityPhoto
+      parameters:
+        - in: path
+          name: IcaoCode
+          description: The unique identifier of Airport
+          required: true
+          type: string
+          x-ms-docs-key-type: Airport
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
     x-description: Provides operations to manage the media for the Airport entity.
   /Airports/$count:
     get:
@@ -1532,6 +1553,27 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property BestFriend in Me
+      operationId: Me.DeleteBestFriendPhoto
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to manage the media for the Person entity.
   /Me/Friends:
     get:
@@ -2059,6 +2101,33 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Friends in Me
+      operationId: Me.DeleteFriendsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -3101,6 +3170,27 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property BestFriend in Me
+      operationId: Me.DeleteBestFriendPhoto
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends:
     get:
@@ -3595,6 +3685,33 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Friends in Me
+      operationId: Me.DeleteFriendsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -4310,6 +4427,33 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Peers in Me
+      operationId: Me.DeletePeersPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -5731,6 +5875,27 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property BestFriend in Me
+      operationId: Me.DeleteBestFriendPhoto
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
     x-description: Provides operations to manage the media for the Person entity.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     get:
@@ -6164,6 +6329,33 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property DirectReports in Me
+      operationId: Me.DeleteDirectReportsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -6751,6 +6943,33 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Friends in Me
+      operationId: Me.DeleteFriendsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -7693,6 +7912,27 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for Person in Me
+      operationId: Me.Person.DeletePhoto
+      parameters:
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -9182,6 +9422,33 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete Photo for the navigation property BestFriend in NewComePeople
+      operationId: NewComePeople.DeleteBestFriendPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
     x-description: Provides operations to manage the media for the Person entity.
   '/NewComePeople/{UserName}/Friends':
     get:
@@ -9728,6 +9995,33 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete Photo for the navigation property Friends in NewComePeople
+      operationId: NewComePeople.DeleteFriendsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -10303,6 +10597,27 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete Photo for Person in NewComePeople
+      operationId: NewComePeople.Person.DeletePhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -11846,6 +12161,33 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property BestFriend in People
+      operationId: People.DeleteBestFriendPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Friends':
     get:
@@ -12470,6 +12812,39 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Friends in People
+      operationId: People.DeleteFriendsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -13748,6 +14123,33 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property BestFriend in People
+      operationId: People.DeleteBestFriendPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends':
     get:
@@ -14326,6 +14728,39 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Friends in People
+      operationId: People.DeleteFriendsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -15174,6 +15609,39 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Peers in People
+      operationId: People.DeletePeersPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -16873,6 +17341,33 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property BestFriend in People
+      operationId: People.DeleteBestFriendPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
     x-description: Provides operations to manage the media for the Person entity.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     get:
@@ -17384,6 +17879,39 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property DirectReports in People
+      operationId: People.DeleteDirectReportsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -18079,6 +18607,39 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Friends in People
+      operationId: People.DeleteFriendsPhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: path
+          name: UserName1
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success
@@ -19193,6 +19754,37 @@ paths:
           schema:
             format: binary
             type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete photo
+      description: Delete photo of a specific user
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-delete-photo?view=graph-rest-1.0
+      operationId: People.Person.DeletePhoto
+      parameters:
+        - in: path
+          name: UserName
+          description: The unique identifier of Person
+          required: true
+          type: string
+          x-ms-docs-key-type: Person
+        - in: header
+          name: If-Match
+          description: ETag
+          type: string
       responses:
         '204':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1303,6 +1303,41 @@
             "$ref": "#/components/responses/error"
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "Airports.Person"
+        ],
+        "summary": "Delete Photo for the navigation property EmergencyAuthority in Airports",
+        "operationId": "Airports.DeleteEmergencyAuthorityPhoto",
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "description": "The unique identifier of Airport",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Airport"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
       }
     },
     "/Airports/$count": {
@@ -2559,6 +2594,38 @@
           "version": "2021-05/me",
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Friends": {
@@ -3432,6 +3499,48 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in Me",
+        "operationId": "Me.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -5122,6 +5231,38 @@
           "version": "2021-05/me",
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
@@ -5937,6 +6078,48 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in Me",
+        "operationId": "Me.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -7113,6 +7296,48 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Peers in Me",
+        "operationId": "Me.DeletePeersPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -9399,6 +9624,38 @@
           "version": "2021-05/me",
           "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
         }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in Me",
+        "operationId": "Me.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
       }
     },
     "/Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
@@ -10109,6 +10366,48 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property DirectReports in Me",
+        "operationId": "Me.DeleteDirectReportsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -11069,6 +11368,48 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in Me",
+        "operationId": "Me.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -12590,6 +12931,38 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/me",
+          "description": "The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "Me.Person"
+        ],
+        "summary": "Delete Photo for Person in Me",
+        "operationId": "Me.Person.DeletePhoto",
+        "parameters": [
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -15037,6 +15410,48 @@
           "version": "2021-05/bestfriend",
           "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
         }
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in NewComePeople",
+        "operationId": "NewComePeople.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/bestfriend",
+          "description": "The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API."
+        }
       }
     },
     "/NewComePeople/{UserName}/Friends": {
@@ -15986,6 +16401,51 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in NewComePeople",
+        "operationId": "NewComePeople.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -16998,6 +17458,41 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "NewComePeople.Person"
+        ],
+        "summary": "Delete Photo for Person in NewComePeople",
+        "operationId": "NewComePeople.Person.DeletePhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -19547,6 +20042,48 @@
           "version": "2021-05/people",
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in People",
+        "operationId": "People.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Friends": {
@@ -20579,6 +21116,58 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in People",
+        "operationId": "People.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -22676,6 +23265,48 @@
           "version": "2021-05/people",
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in People",
+        "operationId": "People.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends": {
@@ -23631,6 +24262,58 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in People",
+        "operationId": "People.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -25033,6 +25716,58 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Peers in People",
+        "operationId": "People.DeletePeersPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -27803,6 +28538,48 @@
           "version": "2021-05/people",
           "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
         }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property BestFriend in People",
+        "operationId": "People.DeleteBestFriendPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
       }
     },
     "/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports": {
@@ -28643,6 +29420,58 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property DirectReports in People",
+        "operationId": "People.DeleteDirectReportsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -29785,6 +30614,58 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete Photo for the navigation property Friends in People",
+        "operationId": "People.DeleteFriendsPhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "UserName1",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"
@@ -31602,6 +32483,53 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "deprecated": true,
+        "x-ms-deprecation": {
+          "removalDate": "2023-03-15T00:00:00.0000000+00:00",
+          "date": "2021-08-24T00:00:00.0000000+00:00",
+          "version": "2021-05/people",
+          "description": "The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API."
+        }
+      },
+      "delete": {
+        "tags": [
+          "People.Person"
+        ],
+        "summary": "Delete photo",
+        "description": "Delete photo of a specific user",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://learn.microsoft.com/graph/api/person-delete-photo?view=graph-rest-1.0"
+        },
+        "operationId": "People.Person.DeletePhoto",
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "description": "The unique identifier of Person",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-docs-key-type": "Person"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "204": {
             "description": "Success"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -853,6 +853,29 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - Airports.Person
+      summary: Delete Photo for the navigation property EmergencyAuthority in Airports
+      operationId: Airports.DeleteEmergencyAuthorityPhoto
+      parameters:
+        - name: IcaoCode
+          in: path
+          description: The unique identifier of Airport
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Airport
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
   /Airports/$count:
     description: Provides operations to count the resources in the collection.
     get:
@@ -1693,6 +1716,28 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property BestFriend in Me
+      operationId: Me.DeleteBestFriendPhoto
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Friends:
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -2283,6 +2328,35 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Friends in Me
+      operationId: Me.DeleteFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -3418,6 +3492,28 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property BestFriend in Me
+      operationId: Me.DeleteBestFriendPhoto
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends:
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -3967,6 +4063,35 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Friends in Me
+      operationId: Me.DeleteFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -4754,6 +4879,35 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Peers in Me
+      operationId: Me.DeletePeersPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -6308,6 +6462,28 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/me
         description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property BestFriend in Me
+      operationId: Me.DeleteBestFriendPhoto
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
   /Me/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports:
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -6785,6 +6961,35 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property DirectReports in Me
+      operationId: Me.DeleteDirectReportsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -7431,6 +7636,35 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for the navigation property Friends in Me
+      operationId: Me.DeleteFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -8464,6 +8698,28 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/me
+        description: The Me API is deprecated and will stop returning data on March 2023. Please use the new me2 API.
+    delete:
+      tags:
+        - Me.Person
+      summary: Delete Photo for Person in Me
+      operationId: Me.Person.DeletePhoto
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -10118,6 +10374,35 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/bestfriend
         description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete Photo for the navigation property BestFriend in NewComePeople
+      operationId: NewComePeople.DeleteBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/bestfriend
+        description: The bestfriend API is deprecated and will stop returning data on March 2023. Please use the new friends API.
   '/NewComePeople/{UserName}/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -10744,6 +11029,36 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete Photo for the navigation property Friends in NewComePeople
+      operationId: NewComePeople.DeleteFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -11399,6 +11714,29 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - NewComePeople.Person
+      summary: Delete Photo for Person in NewComePeople
+      operationId: NewComePeople.Person.DeletePhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -13119,6 +13457,35 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property BestFriend in People
+      operationId: People.DeleteBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -13821,6 +14188,42 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Friends in People
+      operationId: People.DeleteFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -15236,6 +15639,35 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property BestFriend in People
+      operationId: People.DeleteBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee/Friends':
     description: Provides operations to manage the Friends property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person entity.
     get:
@@ -15883,6 +16315,42 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Friends in People
+      operationId: People.DeleteFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -16827,6 +17295,42 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Peers in People
+      operationId: People.DeletePeersPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -18713,6 +19217,35 @@ paths:
         date: '2021-08-24T00:00:00.0000000+00:00'
         version: 2021-05/people
         description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property BestFriend in People
+      operationId: People.DeleteBestFriendPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
   '/People/{UserName}/Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager/DirectReports':
     description: Provides operations to manage the DirectReports property of the Microsoft.OData.Service.Sample.TrippinInMemory.Models.Manager entity.
     get:
@@ -19281,6 +19814,42 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property DirectReports in People
+      operationId: People.DeleteDirectReportsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -20054,6 +20623,42 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete Photo for the navigation property Friends in People
+      operationId: People.DeleteFriendsPhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: UserName1
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success
@@ -21292,6 +21897,39 @@ paths:
               type: string
               format: binary
         required: true
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-03-15T00:00:00.0000000+00:00'
+        date: '2021-08-24T00:00:00.0000000+00:00'
+        version: 2021-05/people
+        description: The People API is deprecated and will stop returning data on March 2023. Please use the new newPeople API.
+    delete:
+      tags:
+        - People.Person
+      summary: Delete photo
+      description: Delete photo of a specific user
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/person-delete-photo?view=graph-rest-1.0
+      operationId: People.Person.DeletePhoto
+      parameters:
+        - name: UserName
+          in: path
+          description: The unique identifier of Person
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: Person
+        - name: If-Match
+          in: header
+          description: ETag
+          schema:
+            type: string
       responses:
         '204':
           description: Success


### PR DESCRIPTION
Fixes #522 
This PR:
- Adds DELETE operations for media content paths unless there are annotations specifying that an entity isn't deletable
- Adds tests to check that the operation details are correct
