### PR TITLE
Updates `PUT` operation id prefix from `Update` to `Set`

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Microsoft.OpenApi.OData</PackageId>
     <SignAssembly>true</SignAssembly>
-    <Version>2.0.0-preview.6</Version>
+    <Version>2.0.0-preview.7</Version>
     <Description>This package contains the codes you need to convert OData CSDL to Open API Document of Model.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft OpenApi OData EDM</PackageTags>
@@ -32,6 +32,7 @@
 		- Replaced integer types by number types
 		- Further fix for generating unique operation ids for paths with composable overloaded functions where all functions in path are overloaded #594
 		- Further fix for generating unique operation ids for navigation property paths with composable overloaded functions #596
+		- Updates PUT operation id prefix from Update to Set #600
 	</PackageReleaseNotes>
     <AssemblyName>Microsoft.OpenApi.OData.Reader</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\tool\Microsoft.OpenApi.OData.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/ComplexPropertyUpdateOperationHandler.cs
@@ -40,7 +40,8 @@ internal abstract class ComplexPropertyUpdateOperationHandler : ComplexPropertyB
         // OperationId
         if (Context.Settings.EnableOperationId)
         {
-            operation.OperationId = EdmModelHelper.GenerateComplexPropertyPathOperationId(Path, Context, "Update");
+            string prefix = OperationType == OperationType.Patch ? "Update" : "Set";
+            operation.OperationId = EdmModelHelper.GenerateComplexPropertyPathOperationId(Path, Context, prefix);
         }
     }
 

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntityUpdateOperationHandler.cs
@@ -50,7 +50,8 @@ namespace Microsoft.OpenApi.OData.Operation
             if (Context.Settings.EnableOperationId)
             {
                 string typeName = entityType.Name;
-                string operationName = $"Update{ Utils.UpperFirstChar(typeName)}";
+                string prefix = OperationType == OperationType.Patch ? "Update" : "Set";
+                string operationName = $"{prefix}{ Utils.UpperFirstChar(typeName)}";
                 if (keySegment.IsAlternateKey)
                 {
                     string alternateKeyName = string.Join("", keySegment.Identifier.Split(',').Select(static x => Utils.UpperFirstChar(x)));

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyUpdateOperationHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.OData.Operation
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
-                string prefix = "Update";
+                string prefix = OperationType == OperationType.Patch ? "Update" : "Set";
                 operation.OperationId = GetOperationId(prefix);
             }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/ComplexPropertyPutOperationHandlerTests.cs
@@ -61,7 +61,7 @@ public class ComplexPropertyPutOperationHandlerTests
 
 		if (enableOperationId)
 		{
-			Assert.Equal("Customers.UpdateBillingAddress", put.OperationId);
+			Assert.Equal("Customers.SetBillingAddress", put.OperationId);
 		}
 		else
 		{
@@ -108,7 +108,7 @@ public class ComplexPropertyPutOperationHandlerTests
 
         if (enableOperationId)
 		{
-			Assert.Equal("Customers.UpdateAlternativeAddresses", put.OperationId);
+			Assert.Equal("Customers.SetAlternativeAddresses", put.OperationId);
 		}
 		else
 		{

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntityPutOperationHandlerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Customers.Customer.UpdateCustomer", putOperation.OperationId);
+                Assert.Equal("Customers.Customer.SetCustomer", putOperation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/NavigationPropertyPutOperationHandlerTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("People.UpdateBestFriend", operation.OperationId);
+                Assert.Equal("People.SetBestFriend", operation.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -165,7 +165,7 @@
           "Airlines.Airline"
         ],
         "summary": "Update entity in Airlines",
-        "operationId": "Airlines.Airline.UpdateAirline",
+        "operationId": "Airlines.Airline.SetAirline",
         "consumes": [
           "application/json"
         ],
@@ -534,7 +534,7 @@
           "Airports.AirportLocation"
         ],
         "summary": "Update property Location value.",
-        "operationId": "Airports.UpdateLocation",
+        "operationId": "Airports.SetLocation",
         "consumes": [
           "application/json"
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -107,7 +107,7 @@ paths:
       tags:
         - Airlines.Airline
       summary: Update entity in Airlines
-      operationId: Airlines.Airline.UpdateAirline
+      operationId: Airlines.Airline.SetAirline
       consumes:
         - application/json
       parameters:
@@ -349,7 +349,7 @@ paths:
       tags:
         - Airports.AirportLocation
       summary: Update property Location value.
-      operationId: Airports.UpdateLocation
+      operationId: Airports.SetLocation
       consumes:
         - application/json
       parameters:

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -192,7 +192,7 @@
           "Airlines.Airline"
         ],
         "summary": "Update entity in Airlines",
-        "operationId": "Airlines.Airline.UpdateAirline",
+        "operationId": "Airlines.Airline.SetAirline",
         "parameters": [
           {
             "name": "AirlineCode",
@@ -609,7 +609,7 @@
           "Airports.AirportLocation"
         ],
         "summary": "Update property Location value.",
-        "operationId": "Airports.UpdateLocation",
+        "operationId": "Airports.SetLocation",
         "parameters": [
           {
             "name": "IcaoCode",

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -125,7 +125,7 @@ paths:
       tags:
         - Airlines.Airline
       summary: Update entity in Airlines
-      operationId: Airlines.Airline.UpdateAirline
+      operationId: Airlines.Airline.SetAirline
       parameters:
         - name: AirlineCode
           in: path
@@ -398,7 +398,7 @@ paths:
       tags:
         - Airports.AirportLocation
       summary: Update property Location value.
-      operationId: Airports.UpdateLocation
+      operationId: Airports.SetLocation
       parameters:
         - name: IcaoCode
           in: path


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET.OData/issues/600

This helps distinguish `PUT` operation ids from `PATCH` operation ids, for paths that potentially supports both.