### PR TITLE
fix: bump oai version

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/src/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.OData.Edm" Version="8.2.3" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0-preview.14" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0-preview.15" />
 	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61">
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Generator/OpenApiSchemaGeneratorTests.cs
@@ -978,8 +978,9 @@ namespace Microsoft.OpenApi.OData.Tests
   ""format"": ""duration"",
   ""description"": ""The length of the appointment, denoted in ISO8601 format."",
   ""pattern"": ""^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$"",
-  ""type"": ""string""
-}"), json)); // TODO FIXME after resolution of https://github.com/microsoft/OpenAPI.NET/issues/2272
+  ""type"": ""string"",
+  ""readOnly"": true
+}"), json));
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Microsoft.OpenAPI.OData.Reader.Tests.csproj
@@ -88,7 +88,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0-preview.14" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0-preview.15" />
     <PackageReference Include="moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
- Fixes a test that was previously failing due to a regression in OAI.NET as a result of NRT support as seen in this comment https://github.com/microsoft/OpenAPI.NET.OData/pull/666/commits/6f52acc33d66dd9c55ed6952e8b4472364ccefb7
- Reference https://github.com/microsoft/OpenAPI.NET/issues/2272