### PR TITLE
Adds config setting for composable functions generation

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,13 +15,13 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>1.6.7</Version>
+    <Version>1.6.8</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET.OData</RepositoryUrl>
     <PackageReleaseNotes>
-		- Fixes empty response objects for OData type cast paths. #546
+		- Adds support for configuring composable functions generations #551
 	</PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -362,6 +362,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool UseStringArrayForQueryOptionsSchema { get; set; } = true;
 
+        /// <summary>
+        /// Gets/Sets a value indicating the depth to expand composable functions.
+        /// </summary>
+        public int ComposableFunctionsExpansionDepth { get; set; } = 1;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -416,7 +421,8 @@ namespace Microsoft.OpenApi.OData
                 EnableAliasForTypeCastSegments = this.EnableAliasForTypeCastSegments,
                 SemVerVersion = this.SemVerVersion,
                 EnableAliasForOperationSegments = this.EnableAliasForOperationSegments,
-                UseStringArrayForQueryOptionsSchema = this.UseStringArrayForQueryOptionsSchema
+                UseStringArrayForQueryOptionsSchema = this.UseStringArrayForQueryOptionsSchema,
+                ComposableFunctionsExpansionDepth = this.ComposableFunctionsExpansionDepth
             };
 
             return newSettings;

--- a/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.OData.Reader/PublicAPI.Unshipped.txt
@@ -21,6 +21,8 @@ Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumFlagsExtension.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AddEnumFlagsExtension.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.get -> bool
 Microsoft.OpenApi.OData.OpenApiConvertSettings.AppendBoundOperationsOnDerivedTypeCastSegments.set -> void
+Microsoft.OpenApi.OData.OpenApiConvertSettings.ComposableFunctionsExpansionDepth.get -> int
+Microsoft.OpenApi.OData.OpenApiConvertSettings.ComposableFunctionsExpansionDepth.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.get -> System.Collections.Generic.Dictionary<Microsoft.OpenApi.OData.Vocabulary.Core.LinkRelKey, string>
 Microsoft.OpenApi.OData.OpenApiConvertSettings.CustomHttpMethodLinkRelMapping.set -> void
 Microsoft.OpenApi.OData.OpenApiConvertSettings.EnableAliasForOperationSegments.get -> bool

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(16980, paths.Count());
+            Assert.Equal(15210, paths.Count());
             AssertGraphBetaModelPaths(paths);
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(17631, paths.Count());
+            Assert.Equal(15861, paths.Count());
         }
                 
         [Theory]
@@ -208,9 +208,9 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(38, paths.Count());
-            Assert.Equal(20, paths.Where(p => p.LastSegment is ODataOperationSegment).Count());
-            Assert.Equal(12, paths.Where(p => p.Segments.Count > 1 && p.LastSegment is ODataNavigationPropertySegment && p.Segments[p.Segments.Count - 2] is ODataOperationSegment).Count());
+            Assert.Equal(26, paths.Count());
+            Assert.Equal(17, paths.Where(p => p.LastSegment is ODataOperationSegment).Count());
+            Assert.Equal(3, paths.Where(p => p.Segments.Count > 1 && p.LastSegment is ODataNavigationPropertySegment && p.Segments[p.Segments.Count - 2] is ODataOperationSegment).Count());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/551

Adds the config setting: `ComposableFunctionsExpansionDepth` which provides a control for how many levels composable functions are to be expanded. The default is 1. This means composable functions will be expanded to generate an operation segment or a navigation property segment in the path, but not both. If the value is set to 2, then the latter will be allowed.